### PR TITLE
docs: cache-bust clones badge so README updates quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/network/members)
-[![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git)](https://github.com/SikamikanikoBG/homelab-monitor)
+[![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
 ![version](https://img.shields.io/badge/version-0.5.0-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)


### PR DESCRIPTION
## Summary

After fixing the `STATS_PAT` secret, the published `clones.json` correctly shows **138 clones / 87 unique (14d)**, and `img.shields.io` serves the right SVG. But GitHub renders README images through its **camo** image proxy, which caches the badge for hours — so visitors keep seeing the stale value (or the old `—`) even though the source is fixed.

This one-character change appends `&cacheSeconds=300` to the clones badge URL. Two effects:

1. The URL changes → camo treats it as a new image and fetches the current value immediately. The badge updates the moment this lands on `main`.
2. Future daily updates from the stats workflow show up within ~5 minutes instead of hours.

No code or workflow changes.

## Test plan

- [ ] Merge, then hard-refresh https://github.com/SikamikanikoBG/homelab-monitor — the **Clones (14d)** badge should show **138** (today's value).
- [ ] After the next daily stats run (~05:17 UTC), the number should update within a few minutes of the workflow finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)