### PR TITLE
ui(containers/services): Ports/Uptime/Memory/Disk columns + clickable port pills

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ WORKDIR /app
 # flask = web layer; jeepney = pure-Python D-Bus client used to read systemd
 # (no native libs, keeps the image slim). curl only needed to vendor Chart.js below.
 # openssh-client provides ssh + ssh-keygen for the multi-host registry probes.
+# iproute2 provides `ss`, used to attribute listening TCP ports to systemd units
+# (services tab Ports column). pid:host + network_mode:host in compose makes
+# the visible PIDs/ports the real host's.
 RUN pip install --no-cache-dir flask==3.0.3 jeepney==0.8.0 prometheus_client==0.20.0 \
  && apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates openssh-client \
+ && apt-get install -y --no-install-recommends curl ca-certificates openssh-client iproute2 \
  && rm -rf /var/lib/apt/lists/*
 
 # Vendor Chart.js so the dashboard works fully offline / on a LAN with no internet.

--- a/app.py
+++ b/app.py
@@ -259,6 +259,15 @@ def read_host():
 # These describe *current state* (is it up? healthy? failed?) rather than a time
 # series, so they live behind /api/health and are refreshed by health_scan().
 _DOCKER_HEALTH = re.compile(r"\((healthy|unhealthy|health: starting)\)")
+# "Up 14 days, 2 hours" / "Up About a minute" / "Up 12 seconds (healthy)" — Docker
+# already builds a human Status string, so we parse it instead of issuing N more
+# inspect calls just for StartedAt.
+_DOCKER_UP_DUR = re.compile(r"^Up\s+(.+?)(?:\s*\(.*\))?$", re.I)
+_DUR_UNITS = {"second": 1, "minute": 60, "hour": 3600, "day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
+# Heavy enrichment (per-container `stats` + Docker layer-size scan) is too costly
+# to hit on every 10 s health_scan, so we keep a separate 30 s cache for it.
+_DOCKER_ENRICH_TTL = 30
+_docker_enrich = {"data": {}, "at": 0}
 
 def _docker_status(state, status):
     """Map a Docker container's state/status string to a (level, label) pair."""
@@ -279,6 +288,60 @@ def _docker_status(state, status):
     if st == "created":                  return "info", "created"
     return "info", st or "unknown"
 
+def _parse_docker_uptime(status_text):
+    """Turn Docker's 'Up 14 days, 2 hours' status text into a uptime in seconds.
+
+    Returns 0 for stopped/restarting/dead/etc. — anything that isn't 'Up …'."""
+    if not status_text:
+        return 0
+    m = _DOCKER_UP_DUR.match(status_text.strip())
+    if not m:
+        return 0
+    total = 0
+    for n, unit in re.findall(r"(\d+|a|an|about)\s*(second|minute|hour|day|week|month|year)s?", m.group(1).lower()):
+        try:
+            total += (1 if n in ("a", "an", "about") else int(n)) * _DUR_UNITS[unit]
+        except (KeyError, ValueError):
+            continue
+    return total
+
+def _container_published_ports(ct):
+    """Unique published host-side ports for a container (de-duped across v4/v6)."""
+    seen = []
+    for p in ct.get("Ports") or []:
+        port = p.get("PublicPort")
+        if isinstance(port, int) and port not in seen:
+            seen.append(port)
+    return sorted(seen)
+
+def _container_stats(cid):
+    """One-shot memory snapshot for a running container. Returns bytes or None."""
+    try:
+        d = json.loads(_docker(f"/containers/{cid}/stats?stream=false&one-shot=true"))
+    except Exception:
+        return None
+    mem = (d.get("memory_stats") or {}).get("usage")
+    # Docker counts page cache against `usage`; subtract it like `docker stats` does.
+    cache = ((d.get("memory_stats") or {}).get("stats") or {}).get("cache", 0)
+    return max(0, (mem or 0) - cache) if mem is not None else None
+
+def _refresh_docker_enrich(running_ids):
+    """Pull SizeRw (one Docker call with size=1) + memory (per-container, in
+    parallel). Cached for _DOCKER_ENRICH_TTL seconds — heavy enough that we
+    don't want it on the 10 s health-scan path."""
+    out = {}
+    try:
+        sized = json.loads(_docker("/containers/json?all=1&size=1"))
+        for ct in sized:
+            out[ct["Id"][:12]] = {"disk_bytes": ct.get("SizeRw") or 0}
+    except Exception:
+        pass
+    if running_ids:
+        with ThreadPoolExecutor(max_workers=min(8, len(running_ids))) as ex:
+            for cid, mem in zip(running_ids, ex.map(_container_stats, running_ids)):
+                out.setdefault(cid, {})["mem_bytes"] = mem
+    return out
+
 def collect_docker():
     try:
         raw = json.loads(_docker("/containers/json?all=1"))
@@ -288,9 +351,24 @@ def collect_docker():
     items = []
     for ct in raw:
         level, label = _docker_status(ct.get("State"), ct.get("Status"))
-        items.append({"name": (ct.get("Names") or ["/?"])[0].lstrip("/"),
-                      "image": ct.get("Image", ""), "state": (ct.get("State") or "").lower(),
-                      "status_text": ct.get("Status", ""), "status": level, "label": label})
+        state = (ct.get("State") or "").lower()
+        status_text = ct.get("Status", "")
+        items.append({"id": ct["Id"][:12],
+                      "name": (ct.get("Names") or ["/?"])[0].lstrip("/"),
+                      "image": ct.get("Image", ""), "state": state,
+                      "status_text": status_text, "status": level, "label": label,
+                      "ports": _container_published_ports(ct),
+                      "uptime_s": _parse_docker_uptime(status_text) if state == "running" else 0})
+    # Merge cached enrichment (memory + disk). Refresh on a slower cadence than
+    # the basic state pass — see _DOCKER_ENRICH_TTL.
+    if time.time() - _docker_enrich["at"] > _DOCKER_ENRICH_TTL:
+        running_ids = [c["id"] for c in items if c["state"] == "running"]
+        _docker_enrich["data"] = _refresh_docker_enrich(running_ids)
+        _docker_enrich["at"] = time.time()
+    for c in items:
+        e = _docker_enrich["data"].get(c["id"]) or {}
+        c["mem_bytes"]  = e.get("mem_bytes")
+        c["disk_bytes"] = e.get("disk_bytes")
     rank = {"crit": 0, "warn": 1, "ok": 2, "info": 3}
     items.sort(key=lambda c: (rank.get(c["status"], 9), c["name"].lower()))
     return {"available": True, "containers": items,
@@ -301,6 +379,57 @@ def collect_docker():
 def _svc_status(active):
     return {"failed": "crit", "active": "ok",
             "activating": "warn", "deactivating": "warn"}.get(active, "info")
+
+# `ss -Hlntp` row example:
+#   LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=1234,fd=3))
+# We capture the local address (column 4) and the whole `users:(...)` tail so
+# the inner `pid=N` matches survive parens/quote noise from multi-owner sockets.
+_LISTEN_RE = re.compile(r"^LISTEN\s+\S+\s+\S+\s+(?P<local>\S+)\s+\S+\s+users:\((?P<users>.*)\)\s*$")
+_LISTEN_PORT_RE = re.compile(r":(\d+)$")
+_LISTEN_PID_RE = re.compile(r"pid=(\d+)")
+# MemoryCurrent on a unit with no accounting comes back as the sentinel 2^64-1.
+_DBUS_U64_MAX = 0xFFFFFFFFFFFFFFFF
+
+def _collect_listen_ports():
+    """Snapshot of TCP/TCPv6 LISTEN sockets keyed by owning PID.
+
+    Single `ss` call per scan, used to attribute ports to systemd units via
+    their MainPID. Needs `iproute2` (provides `ss`) installed in the image;
+    pid:host + network_mode:host in compose makes the PIDs/ports the real
+    host's, not the container's."""
+    by_pid = {}
+    for args in (["ss", "-Hlntp"], ["ss", "-Hln6tp"]):
+        try:
+            r = subprocess.run(args, capture_output=True, timeout=3, text=True)
+        except Exception:
+            continue
+        for ln in (r.stdout or "").splitlines():
+            m = _LISTEN_RE.match(ln)
+            if not m:
+                continue
+            pm = _LISTEN_PORT_RE.search(m.group("local"))
+            if not pm:
+                continue
+            port = int(pm.group(1))
+            for pid in (int(x) for x in _LISTEN_PID_RE.findall(m.group("users"))):
+                by_pid.setdefault(pid, set()).add(port)
+    return {pid: sorted(ports) for pid, ports in by_pid.items()}
+
+def _dbus_get_all(conn, addr_cls, new_method_call_fn, path, interface):
+    """Wrap Properties.GetAll for a single unit object path. Returns a flat
+    {name: value} dict (variants unwrapped) or {} on any failure."""
+    props_addr = addr_cls(path, bus_name="org.freedesktop.systemd1",
+                          interface="org.freedesktop.DBus.Properties")
+    try:
+        body = conn.send_and_get_reply(new_method_call_fn(props_addr, "GetAll", "s", (interface,))).body
+    except Exception:
+        return {}
+    # jeepney decodes `v` (variant) entries as (signature, value) tuples; be
+    # defensive in case the library version returns the value directly.
+    out = {}
+    for k, v in (body[0] or {}).items():
+        out[k] = v[1] if isinstance(v, tuple) and len(v) == 2 else v
+    return out
 
 def collect_systemd():
     """Read systemd *system* units over the host D-Bus socket (pure-Python jeepney).
@@ -329,26 +458,47 @@ def collect_systemd():
             files = conn.send_and_get_reply(new_method_call(mgr, "ListUnitFiles")).body[0]
         except Exception:
             files = []
+        admin = {os.path.basename(p) for p, _state in files
+                 if p.startswith(SYSTEMD_ADMIN_DIR) and p.endswith(".service")}
+        services, running, failed = [], 0, 0
+        for name, desc, _load, active, sub, _follow, obj_path, *_rest in units:
+            if not name.endswith(".service"):
+                continue
+            running += active == "active"
+            failed  += active == "failed"
+            services.append({"name": name, "desc": desc, "active": active, "sub": sub,
+                             "admin": name in admin,
+                             "watched": name in WATCH_SERVICES or name[:-8] in WATCH_SERVICES,
+                             "status": _svc_status(active),
+                             "_obj_path": obj_path})
+        # Default view = the units you actually care about: ones you deployed, ones
+        # you asked to watch, and anything currently failing. Enrichment (mem,
+        # uptime, ports, exit code) is only done for these — touching every unit
+        # would mean ~hundreds of D-Bus round-trips on a busy host.
+        shown = [s for s in services if s["admin"] or s["watched"] or s["status"] == "crit"]
+        listen = _collect_listen_ports()
+        now_us = time.time() * 1_000_000
+        for s in shown:
+            svc_props = _dbus_get_all(conn, DBusAddress, new_method_call,
+                                      s["_obj_path"], "org.freedesktop.systemd1.Service")
+            unit_props = _dbus_get_all(conn, DBusAddress, new_method_call,
+                                       s["_obj_path"], "org.freedesktop.systemd1.Unit")
+            pid = int(svc_props.get("MainPID") or 0)
+            mem = svc_props.get("MemoryCurrent")
+            s["mem_bytes"] = int(mem) if isinstance(mem, int) and 0 < mem < _DBUS_U64_MAX else None
+            enter_us = unit_props.get("ActiveEnterTimestamp") or 0
+            s["uptime_s"] = max(0, int((now_us - enter_us) / 1_000_000)) if enter_us else 0
+            if s["status"] == "crit":
+                ex = svc_props.get("ExecMainStatus")
+                if ex is not None:
+                    s["exit_status"] = int(ex)
+            s["ports"] = listen.get(pid, []) if pid else []
+            s.pop("_obj_path", None)
     except Exception as e:
         return {"available": False, "reason": f"systemd query failed: {e}", "services": [], "summary": {}}
     finally:
         conn.close()
 
-    admin = {os.path.basename(p) for p, _state in files
-             if p.startswith(SYSTEMD_ADMIN_DIR) and p.endswith(".service")}
-    services, running, failed = [], 0, 0
-    for name, desc, _load, active, sub, *_ in units:
-        if not name.endswith(".service"):
-            continue
-        running += active == "active"
-        failed  += active == "failed"
-        services.append({"name": name, "desc": desc, "active": active, "sub": sub,
-                         "admin": name in admin,
-                         "watched": name in WATCH_SERVICES or name[:-8] in WATCH_SERVICES,
-                         "status": _svc_status(active)})
-    # Default view = the units you actually care about: ones you deployed, ones
-    # you asked to watch, and anything currently failing.
-    shown = [s for s in services if s["admin"] or s["watched"] or s["status"] == "crit"]
     rank = {"crit": 0, "warn": 1, "ok": 2, "info": 3}
     shown.sort(key=lambda s: (rank.get(s["status"], 9), s["name"].lower()))
     return {"available": True, "services": shown,

--- a/probe.py
+++ b/probe.py
@@ -9,7 +9,13 @@ Linux with Python 3.6+.
 JSON shape is a deliberate subset of the hub's own /api/health.now block so the
 UI can render local and remote with the same code paths.
 """
-import json, os, socket, subprocess, sys, time, glob
+import json, os, re, socket, subprocess, sys, time, glob
+
+# ss listen-row parser, mirrored from app.py so service ports can be attributed
+# on the remote without depending on the iproute2 *Python* bindings.
+_LISTEN_RE = re.compile(r"^LISTEN\s+\S+\s+\S+\s+(?P<local>\S+)\s+\S+\s+users:\((?P<users>.*)\)\s*$")
+_LISTEN_PORT_RE = re.compile(r":(\d+)$")
+_LISTEN_PID_RE = re.compile(r"pid=(\d+)")
 
 
 def read_loadavg():
@@ -124,6 +130,47 @@ def read_disks():
     return out
 
 
+def _collect_listen_ports():
+    """{pid: [ports]} from `ss -Hlntp` (IPv4 + IPv6). Best-effort: if `ss`
+    isn't installed on the remote, returns {} and ports just stay empty."""
+    by_pid = {}
+    for args in (["ss", "-Hlntp"], ["ss", "-Hln6tp"]):
+        try:
+            r = subprocess.run(args, capture_output=True, timeout=3)
+        except Exception:
+            continue
+        for ln in r.stdout.decode("utf-8", "replace").splitlines():
+            m = _LISTEN_RE.match(ln)
+            if not m:
+                continue
+            pm = _LISTEN_PORT_RE.search(m.group("local"))
+            if not pm:
+                continue
+            port = int(pm.group(1))
+            for pid in (int(x) for x in _LISTEN_PID_RE.findall(m.group("users"))):
+                by_pid.setdefault(pid, set()).add(port)
+    return {pid: sorted(ports) for pid, ports in by_pid.items()}
+
+
+def _systemd_props(unit):
+    """systemctl show on a single unit, parsed into a flat key=value dict."""
+    try:
+        r = subprocess.run(
+            ["systemctl", "show", "--no-pager", unit,
+             "-p", "MainPID", "-p", "MemoryCurrent",
+             "-p", "ActiveEnterTimestampMonotonic", "-p", "ExecMainStatus"],
+            capture_output=True, timeout=3,
+        )
+    except Exception:
+        return {}
+    out = {}
+    for ln in r.stdout.decode("utf-8", "replace").splitlines():
+        if "=" in ln:
+            k, v = ln.split("=", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
 def read_systemd():
     """Inventory systemd services via the CLI — no D-Bus client needed on the
     remote. Output matches the hub's HH.systemd shape so the existing Services
@@ -189,6 +236,37 @@ def read_systemd():
                 "admin": is_admin, "watched": False,
             })
 
+    # Enrich only the shown rows (admin/failed) — calling `systemctl show` per
+    # unit on the full list would be a lot of fork-exec on a busy host.
+    try:
+        boot_uptime_s = float(open("/proc/uptime").read().split()[0])
+    except Exception:
+        boot_uptime_s = 0
+    listen = _collect_listen_ports()
+    for s in services:
+        props = _systemd_props(s["name"])
+        try:
+            pid = int(props.get("MainPID") or 0)
+        except ValueError:
+            pid = 0
+        try:
+            mem = int(props.get("MemoryCurrent") or 0)
+        except ValueError:
+            mem = 0
+        # 2^64-1 is systemd's sentinel for "no accounting / unset".
+        s["mem_bytes"] = mem if 0 < mem < 0xFFFFFFFFFFFFFFFF else None
+        try:
+            enter_us = int(props.get("ActiveEnterTimestampMonotonic") or 0)
+        except ValueError:
+            enter_us = 0
+        s["uptime_s"] = max(0, int(boot_uptime_s - enter_us / 1_000_000)) if (enter_us and boot_uptime_s) else 0
+        if s["status"] == "crit":
+            try:
+                s["exit_status"] = int(props.get("ExecMainStatus", "0"))
+            except ValueError:
+                pass
+        s["ports"] = listen.get(pid, []) if pid else []
+
     # Failed first, then admin units (running first), alphabetical within.
     def k(x):
         if x["status"] == "crit": return (0, x["name"])
@@ -249,7 +327,7 @@ def main():
             "hostname": socket.gethostname(),
         },
         "at": int(time.time()),
-        "probe_version": "0.3",
+        "probe_version": "0.4",
     }
     json.dump(data, sys.stdout, separators=(",", ":"))
     sys.stdout.write("\n")

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -84,6 +84,15 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .cols{display:grid;grid-template-columns:1fr 1fr;gap:16px}@media(max-width:760px){.cols{grid-template-columns:1fr}}
 .cap{color:var(--mut);font-size:12px;margin-top:9px}.pill{font-size:11px;color:var(--mut);border:1px solid var(--bd);border-radius:5px;padding:1px 6px}
 .muted{color:var(--mut)}a{color:#58a6ff}
+/* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
+.ports{display:inline-flex;flex-wrap:wrap;gap:4px}
+.portpill{font-size:11px;padding:1px 7px;border:1px solid var(--bd);border-radius:10px;color:var(--mut);text-decoration:none;line-height:1.6;background:#0d1117;white-space:nowrap;transition:color .2s,border-color .2s,background .2s}
+.portpill:hover{border-color:var(--accent);color:var(--accent);background:#d2992211}
+/* hide non-essential columns on narrow screens so the table doesn't horiz-scroll */
+@media(max-width:1100px){
+  th[data-col="image"],td[data-col="image"],
+  th[data-col="disk"], td[data-col="disk"]  { display:none }
+}
 /* update-available badge (header) + modal */
 .upd{display:none;align-items:center;gap:5px;font-size:12px;color:var(--info);text-decoration:none;border:1px solid #58a6ff55;border-radius:20px;padding:2px 10px;background:#58a6ff11;cursor:pointer;font:inherit}
 .upd:hover{border-color:var(--info)}
@@ -266,7 +275,13 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 <section data-tab="containers" hidden>
   <div class="card"><h2>📦 Docker containers</h2>
     <div class="grid" id="ctkpis"></div>
-    <table style="margin-top:14px"><thead><tr><th>Container</th><th>State</th><th>Image</th><th>Status</th></tr></thead><tbody id="cttbl"></tbody></table>
+    <table style="margin-top:14px"><thead><tr>
+      <th>Container</th><th>State</th>
+      <th data-col="image">Image</th>
+      <th>Ports</th><th>Uptime</th><th>Memory</th>
+      <th data-col="disk">Disk</th>
+      <th>Status</th>
+    </tr></thead><tbody id="cttbl"></tbody></table>
   </div>
 </section>
 
@@ -610,12 +625,21 @@ function renderHealth(){
     {v:ds.problems||0,l:'Need attention'},{v:(ds.total||0)-(ds.running||0),l:'Stopped'},
   ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div></div>`).join('')
     : `<div class="ins info"><div class="ic">ℹ️</div><div><div class="t">Docker unavailable</div><div class="d">${esc(dk.reason||'')}</div></div></div>`;
-  document.getElementById('cttbl').innerHTML = (dk.containers||[]).map(c=>
-    `<tr><td><span class="sdot" style="background:${SC[c.status]}"></span>${esc(c.name)}</td>
+  document.getElementById('cttbl').innerHTML = (dk.containers||[]).map(c=>{
+    // Uptime now has its own column, so trim it out of the status text and
+    // keep only the trailing health/exit detail (if any).
+    const stext = c.status_text || '';
+    const upStripped = stext.replace(/^Up\s+[^()]+\s*/i,'').trim() || (stext.startsWith('Up ') ? '' : stext);
+    return `<tr><td><span class="sdot" style="background:${SC[c.status]}"></span>${esc(c.name)}</td>
      <td><span class="badge ${c.status}">${esc(c.label)}</span></td>
-     <td class="muted" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(c.image)}</td>
-     <td class="muted">${esc(c.status_text)}</td></tr>`).join('')
-    || (dk.available?'<tr><td class="muted">No containers found.</td></tr>':'');
+     <td data-col="image" class="muted" style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(c.image)}</td>
+     <td>${renderPorts(c.ports)}</td>
+     <td class="muted">${c.state==='running'?fmtUpShort(c.uptime_s):'—'}</td>
+     <td class="muted">${fmtBytes(c.mem_bytes)}</td>
+     <td data-col="disk" class="muted">${fmtBytes(c.disk_bytes)}</td>
+     <td class="muted">${upStripped?esc(upStripped):'—'}</td></tr>`;
+  }).join('')
+    || (dk.available?'<tr><td colspan="8" class="muted">No containers found.</td></tr>':'');
 
   // Services — local-only branch; when remote, renderServicesTab() drives it.
   if(CURRENT_HOST === 'local') renderServicesBlock(HH.systemd);
@@ -632,17 +656,30 @@ function renderServicesBlock(sd){
     svc.innerHTML = `<div class="ins info"><div class="ic">ℹ️</div><div><div class="t">systemd monitoring is off</div><div class="d">${esc(sd.reason||'No D-Bus / systemd detected.')}</div></div></div>`;
     return;
   }
+  // Port pills link to <host>:<port> — locally that's this page's host; per-host
+  // tab uses CURRENT_HOST (typically the registry name, e.g. "ardi").
+  const portHost = CURRENT_HOST === 'local' ? location.hostname : CURRENT_HOST;
   const kpis=[{v:ss.loaded||0,l:'Loaded services'},{v:ss.running||0,l:'Running'},
               {v:ss.failed||0,l:'Failed'},{v:ss.admin||0,l:'Your units'}]
     .map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div></div>`).join('');
-  const rows=(sd.services||[]).map(s=>
-    `<tr><td><span class="sdot" style="background:${SC[s.status]}"></span>${esc(s.name)}
+  const rows=(sd.services||[]).map(s=>{
+    // For failed units, the exit code is more useful than a zero uptime.
+    const upCell = s.status==='crit' && s.exit_status!=null
+      ? `exit ${s.exit_status}`
+      : (s.uptime_s ? fmtUpShort(s.uptime_s) : '—');
+    return `<tr><td><span class="sdot" style="background:${SC[s.status]}"></span>${esc(s.name)}
        ${s.admin?'<span class="pill">yours</span>':''}${s.watched?'<span class="pill">watched</span>':''}</td>
      <td><span class="badge ${s.status}">${esc(s.active)}${s.sub&&s.sub!==s.active?' / '+esc(s.sub):''}</span></td>
-     <td class="muted">${esc(s.desc)}</td></tr>`).join('')
-    || '<tr><td colspan="3" class="muted">No user-deployed or failed services found.</td></tr>';
+     <td>${renderPorts(s.ports, portHost)}</td>
+     <td class="muted">${upCell}</td>
+     <td class="muted">${fmtBytes(s.mem_bytes)}</td>
+     <td class="muted">${esc(s.desc)}</td></tr>`;
+  }).join('')
+    || '<tr><td colspan="6" class="muted">No user-deployed or failed services found.</td></tr>';
   svc.innerHTML=`<div class="grid">${kpis}</div>
-    <table style="margin-top:14px"><thead><tr><th>Unit</th><th>State</th><th>Description</th></tr></thead><tbody>${rows}</tbody></table>
+    <table style="margin-top:14px"><thead><tr>
+      <th>Unit</th><th>State</th><th>Ports</th><th>Uptime</th><th>Memory</th><th>Description</th>
+    </tr></thead><tbody>${rows}</tbody></table>
     <p class="cap">Showing the units you deployed (under <code>/etc/systemd/system</code>) plus any failed unit. Vendor services are hidden by default to keep the table readable.</p>`;
 }
 
