### PR TITLE
feat: self-healthcheck endpoint + Dockerfile HEALTHCHECK (v0.7.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,12 @@ COPY static/favicon.svg    /app/static/favicon.svg
 
 ENV PORT=8099
 EXPOSE 8099
+
+# Self-healthcheck so the container reports its own status to Docker (and to
+# our own Containers tab, which reads the same Docker API). /healthz is a
+# locks-free 200 that returns the running version — never blocks on the
+# collector. start-period covers the initial Flask boot.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PORT:-9800}/healthz" || exit 1
+
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Clones (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
-![version](https://img.shields.io/badge/version-0.6.3-blue)
+![version](https://img.shields.io/badge/version-0.7.0-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)
@@ -151,6 +151,11 @@ host /proc, /sys, statvfs ─► CPU / RAM / load / temp / disk
 
 A background thread samples on an interval; the web layer buckets any range down to
 ~360 points so it stays responsive over months.
+
+The container also exposes a tiny **`GET /healthz`** liveness endpoint (no DB, no
+locks — just a 200 with the running version) that the image's `HEALTHCHECK` polls
+every 30s. The Containers tab therefore lists the monitor itself as `(healthy)`,
+and any container orchestrator can pick it up the same way.
 
 ## Adding your own monitor
 

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.6.3"
+VERSION      = "0.7.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
@@ -846,6 +846,13 @@ def api_data():
                     "services": services, "other": other, "summary": summary, "model_summary": model_summary,
                     "events": evs, "insights": insights, "pressure_free_mb": PRESSURE_MB,
                     "mem_total": mem_total, "peak_mem": peak, "now": LATEST})
+
+@app.route("/healthz")
+def healthz():
+    """Cheap liveness probe for Docker's HEALTHCHECK and any uptime monitor.
+    No DB, no locks — just a 200 with the running version so the answer is
+    instant and never gets blocked behind a slow collector pass."""
+    return jsonify({"status": "ok", "version": VERSION}), 200
 
 @app.route("/favicon.ico")
 def favicon():


### PR DESCRIPTION
## Summary

Closes #9. The monitor now reports its own health via Docker's built-in healthcheck mechanism — so it shows up as `(healthy)` in `docker ps`, in its own **Containers** tab, and in any external orchestrator that watches Docker health.

### Changes

- **`app.py`** — new `GET /healthz` route returning `200 {"status":"ok","version":VERSION}`. Locks-free, DB-free, no I/O — answer is instant so a stuck collector can never block liveness.
- **`Dockerfile`** — `HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD curl -fsS http://127.0.0.1:${PORT:-9800}/healthz || exit 1`. `curl` is already installed earlier in the image (we use it to vendor Chart.js), so no new layers.
- **`README.md`** — one paragraph under *How it works* + version badge 0.6.3 → 0.7.0.
- **`VERSION`** — 0.6.3 → 0.7.0. Minor bump because it's a real new capability (Docker-level integration), not a patch.

## Test plan

After merge + cut release:

- [ ] `curl http://ardi:9800/healthz` → 200 with `{"status":"ok","version":"0.7.0"}`.
- [ ] `docker ps` shows `homelab-monitor` with `(healthy)` status within ~30s of start.
- [ ] The dashboard's Containers tab lists itself as healthy alongside everything else it monitors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)