### PR TITLE
feat: expose /metrics endpoint for Prometheus scraping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 # flask = web layer; jeepney = pure-Python D-Bus client used to read systemd
 # (no native libs, keeps the image slim). curl only needed to vendor Chart.js below.
-RUN pip install --no-cache-dir flask==3.0.3 jeepney==0.8.0 \
+RUN pip install --no-cache-dir flask==3.0.3 jeepney==0.8.0 prometheus_client==0.20.0 \
  && apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -150,7 +150,55 @@ a **read-only** mount of `/` (for disk usage), and a **read-only** D-Bus socket 
 systemd state). That's a broad footprint by design — please keep it behind your
 LAN/VPN/firewall and **don't expose it to the public internet.**
 
+## Prometheus integration
+
+Homelab Monitor exposes a standard Prometheus scrape endpoint at `/metrics` (port
+9800 by default). It reads exclusively from the in-memory snapshot that the background
+collector keeps fresh — **no extra polling, no double-sampling**.
+
+### Metrics exposed
+
+| Metric | Labels | Description |
+|---|---|---|
+| `homelab_gpu_vram_used_mb` | `gpu` | GPU VRAM currently used (MB) |
+| `homelab_gpu_vram_total_mb` | `gpu` | GPU VRAM total capacity (MB) |
+| `homelab_gpu_util_pct` | `gpu` | GPU utilisation (%) |
+| `homelab_gpu_temp_c` | `gpu` | GPU temperature (°C) |
+| `homelab_gpu_power_w` | `gpu` | GPU power draw (W) |
+| `homelab_host_cpu_pct` | — | Host CPU usage (%) |
+| `homelab_host_mem_used_pct` | — | Host memory used (%) |
+| `homelab_host_disk_used_pct` | `mountpoint` | Disk used per mount (%) |
+| `homelab_container_state` | `name`, `state` | 1 = container is in this state |
+| `homelab_systemd_unit_state` | `unit`, `state` | 1 = unit is active, 0 = otherwise |
+| `homelab_model_loaded_vram_mb` | `server`, `model` | VRAM used by a loaded model (MB) |
+
+### Quick verification
+
+```bash
+curl http://<your-host-ip>:9800/metrics
+```
+
+### Sample Prometheus scrape config
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'homelab_monitor'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['<your-host-ip>:9800']
+```
+
+### Grafana dashboard
+
+A ready-to-import dashboard is at
+[`docs/grafana/homelab_prometheus_dashboard.json`](docs/grafana/homelab_prometheus_dashboard.json).
+In Grafana: **Dashboards → Import → Upload JSON file**, then select your Prometheus
+datasource. The dashboard covers GPU VRAM, utilisation, temperature, host CPU/RAM,
+disk usage, and model VRAM in a single view.
+
 ## Roadmap
+
 
 A few things that would be nice to add next (PRs very welcome):
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,13 @@ Adding a new monitor (it's meant to be easy):
   3. Expose it via `/api/health` and add a matching tab/panel in dashboard.html.
 """
 import os, re, glob, time, json, socket, sqlite3, threading, subprocess, http.client
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, Response
+try:
+    from prometheus_client import (Gauge, generate_latest, CONTENT_TYPE_LATEST,
+                                   REGISTRY, CollectorRegistry)
+    _PROM_OK = True
+except ImportError:
+    _PROM_OK = False
 
 VERSION      = "0.3.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
@@ -36,6 +42,22 @@ OOM_RE       = re.compile(r"(out of memory|cuda error: out of memory|failed to a
 REAL_FS      = {"ext4", "ext3", "xfs", "btrfs", "zfs", "vfat"}
 
 app = Flask(__name__, static_url_path="/static", static_folder="static")
+
+# ── Prometheus gauges (defined once at module level) ──────────────────────────
+if _PROM_OK:
+    _G = {
+        "gpu_vram_used":     Gauge("homelab_gpu_vram_used_mb",    "GPU VRAM used (MB)",                ["gpu"]),
+        "gpu_vram_total":    Gauge("homelab_gpu_vram_total_mb",   "GPU VRAM total (MB)",               ["gpu"]),
+        "gpu_util":          Gauge("homelab_gpu_util_pct",        "GPU utilisation (%)",               ["gpu"]),
+        "gpu_temp":          Gauge("homelab_gpu_temp_c",          "GPU temperature (°C)",              ["gpu"]),
+        "gpu_power":         Gauge("homelab_gpu_power_w",         "GPU power draw (W)",                ["gpu"]),
+        "host_cpu":          Gauge("homelab_host_cpu_pct",        "Host CPU usage (%)"),
+        "host_mem_used":     Gauge("homelab_host_mem_used_pct",   "Host memory used (%)"),
+        "host_disk_used":    Gauge("homelab_host_disk_used_pct",  "Host disk used (%)",                ["mountpoint"]),
+        "container_state":   Gauge("homelab_container_state",     "Container state (1=running)",       ["name", "state"]),
+        "systemd_unit":      Gauge("homelab_systemd_unit_state",  "Systemd unit state (1=active)",     ["unit",  "state"]),
+        "model_vram":        Gauge("homelab_model_loaded_vram_mb","Model VRAM loaded (MB)",             ["server", "model"]),
+    }
 LOCK = threading.Lock()
 DB = sqlite3.connect(DB_PATH, check_same_thread=False)
 DB.execute("PRAGMA journal_mode=WAL")
@@ -549,6 +571,59 @@ def api_health():
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd,
                     "overview": build_overview(now, docker, systemd)})
+
+@app.route("/metrics")
+def metrics():
+    """Prometheus text-format scrape endpoint.
+
+    Reads exclusively from the in-memory snapshots (LATEST / HEALTH) that the
+    background collector keeps fresh.  No new I/O is triggered on each scrape,
+    so double-sampling is impossible.
+    """
+    if not _PROM_OK:
+        return Response("# prometheus_client not installed\n", mimetype="text/plain", status=503)
+
+    # ── GPU ──────────────────────────────────────────────────────────────────
+    gpu_label = "gpu0"
+    _G["gpu_vram_used"].labels(gpu=gpu_label).set(LATEST.get("mem_used", 0))
+    _G["gpu_vram_total"].labels(gpu=gpu_label).set(LATEST.get("mem_total", 0))
+    _G["gpu_util"].labels(gpu=gpu_label).set(LATEST.get("util", 0))
+    _G["gpu_temp"].labels(gpu=gpu_label).set(LATEST.get("temp", 0))
+    _G["gpu_power"].labels(gpu=gpu_label).set(LATEST.get("power", 0))
+
+    # ── Host ─────────────────────────────────────────────────────────────────
+    host = LATEST.get("host") or {}
+    _G["host_cpu"].set(host.get("cpu", 0))
+    ram_total = host.get("ram_total") or 1
+    ram_used  = host.get("ram_used", 0)
+    _G["host_mem_used"].set(round(100 * ram_used / ram_total, 1))
+    for disk in (host.get("disks") or []):
+        _G["host_disk_used"].labels(mountpoint=disk["mount"]).set(disk.get("pct", 0))
+
+    # ── Model VRAM ───────────────────────────────────────────────────────────
+    for entry in (LATEST.get("models") or []):
+        vram = entry.get("vram")
+        if vram is not None:
+            _G["model_vram"].labels(server=entry.get("service", "?"),
+                                    model=entry.get("model", "?")).set(vram)
+
+    # ── Docker containers ────────────────────────────────────────────────────
+    docker = HEALTH.get("docker") or {}
+    for ct in (docker.get("containers") or []):
+        name  = ct.get("name", "?")
+        state = ct.get("state", "unknown")
+        _G["container_state"].labels(name=name, state=state).set(1)
+
+    # ── Systemd units ────────────────────────────────────────────────────────
+    systemd = HEALTH.get("systemd") or {}
+    for svc in (systemd.get("services") or []):
+        unit   = svc.get("name", "?")
+        active = svc.get("active", "unknown")
+        _G["systemd_unit"].labels(unit=unit, state=active).set(
+            1 if active == "active" else 0)
+
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+
 
 @app.route("/")
 def index():

--- a/docs/grafana/homelab_prometheus_dashboard.json
+++ b/docs/grafana/homelab_prometheus_dashboard.json
@@ -1,0 +1,65 @@
+{
+  "__inputs": [{ "name": "DS_PROMETHEUS", "label": "Prometheus", "type": "datasource", "pluginId": "prometheus" }],
+  "__requires": [{ "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }],
+  "title": "Homelab Monitor",
+  "uid": "homelab-monitor-v1",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1, "type": "gauge", "title": "GPU VRAM Used %",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 90}] } },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "100 * homelab_gpu_vram_used_mb{gpu=\"gpu0\"} / homelab_gpu_vram_total_mb{gpu=\"gpu0\"}", "legendFormat": "VRAM %" }]
+    },
+    {
+      "id": 2, "type": "gauge", "title": "GPU Utilisation %",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 95}] } },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_gpu_util_pct{gpu=\"gpu0\"}", "legendFormat": "GPU Util %" }]
+    },
+    {
+      "id": 3, "type": "gauge", "title": "GPU Temp °C",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 85}] } },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_gpu_temp_c{gpu=\"gpu0\"}", "legendFormat": "Temp °C" }]
+    },
+    {
+      "id": 4, "type": "gauge", "title": "Host CPU %",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 90}] } },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_host_cpu_pct", "legendFormat": "CPU %" }]
+    },
+    {
+      "id": 5, "type": "gauge", "title": "Host RAM %",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 75}, {"color": "red", "value": 90}] } },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_host_mem_used_pct", "legendFormat": "RAM %" }]
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "GPU VRAM Over Time (MB)",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_gpu_vram_used_mb", "legendFormat": "VRAM Used (MB)" }]
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "GPU Utilisation & Temp",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        { "datasource": "${DS_PROMETHEUS}", "expr": "homelab_gpu_util_pct", "legendFormat": "Util %" },
+        { "datasource": "${DS_PROMETHEUS}", "expr": "homelab_gpu_temp_c",   "legendFormat": "Temp °C" }
+      ]
+    },
+    {
+      "id": 8, "type": "table", "title": "Disk Usage",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 6 },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_host_disk_used_pct", "legendFormat": "{{mountpoint}}", "instant": true }]
+    },
+    {
+      "id": 9, "type": "table", "title": "Model VRAM Loaded (MB)",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 6 },
+      "targets": [{ "datasource": "${DS_PROMETHEUS}", "expr": "homelab_model_loaded_vram_mb", "legendFormat": "{{server}} / {{model}}", "instant": true }]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3

Hi @SikamikanikoBG! Here is the complete implementation as discussed in issue #3.

## What changed

### `app.py`
- Added `prometheus_client` import (with graceful fallback if not installed)
- Defined **11 Gauges** at module level (defined once, never re-created):
  - `homelab_gpu_vram_used_mb`, `homelab_gpu_vram_total_mb`, `homelab_gpu_util_pct`, `homelab_gpu_temp_c`, `homelab_gpu_power_w`
  - `homelab_host_cpu_pct`, `homelab_host_mem_used_pct`, `homelab_host_disk_used_pct`
  - `homelab_container_state`, `homelab_systemd_unit_state`
  - `homelab_model_loaded_vram_mb`
- Added `GET /metrics` route that reads **exclusively from `LATEST` and `HEALTH` in-memory snapshots** — exactly as you requested: the exporter is a pure translation layer with zero extra I/O and zero double-sampling.

### `Dockerfile`
- Added `prometheus_client==0.20.0` to the single `pip install` line (keeps the image slim).

### `docs/grafana/homelab_prometheus_dashboard.json`
- Ready-to-import Grafana dashboard covering GPU VRAM, utilisation, temperature, host CPU/RAM, disk usage per mountpoint, and model VRAM loaded.
- Import via **Grafana → Dashboards → Import → Upload JSON file**.

### `README.md`
- New **Prometheus integration** section with: full metrics table, `curl` verification step, sample `prometheus.yml` scrape config, and Grafana import instructions.

## Quick verification

```bash
docker compose up -d --build
curl http://localhost:9800/metrics
```

Expected output:
```
# HELP homelab_gpu_vram_used_mb GPU VRAM used (MB)
# TYPE homelab_gpu_vram_used_mb gauge
homelab_gpu_vram_used_mb{gpu="gpu0"} 4096.0
...
```

Let me know if you'd like any adjustments!
