### PR TITLE
fix: shorter cache for negative update-check results (v0.6.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
-![version](https://img.shields.io/badge/version-0.6.1-blue)
+![version](https://img.shields.io/badge/version-0.6.2-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.6.1"
+VERSION      = "0.6.2"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
@@ -37,7 +37,12 @@ PORT         = int(os.environ.get("PORT", "9800"))
 PRESSURE_MB  = int(os.environ.get("PRESSURE_FREE_MB", "2048"))
 CHECK_UPDATES = os.environ.get("CHECK_UPDATES", "true").strip().lower() not in ("0", "false", "no", "off")
 UPDATE_REPO   = os.environ.get("UPDATE_REPO", "SikamikanikoBG/homelab-monitor")
-UPDATE_TTL    = 6 * 3600                                         # GitHub releases API cache window
+# Split cache: once we know there's an update, the answer won't change for hours
+# so we can cache it long. But "no update found" / network errors should expire
+# sooner — otherwise a release published right after deploy stays invisible for
+# the full 6h, and a transient GitHub blip sticks for the same window.
+UPDATE_TTL_POSITIVE = 6 * 3600
+UPDATE_TTL_NEGATIVE = 30 * 60
 MAX_POINTS   = 360
 HEX64        = re.compile(r"[0-9a-f]{64}")
 OOM_RE       = re.compile(r"(out of memory|cuda error: out of memory|failed to allocate|bfcarena|"
@@ -396,8 +401,11 @@ def collect_update():
         return {"available": False, "current": VERSION, "disabled": True}
     now = int(time.time())
     with _UPDATE_LOCK:
-        if _UPDATE_CACHE["data"] and (now - _UPDATE_CACHE["at"]) < UPDATE_TTL:
-            return _UPDATE_CACHE["data"]
+        cached = _UPDATE_CACHE["data"]
+        if cached:
+            ttl = UPDATE_TTL_POSITIVE if cached.get("available") else UPDATE_TTL_NEGATIVE
+            if (now - _UPDATE_CACHE["at"]) < ttl:
+                return cached
     try:
         req = urllib.request.Request(
             f"https://api.github.com/repos/{UPDATE_REPO}/releases/latest",


### PR DESCRIPTION
## Summary

`collect_update()` used a single **6h TTL** for both "update available" and "no update / error". That meant if the collector ran before a release was published (e.g. the maintainer deploys, then cuts the release a minute later), the dashboard kept saying "you're up to date" for 6h even after the release landed. Same stickiness for transient GitHub blips.

**Concrete repro from earlier today:** ardi deployed v0.6.0 at ~03:33 UTC, collector fetched and cached `latest: v0.5.0` (correct at that moment). v0.6.0 release was published at 03:34 UTC, v0.6.1 at 03:36 UTC. Dashboard kept saying "no update available" until I manually `docker compose restart`'d the container to flush the in-memory cache.

## Change

Split the TTL by result:

| Result | TTL | Why |
|---|---|---|
| **Update available** | 6h | Answer won't change for hours, save GitHub API calls |
| **No update / error** | **30 min** | Recheck sooner so freshly-cut releases or transient errors recover quickly |

Worst-case API usage at 30m negative-cache: ~48 calls/day per host. GitHub's unauthenticated limit is 60 req/hr/IP — well within budget.

## Test plan

- [ ] Verify v0.6.2 release on GitHub.
- [ ] ardi (running 0.6.1 by the time this lands) sees ⬆ v0.6.2 available within 30min of release, no manual restart.
- [ ] If GitHub returns an error or empty release set, retry happens after 30min, not 6h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)