### PR TITLE
fix(services/ui): cap_add SYS_PTRACE for Ports + GB,00 format for memory/disk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     # and bind the dashboard directly on the host; pid:host maps GPU PIDs->containers.
     network_mode: host
     pid: host
+    # SYS_PTRACE lets us resolve /proc/<pid>/fd/* symlinks for processes we
+    # don't own, which is what powers the Services tab's Ports column (we
+    # join /proc/net/tcp listen-inodes back to MainPID). Common in monitoring
+    # stacks; the container is already otherwise host-privileged.
+    cap_add:
+      - SYS_PTRACE
     environment:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: utility   # injects nvidia-smi into the container

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1161,14 +1161,12 @@ function fmtMBshort(v){
   if(v==null) return '—';
   return v>=1024 ? (v/1024).toFixed(1)+' GB' : Math.round(v)+' MB';
 }
-// Bytes → human, for container/service memory + container disk. Distinct from
-// fmtMBshort (which is fed already-aggregated MB host stats).
+// Bytes → "0,00 GB" (European decimal). One unit across the Containers and
+// Services tables so values line up vertically and small footprints stay
+// comparable to the big ones at a glance.
 function fmtBytes(b){
   if(b==null||b<0) return '—';
-  if(b<1024) return b+' B';
-  if(b<1048576) return (b/1024).toFixed(1)+' KB';
-  if(b<1073741824) return (b/1048576|0)+' MB';
-  return (b/1073741824).toFixed(1)+' GB';
+  return (b/1073741824).toFixed(2).replace('.', ',') + ' GB';
 }
 function fmtUpShort(s){
   if(s==null||s<0) return '—';


### PR DESCRIPTION
## Summary
- `cap_add: [SYS_PTRACE]` in `docker-compose.yml` so `/proc/<pid>/fd/*` symlinks can be resolved for processes the container does not own — without it, the Services Ports column stays empty.
- Memory + Disk now render uniformly as `0,00 GB` across the Containers and Services tabs (European decimal). One unit so values line up vertically and small footprints stay comparable to large ones.

## Test plan
- [ ] ardi:9801 — at least one service shows a port chip
- [ ] All memory/disk cells render as `X,XX GB`
- [ ] Containers tab still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)