### PR TITLE
fix(probe): report hottest thermal zone, not acpitz (v0.9.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
 [![website](https://img.shields.io/badge/docs-sikamikanikobg.github.io%2Fhomelab--monitor-d29922?logo=readthedocs&logoColor=white)](https://sikamikanikobg.github.io/homelab-monitor/)
-![version](https://img.shields.io/badge/version-0.9.0-blue)
+![version](https://img.shields.io/badge/version-0.9.1-blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.9.0"
+VERSION      = "0.9.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/probe.py
+++ b/probe.py
@@ -77,19 +77,26 @@ def read_cpu():
 
 
 def read_temp():
-    """First plausible CPU temp from /sys/class/thermal. Coarse, but matches
-    what the hub itself reports for its own box."""
+    """Hottest plausible CPU temp from /sys/class/thermal. Coarse, but matches
+    what the hub itself reports for its own box (app.py takes the max zone too).
+
+    Taking the *max* — not the first zone — matters on boxes that expose an
+    `acpitz` board/ambient sensor alongside the real `x86_pkg_temp`/`coretemp`
+    die sensor. `acpitz` sorts first (thermal_zone0) and reads ~ambient, so the
+    old first-match logic under-reported the CPU by 20-30 °C (e.g. a Celeron
+    reading 28 °C off acpitz while its package sat at 59 °C)."""
+    best = None
     try:
-        for z in sorted(glob.glob("/sys/class/thermal/thermal_zone*/temp")):
+        for z in glob.glob("/sys/class/thermal/thermal_zone*/temp"):
             try:
                 t = int(open(z).read().strip()) / 1000.0
-                if 10 < t < 130:
-                    return {"ctemp": round(t, 1)}
+                if 10 < t < 130 and (best is None or t > best):
+                    best = t
             except Exception:
                 continue
     except Exception:
         pass
-    return {}
+    return {"ctemp": round(best, 1)} if best is not None else {}
 
 
 def read_disks():
@@ -327,7 +334,7 @@ def main():
             "hostname": socket.gethostname(),
         },
         "at": int(time.time()),
-        "probe_version": "0.4",
+        "probe_version": "0.5",
     }
     json.dump(data, sys.stdout, separators=(",", ":"))
     sys.stdout.write("\n")


### PR DESCRIPTION
## Problem
Remote hosts that expose an `acpitz` board/ambient sensor alongside the real `x86_pkg_temp`/`coretemp` die sensor were under-reporting CPU temperature by 20–30 °C.

`probe.py`'s `read_temp()` returned the **first** sorted thermal zone — `thermal_zone0` is almost always `acpitz` (~ambient) — instead of the actual CPU package sensor.

**Real-world:** `cloudy` (Celeron 1037U) showed **27.8 °C** in the fleet view while its package (`x86_pkg_temp`) was actually **~59 °C**. Made it look 20 °C cooler than `ardi` sitting right next to it.

## Fix
`read_temp()` now takes the **max plausible zone** (10–130 °C guard retained), matching how the hub already reads its own box (`app.py` uses `max()` across zones). The docstring claimed local/remote parity that the code didn't deliver — now it does.

**Verified** by piping the patched probe to `cloudy` hub-style (`ssh host python3 -`): `ctemp` now reports ~56 °C instead of 27.8 °C.

## Version
- `VERSION` 0.9.0 → **0.9.1**
- `probe_version` 0.4 → **0.5**

🤖 Generated with [Claude Code](https://claude.com/claude-code)