### PR TITLE
docs: add CONTRIBUTING.md + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Something isn't working the way you expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- A clear, short description of the bug. Screenshots welcome. -->
+
+## What you expected
+
+<!-- What did you think would happen instead? -->
+
+## How to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- HomeLab Monitor version (badge in the README / `docker compose ps`):
+- Host OS:
+- Docker / Compose version (`docker --version`, `docker compose version`):
+- GPU + driver (if relevant — `nvidia-smi` first line):
+- Browser (if a UI bug):
+
+## Logs
+
+<details>
+<summary><code>docker compose logs --tail=200 homelab-monitor</code></summary>
+
+```
+paste logs here
+```
+
+</details>
+
+## Anything else
+
+<!-- Configuration overrides, related issues, things you've already tried. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest a new monitor, model-server probe, alert channel, or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## What you'd like to see
+
+<!-- A clear, short description of the feature or change. -->
+
+## Why it would help
+
+<!-- What problem does it solve? Who else might want it? -->
+
+## Sketch (optional)
+
+<!-- If you've thought about how it might work: a rough API shape, a UI mockup,
+a link to a tool that does it well, etc. For new monitors, see the
+"add a monitor" pattern in CONTRIBUTING.md. -->
+
+## Alternatives you've considered
+
+<!-- Other tools, workarounds, or approaches you've tried or thought about. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thanks for sending a PR! A short description and a ticked checklist are all
+we need — the rest is optional. -->
+
+## What this changes
+
+<!-- One or two sentences. Link related issues with "Fixes #123" if any. -->
+
+## Checklist
+
+- [ ] Branched off the **latest `main`** (`git pull origin main` before
+      branching) — avoids stale-branch merge churn.
+- [ ] Tested locally with `docker compose up -d --build` and the dashboard
+      behaves as expected.
+- [ ] No version bump in this PR — version bumps are handled by the maintainer
+      at release time.
+- [ ] For a new monitor / probe: followed the **"add a monitor" pattern** in
+      `CONTRIBUTING.md` (collector → `health_scan()` → `/api/health` → `TABS`
+      entry + section + renderer). *(Skip if not applicable.)*
+
+## Notes for the reviewer
+
+<!-- Anything worth flagging: trade-offs you considered, screenshots of UI
+changes, things you're unsure about. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to HomeLab Monitor
+
+Thanks for thinking about contributing! This is a small hobby tool meant to help
+fellow home-labbers, so the bar for contributing is intentionally low — a
+typo-fix PR is just as welcome as a new GPU back-end.
+
+## Run it locally
+
+The repo is a single Docker Compose service. You don't need Python on your host.
+
+```bash
+git clone https://github.com/SikamikanikoBG/homelab-monitor.git
+cd homelab-monitor
+docker compose up -d --build
+```
+
+Open **http://localhost:9800** (or `http://<your-host-ip>:9800` from another
+device on your LAN/VPN).
+
+History lives in `./data/gpu.db` — a bind mount that survives rebuilds. Delete
+the file if you want a clean slate.
+
+To rebuild after a code change: `docker compose up -d --build` again. To follow
+logs: `docker compose logs -f`.
+
+> **GPU panels** need an NVIDIA GPU and the
+> [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+> Without a GPU the container, service and host panels still work fine — handy
+> for developing non-GPU features on a laptop.
+
+## Branch off the latest `main`
+
+Before you start, please **sync `main` and branch from it**:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b your-feature
+```
+
+`main` moves, and rebasing a stale branch onto a moved-on `main` is the most
+common source of merge churn here. Fresh branches save everyone time.
+
+## The "add a monitor" pattern
+
+The codebase is deliberately small and modular so adding a new subsystem is a
+short, predictable change. Follow the existing pattern:
+
+1. **Backend collector.** In `app.py`, add a `collect_<thing>()` that returns:
+   ```python
+   {"available": bool, "summary": {...}, "items": [...]}
+   ```
+   Return `{"available": False, ...}` (rather than raising) when the subsystem
+   isn't present — the dashboard should degrade gracefully, not error.
+
+2. **Wire it into the scan.** Call `collect_<thing>()` from `health_scan()` so
+   the background thread keeps it fresh, and include it in the `/api/health`
+   response.
+
+3. **Frontend tab.** In `static/dashboard.html`, add:
+   - one entry to the `TABS` array,
+   - one `<section data-tab="...">` for the tab body,
+   - a small renderer that reads from `/api/health`.
+
+   No build step, no framework — vanilla JS and the vendored Chart.js.
+
+That's the whole pattern. The same shape applies to "add a model-server probe"
+(append to `PROBES` in `app.py`) and "add an alert channel" (extend the alert
+dispatcher).
+
+## Style
+
+- Keep it **plug-and-play** — anything new should work with `docker compose up
+  -d --build` and no extra config. If a feature needs config, give it a safe
+  default and make it optional.
+- Keep the tone **humble and welcoming** in UI copy, README, and commit
+  messages. This project is for hobbyists; please don't make anyone feel small
+  for not knowing something.
+- Match the existing code style — short functions, plain names, comments only
+  where the *why* isn't obvious from the code.
+
+## Submitting a PR
+
+- Open an issue first for anything larger than a small fix, so we can agree on
+  the shape before you spend time on it.
+- Keep PRs focused — one feature or fix per PR is easier to review.
+- Leave the version bump to the maintainer; it happens on release, not per PR.
+
+Thanks again — every issue, suggestion, and PR helps. 🛰️


### PR DESCRIPTION
## Summary

Closes #11. Lowers the bar for new contributors and helps prevent stale-branch PRs.

- **`CONTRIBUTING.md`** — local run (`docker compose up -d --build`), the project's **"add a monitor" pattern** (`collect_<thing>()` → `health_scan()` → `/api/health` → `TABS` entry + `<section>` + small renderer), and a clear "branch off the latest `main`" note.
- **`.github/ISSUE_TEMPLATE/bug_report.md`** + **`feature_request.md`** — so new issues offer template choices.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — short checklist: branched off latest `main`, tested locally with `docker compose up -d --build`, version left to maintainer, "add a monitor" pattern followed when applicable.

Tone matches the README — humble and welcoming, no jargon, hobbyist-friendly.

## Test plan

- [ ] Open a new issue on the repo and confirm both **Bug report** and **Feature request** templates appear.
- [ ] Open a draft PR and confirm the checklist body pre-fills.
- [ ] Skim `CONTRIBUTING.md` from the rendered GitHub view for typos / broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)