### PR TITLE
fix: render release notes as HTML in update modal (v0.6.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
-![version](https://img.shields.io/badge/version-0.6.2-blue)
+![version](https://img.shields.io/badge/version-0.6.3-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.6.2"
+VERSION      = "0.6.3"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
@@ -385,6 +385,25 @@ def build_overview(now, docker, systemd):
 _UPDATE_CACHE = {"at": 0, "data": None}
 _UPDATE_LOCK  = threading.Lock()
 
+def _render_markdown(md_text):
+    """Render Markdown to HTML via GitHub's /markdown endpoint so the update modal
+    can show release notes as proper prose (headings, lists, code, tables) rather
+    than raw `##` markup. GitHub sanitises the output server-side, so it's safe to
+    set as innerHTML. Returns None on failure — caller falls back to plain text."""
+    if not md_text:
+        return None
+    try:
+        body = json.dumps({"text": md_text, "mode": "gfm", "context": UPDATE_REPO}).encode("utf-8")
+        req = urllib.request.Request(
+            "https://api.github.com/markdown", data=body,
+            headers={"Content-Type": "application/json",
+                     "Accept": "application/vnd.github+json",
+                     "User-Agent": f"homelab-monitor/{VERSION}"})
+        with urllib.request.urlopen(req, timeout=8) as r:
+            return r.read().decode("utf-8")
+    except Exception:
+        return None
+
 def _parse_semver(v):
     """Tolerant semver parser: 'v0.5.0' / '0.5.0-beta' → (0, 5, 0). Missing
     components → 0. Anything unparseable falls back to 0 so a malformed tag
@@ -431,6 +450,12 @@ def collect_update():
         "published_at": payload.get("published_at"),
         "checked_at":   now,
     }
+    # Only render markdown when there's actually an update — the rendered HTML
+    # is only ever shown inside the "update available" modal, so rendering on
+    # the up-to-date path would waste a GitHub API call every cycle.
+    if data["available"]:
+        html = _render_markdown(data["release_notes"])
+        if html: data["release_notes_html"] = html
     with _UPDATE_LOCK:
         _UPDATE_CACHE.update({"at": now, "data": data})
     return data

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -76,7 +76,24 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .umodal .row{display:flex;gap:8px;margin-top:10px;flex-wrap:wrap}
 .umodal .btn{background:#0d1117;border:1px solid var(--bd);color:var(--tx);border-radius:7px;padding:7px 12px;cursor:pointer;font:inherit;font-size:13px;text-decoration:none;display:inline-flex;align-items:center;gap:6px}
 .umodal .btn:hover{border-color:var(--mut)}
-.umodal .notes{margin-top:14px;padding-top:12px;border-top:1px solid var(--bd);font-size:13px;color:var(--tx);white-space:pre-wrap;line-height:1.45;max-height:32vh;overflow:auto}
+.umodal .notes{margin-top:14px;padding-top:12px;border-top:1px solid var(--bd);font-size:13px;color:var(--tx);line-height:1.5;max-height:40vh;overflow:auto}
+/* Prose styling for GitHub-rendered release notes (innerHTML from /api/markdown). */
+.umodal .notes h1,.umodal .notes h2,.umodal .notes h3,.umodal .notes h4{margin:.9em 0 .35em;font-weight:600;color:var(--tx);text-transform:none;letter-spacing:0}
+.umodal .notes h1{font-size:1.15em}.umodal .notes h2{font-size:1.05em}.umodal .notes h3{font-size:.98em}
+.umodal .notes p{margin:.5em 0}
+.umodal .notes ul,.umodal .notes ol{padding-left:1.5em;margin:.4em 0}
+.umodal .notes li{margin:.2em 0}
+.umodal .notes code{background:#0d1117;border:1px solid var(--bd);border-radius:4px;padding:0 5px;font-size:.9em;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.umodal .notes pre{background:#0d1117;border:1px solid var(--bd);border-radius:6px;padding:9px 11px;overflow-x:auto;font-size:12px;margin:.5em 0}
+.umodal .notes pre code{background:none;border:0;padding:0;font-size:12px}
+.umodal .notes table{border-collapse:collapse;margin:.6em 0;font-size:12.5px;display:block;overflow-x:auto}
+.umodal .notes th,.umodal .notes td{border:1px solid var(--bd);padding:5px 9px;text-align:left}
+.umodal .notes th{background:#0d1117;font-weight:600}
+.umodal .notes a{color:#58a6ff;text-decoration:none}
+.umodal .notes a:hover{text-decoration:underline}
+.umodal .notes blockquote{border-left:3px solid var(--bd);padding:.2em 0 .2em 10px;color:var(--mut);margin:.5em 0}
+.umodal .notes hr{border:0;border-top:1px solid var(--bd);margin:1em 0}
+.umodal .notes img{max-width:100%}
 </style></head><body><div class="wrap">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
@@ -415,10 +432,18 @@ function openUpdateModal(up){
   document.getElementById('updmeta').textContent = "You're on v" + up.current + '. Latest is v' + up.latest + when + '.';
   document.getElementById('updlink').href = up.release_url
     || ('https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v' + up.latest);
+  // Prefer the server-rendered HTML (GitHub /markdown returns sanitised
+  // GitHub-flavoured markdown). Fall back to plain text if the render call
+  // failed for any reason — better to show raw markdown than show nothing.
   const notes = document.getElementById('updnotes');
-  if(up.release_notes && up.release_notes.trim()){
+  if(up.release_notes_html){
+    notes.hidden = false; notes.innerHTML = up.release_notes_html;
+  } else if(up.release_notes && up.release_notes.trim()){
     notes.hidden = false; notes.textContent = up.release_notes;
-  } else { notes.hidden = true; notes.textContent = ''; }
+    notes.style.whiteSpace = 'pre-wrap';
+  } else {
+    notes.hidden = true; notes.innerHTML = '';
+  }
   document.getElementById('updmodal').classList.add('show');
 }
 function closeUpdateModal(){ document.getElementById('updmodal').classList.remove('show'); }


### PR DESCRIPTION
## Summary

The update modal showed release notes as **raw markdown** — `## Heading`, `**bold**`, literal table pipes — because the renderer was using \`textContent\` on the body. Reported live from ardi's dashboard after v0.6.2.

Render server-side via GitHub's \`POST /markdown\` endpoint (GFM mode, with the repo as \`context\` so \`#N\` issue references resolve). GitHub sanitises its own output, so it's safe to \`innerHTML\`.

The extra API call only fires when an update is **actually available** (i.e., when the modal would open). On the up-to-date path nothing extra happens, so the new behaviour stays free for the common case.

If the render call fails (rate limit, network blip), the frontend falls back to plain-text \`textContent\` with \`pre-wrap\` so a hiccup doesn't blank the modal — it just shows the markdown source as before.

## Frontend

- Drop \`white-space:pre-wrap\` from the \`.notes\` block (broke HTML rendering).
- Add prose styles inside the modal: headings, lists, \`<code>\`, \`<pre>\`, GFM tables, links, blockquotes, \`<hr>\`, images. All themed to match the rest of the dashboard.

## Test plan

After merge + cut v0.6.3 release:

- [ ] On ardi (still running 0.6.0/0.6.1/0.6.2 — whichever it is now), within 30 min the update badge surfaces v0.6.3.
- [ ] Click badge — modal opens with **rendered** headings, lists, and tables (no raw \`##\`).
- [ ] Verify with the v0.6.2 release notes (they have a table) that the table renders with borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)