### PR TITLE
feat: branded GitHub star button + contribution footer (v0.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
-![version](https://img.shields.io/badge/version-0.6.0-blue)
+![version](https://img.shields.io/badge/version-0.6.1-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.6.0"
+VERSION      = "0.6.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -11,8 +11,14 @@
 .wrap{max-width:1140px;margin:0 auto;padding:22px 18px 70px}
 header{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
 h1{font-size:22px;margin:0}.ver{color:var(--mut);font-size:12px;border:1px solid var(--bd);border-radius:20px;padding:1px 9px}
-.ghstar{display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--tx);text-decoration:none;border:1px solid var(--bd);border-radius:20px;padding:2px 10px;background:#0d1117}
-.ghstar:hover{border-color:var(--mut)}.ghstar .st{color:var(--accent)}.ghstar .cnt{color:var(--mut)}
+.ghstar{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--tx);text-decoration:none;border:1px solid #d2992255;border-radius:20px;padding:3px 11px;background:#d2992211;transition:background .2s,border-color .2s}
+.ghstar:hover{border-color:var(--accent);background:#d2992222}
+.ghstar svg{width:13px;height:13px;fill:currentColor;flex:none}
+.ghstar .cnt{color:var(--mut)}
+/* once the user clicks Star, persist a localStorage flag and tone the button down — no further nudge. */
+.ghstar.starred{background:transparent;border-color:var(--bd);color:var(--mut)}
+.ghstar.starred:hover{border-color:var(--mut);background:transparent}
+.ghstar.starred svg{fill:var(--accent)}
 .live{display:flex;align-items:center;gap:6px;color:var(--mut);font-size:13px;margin-left:auto}
 .pulse{width:9px;height:9px;border-radius:50%;background:var(--ok);animation:p 2s infinite}
 @keyframes p{0%{box-shadow:0 0 0 0 #3fb95066}70%{box-shadow:0 0 0 8px #3fb95000}100%{box-shadow:0 0 0 0 #3fb95000}}
@@ -74,7 +80,9 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 </style></head><body><div class="wrap">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
-<a class="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub"><span class="st">★</span> Star <span class="cnt" id="ghcount"></span></a>
+<a class="ghstar" id="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub">
+<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<span id="ghlabel">Star</span> <span class="cnt" id="ghcount"></span></a>
 <span class="live"><span class="pulse"></span><span id="lastup">connecting…</span></span></header>
 <p class="sub">One small container for your home lab — GPU &amp; local-AI, Docker containers, systemd services and host health, all on one page. Everything is discovered automatically; nothing is hardcoded.</p>
 
@@ -208,7 +216,8 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 </section>
 
 <p class="cap">Self-hosted &amp; open source • single container • no Prometheus/Grafana required • history downsampled on read.
-GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker API.</p>
+GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker API.
+<br>Ideas welcome — see <a href="https://github.com/SikamikanikoBG/homelab-monitor/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">CONTRIBUTING.md</a> · issues &amp; PRs always open.</p>
 </div>
 
 <!-- ───────── Update-available modal ───────── -->
@@ -547,4 +556,24 @@ fetch('https://api.github.com/repos/SikamikanikoBG/homelab-monitor')
   .then(r=>r.ok?r.json():null)
   .then(d=>{if(d&&typeof d.stargazers_count==='number')document.getElementById('ghcount').textContent=d.stargazers_count;})
   .catch(()=>{});
+
+// Star-button state: subtle gold nudge until the user clicks Star, then quietly
+// flip to muted "✓ Starred" and never push again on this device. We can't see
+// from the browser whether they *actually* starred (would need their GitHub
+// auth), so we trust the click-through and stop nudging.
+(function(){
+  const btn = document.getElementById('ghstar');
+  if(!btn) return;
+  const lbl = document.getElementById('ghlabel');
+  if(localStorage.getItem('hl_starred') === '1'){
+    btn.classList.add('starred');
+    btn.title = "Thanks for starring HomeLab Monitor!";
+    lbl.textContent = '✓ Starred';
+  }
+  btn.addEventListener('click', () => {
+    localStorage.setItem('hl_starred', '1');
+    btn.classList.add('starred'); lbl.textContent = '✓ Starred';
+    btn.title = "Thanks for starring HomeLab Monitor!";
+  });
+})();
 </script></body></html>


### PR DESCRIPTION
## Summary

Two small UX changes plus a version bump that lets the in-UI update notification (shipped in v0.6.0) actually fire against a current-running 0.6.0 container.

### 1. Branded star button in the header

Replaces the vague \`★ Star\` text link with a proper GitHub-branded button: inline Octocat SVG + Star label + live count. Subtle gold background invites the click without bombarding.

After click, store \`hl_starred=1\` in localStorage. On next page load the button is muted (no accent, no glow), label flips to **✓ Starred**. We can't tell from the browser whether the user *actually* starred (would need their GitHub auth), so we trust the click-through and stop nudging.

### 2. Contribution footer line

One small line added to the existing footer:

> Ideas welcome — see CONTRIBUTING.md · issues & PRs always open.

No popups, no toasts, no animations.

### 3. VERSION 0.6.0 → 0.6.1

So the v0.6.1 release on GitHub gives ardi's 0.6.0 container something newer to detect — closes the loop on testing the update badge end-to-end.

## Test plan

After merge + cut v0.6.1 release on GitHub (no ardi redeploy):

- [ ] http://ardi:9800 — header shows the branded button with logo + count.
- [ ] Click Star → tab opens to repo, button immediately flips to **✓ Starred**, refresh persists state, no further nudge.
- [ ] Footer shows the **CONTRIBUTING.md** link, clicking opens it on GitHub.
- [ ] After ardi's collector refreshes (process restart flushes the 6h cache, or wait), the **⬆ v0.6.1 available** badge appears in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)