### PR TITLE
Funnel: above-the-fold GitHub/star CTA, v0.9.0 callout, startup banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
 [![website](https://img.shields.io/badge/docs-sikamikanikobg.github.io%2Fhomelab--monitor-d29922?logo=readthedocs&logoColor=white)](https://sikamikanikobg.github.io/homelab-monitor/)
-![version](https://img.shields.io/badge/version-0.8.0-blue)
+![version](https://img.shields.io/badge/version-0.9.0-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)
 [![last commit](https://img.shields.io/github/last-commit/SikamikanikoBG/homelab-monitor?color=informational)](https://github.com/SikamikanikoBG/homelab-monitor/commits/main)
+
+> 🆕 **v0.9.0** — the **Containers** and **Services** tabs now show uptime, memory, disk and clickable ports per host. [Release notes →](https://github.com/SikamikanikoBG/homelab-monitor/releases)
+>
+> 🛰️ **Source, issues and roadmap live on [GitHub](https://github.com/SikamikanikoBG/homelab-monitor).** If HomeLab Monitor saves you a browser tab, a ⭐ there genuinely helps other home-labbers find it.
 
 A small, friendly dashboard for a self-hosted home lab. One container gives you a
 single page that answers the everyday questions: **is the GPU busy and which model

--- a/app.py
+++ b/app.py
@@ -1995,4 +1995,11 @@ threading.Thread(target=collector, daemon=True).start()
 threading.Thread(target=host_poller, daemon=True).start()
 
 if __name__ == "__main__":
+    print(
+        f"\n  HomeLab Monitor v{VERSION}\n"
+        f"      Open  ->  http://localhost:{PORT}   (or http://<this-host-ip>:{PORT} over your LAN/VPN)\n"
+        f"      Like it? A star on GitHub helps other home-labbers find it:\n"
+        f"      https://github.com/SikamikanikoBG/homelab-monitor\n",
+        flush=True,
+    )
     app.run(host="0.0.0.0", port=PORT, threaded=True)


### PR DESCRIPTION
Acts on the 2026-05-31 intelligence digest's funnel suggestions to fix the Docker Hub -> GitHub drop-off (pulls:stars was ~300:5).

## Changes
- **README (also = Docker Hub overview, auto-synced):** above-the-fold blockquote linking to GitHub for source/issues/roadmap + a soft star nudge, and a **v0.9.0** release callout.
- **README:** bump stale version badge `0.8.0 -> 0.9.0` to match `app.py`.
- **app.py:** humble startup banner (URL + star link) on local `python app.py`, mirroring the existing in-dashboard star CTA.

## Already satisfied (no change needed)
- `docs/demo.gif` is already embedded right after the elevator pitch, before install.
- The dashboard already has a full in-product star nudge (gold ★ button + persisted state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)