@@ -1124,10 +1161,30 @@ function fmtMBshort(v){
   if(v==null) return '—';
   return v>=1024 ? (v/1024).toFixed(1)+' GB' : Math.round(v)+' MB';
 }
+// Bytes → human, for container/service memory + container disk. Distinct from
+// fmtMBshort (which is fed already-aggregated MB host stats).
+function fmtBytes(b){
+  if(b==null||b<0) return '—';
+  if(b<1024) return b+' B';
+  if(b<1048576) return (b/1024).toFixed(1)+' KB';
+  if(b<1073741824) return (b/1048576|0)+' MB';
+  return (b/1073741824).toFixed(1)+' GB';
+}
 function fmtUpShort(s){
-  if(s==null) return '—';
+  if(s==null||s<0) return '—';
+  if(s<60) return s+'s';
   const d=s/86400|0, h=s%86400/3600|0, m=s%3600/60|0;
-  return d?`${d}d ${h}h`:h?`${h}h ${m}m`:`${m}m`;
+  return d?`${d}d ${h.toString().padStart(2,'0')}h`:h?`${h}h ${m}m`:`${m}m`;
+}
+// Build a host:port pill row that opens in a new tab. host defaults to the
+// current page's hostname; pass a remote host for the per-host Services tab.
+function renderPorts(ports, host){
+  if(!ports || !ports.length) return '<span class="muted">—</span>';
+  host = host || location.hostname;
+  const proto = location.protocol || 'http:';
+  return '<span class="ports">' + ports.map(p =>
+    `<a class="portpill" href="${proto}//${esc(host)}:${p}" target="_blank" rel="noopener" title="Open ${esc(host)}:${p} in a new tab">↗${p}</a>`
+  ).join('') + '</span>';
 }
 function fmtAge(at){
   if(!at) return '—';


### PR DESCRIPTION
## Summary

Adds four new columns to the **Containers** tab (Ports, Uptime, Memory, Disk) and three to the **Services** tab (Ports, Uptime, Memory). Port chips are clickable and open `<host>:<port>` in a new tab.

### Containers tab

| Column   | Source                                                         | Cost                                |
|----------|----------------------------------------------------------------|-------------------------------------|
| Ports    | `Ports[].PublicPort` from `/containers/json` (already fetched) | free                                |
| Uptime   | Regex-parse of Docker's `Status` ("Up 14 days, 2 hours")       | free                                |
| Memory   | `/containers/{id}/stats?stream=false&one-shot=true` (parallel) | N calls every 30 s (cached)         |
| Disk     | `SizeRw` from `/containers/json?size=1`                        | one extra Docker scan every 30 s     |

`_DOCKER_ENRICH_TTL = 30` keeps the heavy bits off the 10 s `health_scan` loop. `Image` + `Disk` hide below 1100 px so the row still fits on a laptop.

### Services tab

| Column  | Source                                                | Notes                                     |
|---------|-------------------------------------------------------|-------------------------------------------|
| Ports   | `ss -Hlntp` matched on `MainPID`                      | needs `iproute2` (added to Dockerfile)    |
| Uptime  | D-Bus `Unit.ActiveEnterTimestamp`                     | `exit N` for failed units (`ExecMainStatus`) |
| Memory  | D-Bus `Service.MemoryCurrent`                         | sentinel `2^64-1` ⇒ "—"                   |

Enrichment is only done for the **shown** rows (admin/failed) — enriching every loaded unit would mean hundreds of D-Bus round-trips.

### Multi-host (probe.py)

`probe.py` learned the same fields via `ss` + `systemctl show`, so when per-host Containers/Services lands the remote rows will populate too. `probe_version` bumped 0.3 → 0.4.

## Test plan
- [ ] Containers tab on the hub: every running container shows Uptime, Memory, Disk; clicking a port chip opens `http://<hub-host>:<port>` in a new tab
- [ ] Containers with no published ports show "—" in the Ports column
- [ ] Stopped/exited containers show "—" Uptime and the full status text in the Status column
- [ ] Services tab on the hub: at least one unit (e.g. `tailscaled.service`) shows a port; memory shows a value
- [ ] Failed unit's Uptime cell shows "exit N" instead of "0s"
- [ ] Narrow viewport (<1100 px): Image + Disk columns hidden
- [ ] Per-host Services tab on a remote host shows the new columns (after probe redeploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)