### PR TITLE
feat: in-UI update notification + favicon (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/network/members)
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
-![version](https://img.shields.io/badge/version-0.5.0-blue)
+![version](https://img.shields.io/badge/version-0.6.0-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Set these under `environment:` in `docker-compose.yml` (all optional):
 | `PORT` | `9800` | Dashboard port |
 | `WATCH_CONTAINERS` | — | Extra containers to scan for OOM (comma-separated) |
 | `WATCH_SERVICES` | — | systemd units to always show, even vendor ones (comma-separated) |
+| `CHECK_UPDATES` | `true` | Set to `false` to disable the daily GitHub-releases check (no outbound calls) |
 
 History lives in `./data/gpu.db` (a bind mount), so it survives restarts and upgrades.
 

--- a/app.py
+++ b/app.py
@@ -35,6 +35,9 @@ DOCKER_SOCK  = os.environ.get("DOCKER_SOCK", "/var/run/docker.sock")
 HOST_ROOT    = os.environ.get("HOST_ROOT", "/rootfs")          # host / mounted read-only (optional)
 PORT         = int(os.environ.get("PORT", "9800"))
 PRESSURE_MB  = int(os.environ.get("PRESSURE_FREE_MB", "2048"))
+CHECK_UPDATES = os.environ.get("CHECK_UPDATES", "true").strip().lower() not in ("0", "false", "no", "off")
+UPDATE_REPO   = os.environ.get("UPDATE_REPO", "SikamikanikoBG/homelab-monitor")
+UPDATE_TTL    = 6 * 3600                                         # GitHub releases API cache window
 MAX_POINTS   = 360
 HEX64        = re.compile(r"[0-9a-f]{64}")
 OOM_RE       = re.compile(r"(out of memory|cuda error: out of memory|failed to allocate|bfcarena|"
@@ -82,7 +85,7 @@ LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "te
           "procs": [], "models": [], "host": {}}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
-HEALTH = {"docker": None, "systemd": None, "at": 0}
+HEALTH = {"docker": None, "systemd": None, "update": None, "at": 0}
 WATCH_SERVICES = [s.strip() for s in os.environ.get("WATCH_SERVICES", "").split(",") if s.strip()]
 SYSTEMD_ADMIN_DIR = "/etc/systemd/system/"   # units here are admin/user-authored (vs vendor)
 _ct_cache = {"list": [], "at": 0}
@@ -369,9 +372,65 @@ def build_overview(now, docker, systemd):
                       "metric": "—", "detail": "unavailable"})
     return cards
 
+# ── Update check (GitHub releases) ────────────────────────────────────────────
+# Hits the public releases endpoint, caches for UPDATE_TTL, compares against
+# VERSION. Surfaces via /api/health → dashboard badge. Off when CHECK_UPDATES
+# is false; degrades silently to "not available" on network/rate-limit errors
+# so the UI never lights up red because GitHub blinked.
+_UPDATE_CACHE = {"at": 0, "data": None}
+_UPDATE_LOCK  = threading.Lock()
+
+def _parse_semver(v):
+    """Tolerant semver parser: 'v0.5.0' / '0.5.0-beta' → (0, 5, 0). Missing
+    components → 0. Anything unparseable falls back to 0 so a malformed tag
+    just looks like an older version, never crashes the comparison."""
+    s = (v or "").lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    out = []
+    for p in s.split("."):
+        try: out.append(int(p))
+        except ValueError: out.append(0)
+    return tuple(out) or (0,)
+
+def collect_update():
+    if not CHECK_UPDATES:
+        return {"available": False, "current": VERSION, "disabled": True}
+    now = int(time.time())
+    with _UPDATE_LOCK:
+        if _UPDATE_CACHE["data"] and (now - _UPDATE_CACHE["at"]) < UPDATE_TTL:
+            return _UPDATE_CACHE["data"]
+    try:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{UPDATE_REPO}/releases/latest",
+            headers={"Accept": "application/vnd.github+json",
+                     "User-Agent": f"homelab-monitor/{VERSION}"})
+        with urllib.request.urlopen(req, timeout=8) as r:
+            payload = json.loads(r.read())
+    except Exception as e:
+        # Network down, rate-limited, no releases yet — degrade silently. We
+        # still cache the negative result so we don't hammer GitHub on retry.
+        data = {"available": False, "current": VERSION, "error": str(e)[:200]}
+        with _UPDATE_LOCK:
+            _UPDATE_CACHE.update({"at": now, "data": data})
+        return data
+    latest = (payload.get("tag_name") or "").lstrip("vV")
+    data = {
+        "available":    bool(latest) and _parse_semver(latest) > _parse_semver(VERSION),
+        "current":      VERSION,
+        "latest":       latest or None,
+        "release_url":  payload.get("html_url"),
+        "release_name": payload.get("name") or (latest and f"v{latest}") or None,
+        "release_notes": payload.get("body") or "",
+        "published_at": payload.get("published_at"),
+        "checked_at":   now,
+    }
+    with _UPDATE_LOCK:
+        _UPDATE_CACHE.update({"at": now, "data": data})
+    return data
+
 def health_scan():
     HEALTH["docker"]  = collect_docker()
     HEALTH["systemd"] = collect_systemd()
