### PR TITLE
ui(dashboard): pre/post-star CTA — soft nudge before, ideas pointer after

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -15,10 +15,16 @@ h1{font-size:22px;margin:0}.ver{color:var(--mut);font-size:12px;border:1px solid
 .ghstar:hover{border-color:var(--accent);background:#d2992222}
 .ghstar svg{width:13px;height:13px;fill:currentColor;flex:none}
 .ghstar .cnt{color:var(--mut)}
-/* once the user clicks Star, persist a localStorage flag and tone the button down — no further nudge. */
+/* once the user clicks Star, persist a localStorage flag and tone the button down — the trailing CTA swaps from a soft pre-star nudge to a thank-you + ideas pointer. */
 .ghstar.starred{background:transparent;border-color:var(--bd);color:var(--mut)}
 .ghstar.starred:hover{border-color:var(--mut);background:transparent}
 .ghstar.starred svg{fill:var(--accent)}
+.star-cta{font-size:11px;color:var(--mut)}
+.star-cta a{color:inherit;text-decoration:none;border-bottom:1px dotted transparent;transition:color .2s,border-color .2s}
+.star-cta a:hover{color:var(--accent);border-bottom-color:var(--accent)}
+.star-cta.cta-post{display:none}
+.ghstar.starred ~ .cta-pre{display:none}
+.ghstar.starred ~ .cta-post{display:inline}
 .live{display:flex;align-items:center;gap:6px;color:var(--mut);font-size:13px;margin-left:auto}
 .pulse{width:9px;height:9px;border-radius:50%;background:var(--ok);animation:p 2s infinite}
 @keyframes p{0%{box-shadow:0 0 0 0 #3fb95066}70%{box-shadow:0 0 0 8px #3fb95000}100%{box-shadow:0 0 0 0 #3fb95000}}
@@ -178,6 +184,8 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 <a class="ghstar" id="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub">
 <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 <span id="ghlabel">Star</span> <span class="cnt" id="ghcount"></span></a>
+<span class="star-cta cta-pre">if it helps, a ⭐ helps me back</span>
+<span class="star-cta cta-post">thanks! got ideas? → <a href="https://github.com/SikamikanikoBG/homelab-monitor/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">CONTRIBUTING</a></span>
 <span class="live"><span class="pulse"></span><span id="lastup">connecting…</span></span></header>
 <p class="sub">One small container for your home lab — GPU &amp; local-AI, Docker containers, systemd services and host health, all on one page. Everything is discovered automatically; nothing is hardcoded.</p>
 


### PR DESCRIPTION
## Summary
- Trails the GitHub star badge in the header with a tiny 11px line that auto-swaps based on the existing `.ghstar.starred` localStorage flag — no JS changes, pure CSS sibling combinator.
- **Pre-star**: `if it helps, a ⭐ helps me back` (gentle, opt-in)
- **Post-star**: `thanks! got ideas? → CONTRIBUTING` (links to `CONTRIBUTING.md`)

## Test plan
- [ ] Fresh browser / cleared localStorage: pre-star copy visible next to the badge
- [ ] Click Star: badge mutes, copy swaps to "thanks! got ideas? → CONTRIBUTING"
- [ ] Reload: post-star copy persists (localStorage `hl_starred=1`)
- [ ] Narrow viewport: header `flex-wrap` keeps the line readable, no overflow
- [ ] CONTRIBUTING link opens in a new tab with `rel=noopener`

🤖 Generated with [Claude Code](https://claude.com/claude-code)