### PR TITLE
fix: clear stale label series on each /metrics scrape

### DIFF
--- a/app.py
+++ b/app.py
@@ -583,6 +583,11 @@ def metrics():
     if not _PROM_OK:
         return Response("# prometheus_client not installed\n", mimetype="text/plain", status=503)
 
+    # Clear all multi-label gauges before re-populating so stale series vanish.
+    for key in ("gpu_vram_used", "gpu_vram_total", "gpu_util", "gpu_temp", "gpu_power",
+                "host_disk_used", "model_vram", "container_state", "systemd_unit"):
+        _G[key].clear()
+
     # ── GPU ──────────────────────────────────────────────────────────────────
     gpu_label = "gpu0"
     _G["gpu_vram_used"].labels(gpu=gpu_label).set(LATEST.get("mem_used", 0))


### PR DESCRIPTION
Closes #6

Hi @SikamikanikoBG! Spotted the same issue when reviewing the scrape behaviour — great catch. Here is the fix.

## What changed

**`app.py` — `/metrics` handler only**

Added a single `for` loop that calls `.clear()` on every multi-label gauge **before** re-populating it on each scrape:

```python
for key in ("gpu_vram_used", "gpu_vram_total", "gpu_util", "gpu_temp", "gpu_power",
            "host_disk_used", "model_vram", "container_state", "systemd_unit"):
    _G[key].clear()
```

This ensures that stale label combinations — a container that went from `running` → `exited`, an unmounted disk, an unloaded model, or a removed systemd unit — are not reported on the next scrape.

Single-label gauges (`host_cpu`, `host_mem_used`) are intentionally left alone: they have no label combinations to go stale and `.clear()` on them would cause a momentary gap in the series.

## Why this approach

`.clear()` is the idiomatic solution recommended by the `prometheus_client` maintainers for exactly this pattern (dynamic label sets that change at runtime). The alternative — a custom `Collector` — is more powerful but adds complexity that is not needed here.

## Verification

```bash
# Start the container, scrape once to populate series
curl -s http://localhost:9800/metrics | grep homelab_container_state

# Stop a container, scrape again — its label series should be gone
docker stop <some-container>
curl -s http://localhost:9800/metrics | grep homelab_container_state
# The stopped container's old state="running" line should no longer appear
```