+    HEALTH["update"]  = collect_update()
     HEALTH["at"]      = int(time.time())
 
 # ── Settings (UI-managed; persisted in SQLite, no env required) ───────────────
@@ -767,8 +826,9 @@ def api_health():
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}
     systemd = HEALTH["systemd"] or {"available": False, "reason": "warming up…",
                                     "services": [], "summary": {}}
+    update  = HEALTH["update"]  or {"available": False, "current": VERSION}
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
-                    "docker": docker, "systemd": systemd,
+                    "docker": docker, "systemd": systemd, "update": update,
                     "overview": build_overview(now, docker, systemd)})
 
 @app.route("/metrics")

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.5.0"
+VERSION      = "0.6.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
@@ -813,6 +813,13 @@ def api_data():
                     "services": services, "other": other, "summary": summary, "model_summary": model_summary,
                     "events": evs, "insights": insights, "pressure_free_mb": PRESSURE_MB,
                     "mem_total": mem_total, "peak_mem": peak, "now": LATEST})
+
+@app.route("/favicon.ico")
+def favicon():
+    """Default-favicon URL — browsers ask for /favicon.ico even when an explicit
+    <link rel="icon"> points elsewhere (during early page load, or for tabs that
+    open without rendering HTML). Serve the SVG we ship in static/."""
+    return app.send_static_file("favicon.svg")
 
 @app.route("/api/health")
 def api_health():

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -53,8 +53,25 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .cols{display:grid;grid-template-columns:1fr 1fr;gap:16px}@media(max-width:760px){.cols{grid-template-columns:1fr}}
 .cap{color:var(--mut);font-size:12px;margin-top:9px}.pill{font-size:11px;color:var(--mut);border:1px solid var(--bd);border-radius:5px;padding:1px 6px}
 .muted{color:var(--mut)}a{color:#58a6ff}
+/* update-available badge (header) + modal */
+.upd{display:none;align-items:center;gap:5px;font-size:12px;color:var(--info);text-decoration:none;border:1px solid #58a6ff55;border-radius:20px;padding:2px 10px;background:#58a6ff11;cursor:pointer;font:inherit}
+.upd:hover{border-color:var(--info)}
+.upd.show{display:inline-flex}
+.umodal{position:fixed;inset:0;background:#0008;display:none;align-items:center;justify-content:center;z-index:50;padding:18px}
+.umodal.show{display:flex}
+.umodal .box{background:var(--card);border:1px solid var(--bd);border-radius:12px;max-width:640px;width:100%;max-height:84vh;display:flex;flex-direction:column}
+.umodal .hd{display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1px solid var(--bd)}
+.umodal .hd .x{margin-left:auto;background:none;border:0;color:var(--mut);font-size:22px;line-height:1;cursor:pointer;padding:0 4px}
+.umodal .hd .x:hover{color:var(--tx)}
+.umodal .bd{padding:14px 18px;overflow:auto}
+.umodal pre.cmd{background:#0d1117;border:1px solid var(--bd);border-radius:8px;padding:10px 12px;font-size:12.5px;white-space:pre-wrap;word-break:break-all;margin:8px 0 0;color:var(--tx)}
+.umodal .row{display:flex;gap:8px;margin-top:10px;flex-wrap:wrap}
+.umodal .btn{background:#0d1117;border:1px solid var(--bd);color:var(--tx);border-radius:7px;padding:7px 12px;cursor:pointer;font:inherit;font-size:13px;text-decoration:none;display:inline-flex;align-items:center;gap:6px}
+.umodal .btn:hover{border-color:var(--mut)}
+.umodal .notes{margin-top:14px;padding-top:12px;border-top:1px solid var(--bd);font-size:13px;color:var(--tx);white-space:pre-wrap;line-height:1.45;max-height:32vh;overflow:auto}
 </style></head><body><div class="wrap">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
+<button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
 <a class="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub"><span class="st">★</span> Star <span class="cnt" id="ghcount"></span></a>
 <span class="live"><span class="pulse"></span><span id="lastup">connecting…</span></span></header>
 <p class="sub">One small container for your home lab — GPU &amp; local-AI, Docker containers, systemd services and host health, all on one page. Everything is discovered automatically; nothing is hardcoded.</p>
@@ -191,6 +208,26 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 <p class="cap">Self-hosted &amp; open source • single container • no Prometheus/Grafana required • history downsampled on read.
 GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker API.</p>
 </div>
+
+<!-- ───────── Update-available modal ───────── -->
+<div class="umodal" id="updmodal" role="dialog" aria-modal="true" aria-labelledby="updtitle">
+  <div class="box">
+    <div class="hd">
+      <strong id="updtitle">Update available</strong>
+      <button class="x" type="button" id="updclose" aria-label="Close">×</button>
+    </div>
+    <div class="bd">
+      <div class="muted" id="updmeta"></div>
+      <div style="margin-top:12px">To update, run this on the host that's running the container:</div>
+      <pre class="cmd" id="updcmd">cd &lt;your-clone-dir&gt; &amp;&amp; git pull &amp;&amp; docker compose up -d --build</pre>
+      <div class="row">
+        <button class="btn" type="button" id="updcopy">📋 Copy command</button>
+        <a class="btn" id="updlink" href="#" target="_blank" rel="noopener">View on GitHub →</a>
+      </div>
+      <div class="notes" id="updnotes" hidden></div>
+    </div>
+  </div>
+</div>
 <script>
 // ── Tab registry. Add a monitor: append one entry here + a matching <section
 //    data-tab="..."> above + a render in renderData()/renderHealth(). ──────────
@@ -305,6 +342,17 @@ function renderHealth(){
   if(!HH) return;
   document.getElementById('ver').textContent='v'+HH.version;
 
+  // Update-available badge — only visible when GitHub releases shows a newer tag.
+  const up = HH.update || {};
+  const ub = document.getElementById('updbadge');
+  if(up.available && up.latest){
+    document.getElementById('updlatest').textContent = 'v'+up.latest;
+    ub.classList.add('show');
+    ub.onclick = () => openUpdateModal(up);
+  } else {
+    ub.classList.remove('show');
+  }
+
   // Overview status cards (one per subsystem; click to jump to its tab)
   document.getElementById('ovcards').innerHTML = (HH.overview||[]).map(c=>
     `<button class="ov ${c.status}" data-go="${c.key}"><div class="h"><span class="sdot" style="background:${SC[c.status]}"></span>${esc(c.label)}</div>
@@ -348,6 +396,21 @@ function renderHealth(){
       <p class="cap">Showing the units you deployed (under <code>/etc/systemd/system</code>), anything you set in <code>WATCH_SERVICES</code>, and any failed unit.</p>`;
   }
 }
+
+// ── Update-available modal ────────────────────────────────────────────────────
+function openUpdateModal(up){
+  document.getElementById('updtitle').textContent = (up.release_name || ('v'+up.latest)) + ' available';
+  const when = up.published_at ? ' (published ' + new Date(up.published_at).toLocaleDateString() + ')' : '';
+  document.getElementById('updmeta').textContent = "You're on v" + up.current + '. Latest is v' + up.latest + when + '.';
+  document.getElementById('updlink').href = up.release_url
+    || ('https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v' + up.latest);
+  const notes = document.getElementById('updnotes');
+  if(up.release_notes && up.release_notes.trim()){
+    notes.hidden = false; notes.textContent = up.release_notes;
+  } else { notes.hidden = true; notes.textContent = ''; }
+  document.getElementById('updmodal').classList.add('show');
+}
+function closeUpdateModal(){ document.getElementById('updmodal').classList.remove('show'); }
 
 // ── Charts (only built for the visible tab) ───────────────────────────────────
 function buildCharts(){
@@ -458,6 +521,22 @@ document.querySelector(`.rb[data-r="${R}"]`)?.classList.add('on');
 window.addEventListener('hashchange',()=>{const h=location.hash.slice(1); if(h && TABS.some(t=>t.id===h) && h!==TAB) showTab(h);});
 document.getElementById('al_save').onclick = saveAlerts;
 document.getElementById('al_test').onclick = testAlerts;
+// Update modal: close via × button, Escape, or backdrop click; copy command to clipboard.
+document.getElementById('updclose').onclick = closeUpdateModal;
+document.getElementById('updmodal').addEventListener('click', e => { if(e.target.id==='updmodal') closeUpdateModal(); });
+document.addEventListener('keydown', e => { if(e.key==='Escape') closeUpdateModal(); });
+document.getElementById('updcopy').onclick = async () => {
+  const cmd = document.getElementById('updcmd').textContent;
+  try { await navigator.clipboard.writeText(cmd); }
+  catch(e){
+    // Fallback: select the <pre> so the user can Ctrl+C manually.
+    const r = document.createRange(); r.selectNodeContents(document.getElementById('updcmd'));
+    const s = window.getSelection(); s.removeAllRanges(); s.addRange(r);
+    return;
+  }
+  const b = document.getElementById('updcopy'), t = b.textContent;
+  b.textContent = '✓ Copied'; setTimeout(() => { b.textContent = t; }, 1500);
+};
 showTab(TAB);
 loadData(); loadHealth();
 setInterval(()=>{if(document.getElementById('auto').checked){loadData();loadHealth();}},15000);

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>HomeLab Monitor</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+<link rel="alternate icon" href="/favicon.ico">
 <script src="/static/chart.min.js" onerror="this.remove();var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"></script>
 <style>
 :root{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HomeLab Monitor">
+  <rect width="64" height="64" rx="12" fill="#0d1117"/>
+  <text x="32" y="48" text-anchor="middle" font-size="44"
+        font-family="Apple Color Emoji,Segoe UI Emoji,Noto Color Emoji,sans-serif">🛰️</text>
+</svg>


### PR DESCRIPTION
## Summary

Closes Phase 1 of #16. Two changes shipped together:

### 1. In-UI update notification (Phase 1 of #16)

**Backend** (`app.py`)
- `collect_update()` queries `https://api.github.com/repos/SikamikanikoBG/homelab-monitor/releases/latest`, caches the response for **6 hours**, and compares the `tag_name` against the running `VERSION` using a tolerant semver tuple compare (ignores `-prerelease` / `+build` suffixes).
- Wired into `health_scan()` (called every 15s, real HTTP fetch only every 6h thanks to the cache) and surfaced via `/api/health` under an `update` key.
- Network errors / rate limits cache a quiet `available: false` so we don't hammer GitHub or spam logs.
- New env var **`CHECK_UPDATES=false`** disables the check entirely — no outbound calls. Default `true`. Documented in the Configuration table.

**Frontend** (`static/dashboard.html`)
- Small *⬆ vX.Y.Z available* badge in the header, hidden when `update.available` is false, so existing users see no change until there's a real release.
- Clicking the badge opens a modal with: current/latest line, **copy command** button (Clipboard API + selection fallback), **View on GitHub** link, and the release notes in a scrollable plain-text block. Close via ×, Escape, or backdrop click.

### 2. Favicon

- `static/favicon.svg` — 🛰️ on the dashboard's dark card colour. Matches the H1 branding.
- `<link rel="icon">` in `dashboard.html`.
- `/favicon.ico` Flask route serving the SVG so legacy/default-path requests don't 404.

### Version

- `VERSION` 0.5.0 → **0.6.0** and README badge to match.

Phase 2 (safe one-click update when `requirements.txt` / `Dockerfile` / `docker-compose.yml` are unchanged across versions) remains tracked in #16 and is not part of this PR.

## Test plan

Manual checks once running on ardi (`cd /home/ardi/gpu-monitor && git pull && sudo docker compose up -d --build`):

- [ ] Browser tab and bookmark show the 🛰️ favicon.
- [ ] With current `VERSION = 0.6.0` and latest release on GitHub being `v0.6.0` → no badge. (Cut a v0.6.0 release after merge to verify the comparison logic, or temporarily edit `VERSION` to `0.5.0` to force the badge.)
- [ ] `curl http://ardi:9800/api/health | jq .update` shows the new key with `available`, `current`, `latest`, `release_url`, `release_notes`, `checked_at`.
- [ ] `curl http://ardi:9800/favicon.ico` returns the SVG.
- [ ] When badge is visible: click → modal opens, copy-command button copies the right string, View-on-GitHub link works, ×/Escape/backdrop all close.
- [ ] Set `CHECK_UPDATES=false` in `docker-compose.yml`, restart → `/api/health → update.disabled: true`, badge stays hidden.

⚠️ I couldn't run the container on my dev box (no Docker/GPU here), so the visual checks above are for the maintainer to validate on ardi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)