### PR TITLE
docs: add unique-cloners badge alongside total clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/network/members)
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
+[![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
 ![version](https://img.shields.io/badge/version-0.5.0-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)


### PR DESCRIPTION
## Summary

The stats workflow already publishes `clones-unique.json` (latest value: **87 unique cloners / 14d**) to the `stats` branch. This adds a second badge that surfaces it next to the total-clones badge — same shields endpoint pattern, same `cacheSeconds=300` so camo refreshes it promptly.

No workflow changes; reads existing JSON.

## Test plan

- [ ] Merge, hard-refresh README, confirm a **unique cloners (14d)** badge renders next to **clones (14d)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)