### PR TITLE
fix: ship favicon.svg into the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN mkdir -p /app/static \
 
 COPY app.py /app/app.py
 COPY static/dashboard.html /app/static/dashboard.html
+COPY static/favicon.svg    /app/static/favicon.svg
 
 ENV PORT=8099
 EXPOSE 8099


### PR DESCRIPTION
## Summary

Hotfix for #17. The 0.6.0 image was built without `favicon.svg` because the Dockerfile only copies `static/dashboard.html` out of `static/`. After deploy on ardi, `/favicon.ico` returns 404 — `app.send_static_file('favicon.svg')` fails because the file isn't in the image.

One-line fix: add a `COPY static/favicon.svg /app/static/favicon.svg` line matching the existing dashboard.html copy.

## Test plan

- [ ] Merge, redeploy, `curl http://ardi:9800/favicon.ico` returns 200 with `Content-Type: image/svg+xml` and the SVG bytes.
- [ ] Browser tab shows the 🛰️ favicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)