### PR TITLE
fix(compose): apparmor=unconfined so CAP_SYS_PTRACE actually takes effect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
     # stacks; the container is already otherwise host-privileged.
     cap_add:
       - SYS_PTRACE
+    # Docker's default AppArmor profile (`docker-default`) denies ptrace
+    # access even when CAP_SYS_PTRACE is granted, blocking the readlink()s
+    # above. Opting this container out of AppArmor lets the cap actually
+    # take effect.
+    security_opt:
+      - apparmor=unconfined
     environment:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: utility   # injects nvidia-smi into the container


### PR DESCRIPTION
Docker default AppArmor profile blocks ptrace even with the cap. Verified on ardi that adding apparmor=unconfined unblocks /proc/<pid>/fd readlink. Ports column on Services tab can now populate.