### PR TITLE
UI rev6: Portainer-style layout + dark/light/system theme + AI Models timeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Boot it and hit /healthz
         run: |
-          docker run -d --name hlm -e PORT=9800 -p 9800:9800 homelab-monitor:ci
+          # /data is a compose volume in real deploys; for a bare run point the
+          # SQLite DB + SSH dir at writable paths so the app can boot headless.
+          docker run -d --name hlm -e PORT=9800 -e DB_PATH=/tmp/gpu.db -e SSH_DIR=/tmp/.ssh -p 9800:9800 homelab-monitor:ci
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:9800/healthz >/dev/null; then
               echo "healthz OK after ${i}s"; docker rm -f hlm; exit 0

--- a/design/migration-parity.md
+++ b/design/migration-parity.md
@@ -1,0 +1,42 @@
+# UI migration parity checklist — current `dashboard.html` → rev 6 (Portainer-style)
+
+Contract for the migration: **every row in the "Current" column must still work after migration.**
+Strategy: keep all JS renderers + element IDs + API calls; replace only the **shell, CSS, nav, and theming**, and add the **AI Models timeline/expand** + **dark/light/system** + **density**.
+
+Legend — Action: 🟢 keep as-is · 🔵 restyle (same DOM/IDs) · 🟠 restructure (new shell, same renderer) · 🆕 new.
+
+| # | Area | Current dashboard | rev 6 target | Action | Risk / note |
+|---|------|-------------------|--------------|--------|-------------|
+| 1 | **App shell** | `header` (title/ver/update/star/live) + sticky `.topnav` (hostbar + tab nav + gear) | Left **sidebar** (brand, grouped nav, footer) + content **top bar** | 🟠 | Keep all `<section data-tab>` blocks & inner IDs untouched |
+| 2 | **Navigation** | Top tab row + **gear drawer** for settings (`#nav`/`#subnav`, `setSettingsMode`) | Sidebar groups **Monitoring / Settings** (both always visible) | 🟠 | `showTab()` stays the source of truth; drawer logic collapses to a no-op |
+| 3 | **Nav attention dots** | `#ndot-<key>` dot on tab when crit/warn (`renderHealth`) | **count badge** on sidebar row (red/amber) | 🔵 | Same data (`HH.overview[].status`), new element |
+| 4 | **Host switcher** | `.hostbar` pills + `+ Add host` (`renderHostBar`) | Desktop: pills in top bar · Mobile: scrollable strip | 🟠 | Reuse `renderHostBar`, retarget container; `setHost`/`CURRENT_HOST` unchanged |
+| 5 | **Range + auto-refresh** | `.controls` card (1h/6h/24h/7d/30d/all + auto-refresh) | Segmented range in top bar; auto-refresh kept | 🔵 | Keep `#auto`, `.rb[data-r]`, 15 s poll loop |
+| 6 | **Theme** | dark only (hardcoded `:root`) | **dark / light / system** + toggle | 🆕 | Tokenize; charts read hardcoded colors → see #20 |
+| 7 | **Density** | none | comfortable default + **Compact** toggle | 🆕 | `.dense` class on root |
+| 8 | **Overview = Fleet** | `.fleet-tbl` (Host/Status/CPU/RAM/GPU/Load/Uptime/Temp/Disks), row-click → focus host | same table, restyled (badges, tabular nums, toolbar) | 🔵 | `renderFleet()` kept; **must not** become single-host KPIs |
+| 9 | **GPU** | now-KPIs + VRAM bar + now table + GPU-services summary + **stacked VRAM chart w/ capacity + pressure bands + OOM ▼** + util/power/temp dual chart | same, restyled | 🔵 | Charts (`buildCharts`) kept verbatim — the AI-eng's must-keep |
+| 10 | **AI Models** | loaded-now table (service/model/vram) + range summary (model/server/peak) | **+ expandable rows** (details) **+ per-model VRAM timeline** | 🆕🔵 | Timeline from `D.services[service]`; events from `D.events`; details from `D.summary`/`model_summary` |
+| 11 | **Containers** | KPIs + table (name/state badge/image/ports/uptime/mem/disk/status) | table + toolbar + flat badges | 🔵 | `renderHealth` container block kept; restyle `.badge`,`.sdot` |
+| 12 | **Services** | KPIs + table (unit/state/ports/uptime/mem/desc), `yours`/`watched` pills, port pills | table + toolbar + badges | 🔵 | `renderServicesBlock` kept |
+| 13 | **Host** | KPIs (CPU/RAM/Load/Uptime/temp) + disk bars + CPU/RAM/load chart | KPIs + disk table + chart | 🔵 | `renderHostTab` + local path kept |
+| 14 | **Hosts (settings)** | pubkey copy/show-cmd, add form, **Scan LAN**, host rows: Test/Remove/**Edit inline**, capability checklist, remedy **copy / Run-on-remote (sudo panel)**, LAN suggestions | same, restyled in Settings group | 🔵 | Large surface — **do not drop**: `loadHosts`,`testHost`,`scanLAN`,`openRunPanel`,`beginEditHost`,`renderChecks` |
+| 15 | **Alerts (settings)** | enable, Discord webhook (secret-masked), ntfy topic/server, min severity, disk %, Save/Test | same, restyled | 🔵 | `loadAlerts`/`saveAlerts`/`testAlerts` kept |
+| 16 | **Update modal** | badge → modal w/ release notes (GitHub markdown), copy cmd, link | same, restyled | 🔵 | `openUpdateModal`, `/api/markdown` kept |
+| 17 | **GitHub star** | pill + count fetch + pre/post CTA + `hl_starred` localStorage | one place (sidebar footer) + count + CTA | 🟠 | Trim from header to footer; keep star-state logic |
+| 18 | **Status semantics** | color + dot; `--accent`==`--warn`==#d29922 | **neutral selection; amber=warn only**; badge = square+word; counts not bare dots | 🔵 | Unanimous fix; colorblind-safe |
+| 19 | **Multi-host scope** | local-only notices on gpu/models/containers when remote host selected; host-scoped host/services | unchanged behavior | 🟢 | `renderLocalOnlyNotice` etc. kept |
+| 20 | **Charts theming** | Chart.js colors hardcoded (`#21262d` grid, `#8b949e` ticks, `#e6edf3` legend) | read theme tokens so light mode looks right | 🔵 | Low risk if deferred: charts stay dark-tuned until parametrized |
+| 21 | **Polling / routing** | 15 s `setInterval`, `#hash` routing, `hashchange` | unchanged | 🟢 | Keep wire-up block |
+| 22 | **APIs consumed** | `/api/data /health /fleet /settings /notify/test /hub/pubkey /hosts(.../test/run) /host_data /lan/scan /markdown` + GitHub star | unchanged | 🟢 | **No backend changes** — pure front-end migration |
+
+## AI Models enhancement (#10) — proposed detail
+Expandable row per model; expanded panel shows (all from existing data):
+- **VRAM timeline** — sparkline of `D.services[service]` over the selected range, with OOM `▼` markers from `D.events`.
+- **Server / backend** (ollama, vLLM, TGI, llama.cpp, SD, ComfyUI), **GPU placement** where known.
+- **Peak / Avg VRAM** (`D.summary`), **% time resident** (`summary.present`), **current VRAM** (`n.models[].vram`).
+- Status badge: Loaded / Idle.
+
+## Out of scope (explicit, so it's not "forgotten")
+- No backend/`app.py`/`probe.py` changes. No new API. No multi-GPU backend (mock shows it; real data is single-GPU today — keep current behavior, leave room in layout).
+- Chart light-theme polish (#20) may land in a follow-up if time-boxed.

--- a/design/nav-mockups.html
+++ b/design/nav-mockups.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HomeLab Monitor — layout (rev 6)</title>
+<style>
+:root{--mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code","Cascadia Mono",Menlo,Consolas,monospace}
+:root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
+--crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;--sb:#0b0f15;--canvas:#070a0e;--inset:#0d1117;--hover:#161b22;
+--sel:#1c232e;--okbg:#3fb95018;--warnbg:#d2992218;--critbg:#f8514918}
+[data-theme="light"]{--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;--free:#eaeef2;
+--crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;--sb:#f6f8fa;--canvas:#eaeef2;--inset:#f6f8fa;--hover:#eef1f4;
+--sel:#e7ebf0;--okbg:#1a7f3714;--warnbg:#9a670014;--critbg:#cf222e14}
+*{box-sizing:border-box}
+body{margin:0;background:var(--canvas);color:var(--tx);font:14.5px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+.page{max-width:1340px;margin:0 auto;padding:24px 20px 70px}
+.lead{display:flex;align-items:flex-start;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+.lead h1{font-size:20px;margin:0 0 4px}.lead p{color:var(--mut);margin:0;font-size:13px;max-width:780px}
+.lead b{color:var(--tx)}
+.themeswitch{display:flex;align-items:center;border:1px solid var(--bd);border-radius:6px;overflow:hidden;flex:none}
+.themeswitch .tlab{color:var(--mut);font-size:10px;text-transform:uppercase;letter-spacing:.05em;padding:0 10px;border-right:1px solid var(--bd)}
+.themeswitch button{border:0;border-right:1px solid var(--bd);background:var(--card);color:var(--mut);font:inherit;font-size:12px;padding:5px 12px;cursor:pointer}
+.themeswitch button:last-child{border-right:0}
+.themeswitch button.on{background:var(--hover);color:var(--tx);font-weight:600}
+.legend{display:flex;gap:14px;flex-wrap:wrap;margin:12px 0 22px;font-size:12px;color:var(--mut)}
+.legend b{color:var(--accent);font-weight:600}
+.cap{font-size:12px;text-transform:uppercase;letter-spacing:.06em;color:var(--mut);margin:0 0 9px}
+.cap b{color:var(--tx)}
+.frames{display:flex;gap:30px;align-items:flex-start;flex-wrap:wrap}
+
+/* ── GitHub star ─────────────────────────────────────────────────────────── */
+.ghstar{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--tx);text-decoration:none;border:1px solid var(--bd);border-radius:5px;padding:3px 10px;background:var(--inset);cursor:pointer}
+.ghstar:hover{border-color:var(--mut);background:var(--hover)}
+.ghstar svg{width:13px;height:13px;fill:currentColor;flex:none}
+.ghstar .cnt{color:var(--mut);font-family:var(--mono)}
+.ghstar.starred{border-color:var(--bd);color:var(--mut)}.ghstar.starred svg{fill:var(--accent)}
+
+/* ── status badges (text + square; colour is never the only channel) ─────── */
+.st{width:8px;height:8px;border-radius:2px;flex:none;background:var(--mut)}
+.st.ok{background:var(--ok)}.st.warn{background:var(--warn)}.st.crit{background:var(--crit)}
+.badge{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;padding:2px 8px;border-radius:4px;color:var(--mut);background:var(--inset);border:1px solid var(--bd)}
+.badge .st{width:7px;height:7px}
+.badge.ok{color:var(--ok);background:var(--okbg);border-color:transparent}
+.badge.warn{color:var(--warn);background:var(--warnbg);border-color:transparent}
+.badge.crit{color:var(--crit);background:var(--critbg);border-color:transparent}
+
+/* ── DESKTOP shell: grouped sidebar + content top bar + tables ───────────── */
+.desk{width:900px;max-width:100%;height:640px;border:1px solid var(--bd);border-radius:10px;overflow:hidden;
+display:grid;grid-template-columns:212px 1fr;background:var(--bg);box-shadow:0 16px 46px #0009}
+.side{background:var(--sb);border-right:1px solid var(--bd);display:flex;flex-direction:column;min-width:0}
+.brand{display:flex;align-items:center;gap:9px;padding:14px 15px 12px;border-bottom:1px solid var(--bd)}
+.brand .logo{font-size:17px}.brand .nm{font-size:13.5px;font-weight:600;white-space:nowrap;overflow:hidden}
+.brand .ver{margin-left:auto;color:var(--mut);font-size:10px;font-family:var(--mono);border:1px solid var(--bd);border-radius:4px;padding:0 5px}
+.navlist{flex:1 1 auto;overflow:auto;padding:8px 8px}
+.group{color:var(--mut);font-size:9.5px;text-transform:uppercase;letter-spacing:.08em;padding:12px 9px 5px;font-weight:600}
+.nrow{display:flex;align-items:center;gap:9px;width:100%;border:0;background:none;color:var(--mut);font:inherit;font-size:13px;
+text-align:left;padding:8px 10px;border-radius:6px;cursor:pointer}
+.nrow:hover{background:var(--hover);color:var(--tx)}
+.nrow.on{background:var(--sel);color:var(--tx);font-weight:600}     /* neutral selection — no amber, no edge bar */
+.nrow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;font-weight:700;padding:0 6px;border-radius:9px;min-width:18px;text-align:center}
+.nrow .cnt.warn{color:var(--warn);background:var(--warnbg)}
+.nrow .cnt.crit{color:var(--crit);background:var(--critbg)}
+.foot{border-top:1px solid var(--bd);padding:9px 10px;display:flex;flex-direction:column;gap:8px}
+.footrow{display:flex;align-items:center;gap:8px;justify-content:space-between}
+.thtoggle{display:inline-flex;align-items:center;gap:6px;border:0;background:none;color:var(--mut);font:inherit;font-size:12px;cursor:pointer;padding:3px 2px}
+.thtoggle:hover{color:var(--tx)}
+
+.main{display:flex;flex-direction:column;min-width:0}
+/* content top bar = environment (host) selector + range + status */
+.topbar{display:flex;align-items:center;gap:8px;padding:9px 16px;border-bottom:1px solid var(--bd);background:var(--bg);flex-wrap:wrap}
+.envlbl{color:var(--mut);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+.hpill{background:var(--inset);border:1px solid var(--bd);color:var(--tx);border-radius:5px;padding:3px 9px 3px 7px;cursor:pointer;font:inherit;font-family:var(--mono);font-size:12px;display:inline-flex;align-items:center;gap:6px}
+.hpill .st{width:7px;height:7px}
+.hpill.on{border-color:var(--mut);background:var(--sel)}
+.range{display:flex;margin-left:6px;border:1px solid var(--bd);border-radius:5px;overflow:hidden}
+.range button{background:var(--inset);border:0;border-right:1px solid var(--bd);color:var(--mut);font:inherit;font-family:var(--mono);font-size:11.5px;padding:3px 9px;cursor:pointer}
+.range button:last-child{border-right:0}.range button.on{background:var(--sel);color:var(--tx)}
+.spacer{margin-left:auto}
+.upd{background:var(--inset);border:1px solid var(--bd);color:var(--accent);border-radius:5px;font:inherit;font-size:11.5px;padding:2px 9px;cursor:pointer}
+.upd:hover{border-color:var(--accent)}
+.live{display:flex;align-items:center;gap:6px;color:var(--mut);font-size:12px;font-family:var(--mono)}
+.live .st{width:8px;height:8px}
+.content{flex:1 1 auto;overflow:auto;padding:14px 16px}
+.ptitle{font-size:16px;font-weight:700;margin:0}.psub{color:var(--mut);font-size:12.5px;margin:2px 0 0}
+.phead{display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:12px}
+
+/* table toolbar: search + filter + count + density */
+.tbar{display:flex;align-items:center;gap:8px;margin-bottom:9px;flex-wrap:wrap}
+.search{display:flex;align-items:center;gap:6px;border:1px solid var(--bd);border-radius:6px;background:var(--inset);padding:4px 9px;min-width:170px}
+.search input{border:0;background:none;color:var(--tx);font:inherit;font-size:12.5px;outline:none;width:100%}
+.search .ic{color:var(--mut);font-size:12px}
+.tbtn{border:1px solid var(--bd);background:var(--inset);color:var(--mut);font:inherit;font-size:12px;border-radius:6px;padding:4px 10px;cursor:pointer}
+.tbtn:hover{color:var(--tx);border-color:var(--mut)}
+.tbtn.on{color:var(--tx);background:var(--sel)}
+.tcount{margin-left:auto;color:var(--mut);font-size:11.5px;font-family:var(--mono)}
+
+/* cards & metrics */
+.card{background:var(--card);border:1px solid var(--bd);border-radius:7px;margin:0 0 12px;overflow:hidden}
+.card .hd{display:flex;align-items:center;gap:8px;padding:9px 12px;border-bottom:1px solid var(--bd);background:var(--sb)}
+.card .hd .lbl{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
+.card .hd .meta{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--mut)}
+.card .bd{padding:12px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px}
+.kpi{position:relative;background:var(--card);border:1px solid var(--bd);border-radius:7px;padding:10px 12px}
+.kpi .st{position:absolute;top:11px;right:11px}
+.kpi .v{font-family:var(--mono);font-size:20px;font-weight:600;font-variant-numeric:tabular-nums;line-height:1.1}
+.kpi .v.warn{color:var(--warn)}.kpi .v.crit{color:var(--crit)}
+.kpi .v u{font-style:normal;font-size:12px;color:var(--mut);font-weight:500;margin-left:1px}
+.kpi .l{color:var(--mut);font-size:10.5px;margin-top:3px}
+.bar{height:6px;border-radius:3px;background:var(--free);overflow:hidden;margin-top:9px}.bar>i{display:block;height:100%}
+
+/* data table — the workhorse */
+.tbl{width:100%;border-collapse:collapse;font-size:12.5px;background:var(--card);border:1px solid var(--bd);border-radius:7px;overflow:hidden}
+.tbl th{text-align:left;font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--mut);font-weight:600;padding:8px 12px;border-bottom:1px solid var(--bd);background:var(--sb);cursor:pointer;white-space:nowrap;user-select:none}
+.tbl th .car{opacity:.5;font-size:9px}.tbl th.sort{color:var(--tx)}
+.tbl th.num,.tbl td.num{text-align:right}
+.tbl td{padding:8px 12px;border-bottom:1px solid var(--bd);color:var(--tx)}
+.tbl tr:last-child td{border-bottom:0}
+.tbl tbody tr{cursor:pointer}.tbl tbody tr:hover td{background:var(--hover)}
+.tbl td.num{font-family:var(--mono);font-variant-numeric:tabular-nums;color:var(--mut)}
+.tbl td.name{font-family:var(--mono);color:var(--tx)}
+.dense .tbl th{padding:5px 12px}.dense .tbl td{padding:5px 12px}.dense .nrow{padding:6px 10px}.dense .content{padding:11px 16px}
+
+/* GPU VRAM chart (stacked, capacity line, OOM marker) */
+.vram{width:100%;height:120px;display:block}
+
+/* ── MOBILE ──────────────────────────────────────────────────────────────── */
+.phone{width:332px;height:700px;border:1px solid var(--bd);border-radius:28px;overflow:hidden;background:var(--bg);box-shadow:0 16px 46px #0009;display:flex;flex-direction:column;position:relative}
+.appbar{display:flex;align-items:center;gap:8px;padding:11px 14px 9px;border-bottom:1px solid var(--bd);background:var(--sb)}
+.appbar .logo{font-size:15px}.appbar .nm{font-size:13.5px;font-weight:600}
+.appbar .mtools{margin-left:auto;display:flex;gap:7px}
+.hoststrip{display:flex;align-items:center;gap:6px;overflow-x:auto;padding:7px 12px;border-bottom:1px solid var(--bd);background:var(--sb);scrollbar-width:none}
+.hoststrip::-webkit-scrollbar{display:none}
+.hoststrip .hlabel{color:var(--mut);font-size:9px;text-transform:uppercase;letter-spacing:.05em;flex:none}
+.hoststrip .hpill{flex:none}.hoststrip .hpill.add{border-style:dashed;color:var(--mut)}
+.updstrip{display:flex;align-items:center;justify-content:space-between;gap:7px;padding:6px 13px;background:var(--warnbg);border-bottom:1px solid var(--bd);font-size:11.5px;color:var(--accent)}
+.updstrip b{cursor:pointer}.updstrip .x{cursor:pointer;color:var(--mut)}
+.mscroll{flex:1 1 auto;overflow:auto;padding:12px 13px}
+.mscroll .tbl{display:block;overflow-x:auto;white-space:nowrap}
+.mtitle{font-size:15px;font-weight:700;margin:0 0 1px}.msub{color:var(--mut);font-size:12px;margin:0 0 12px}
+.botnav{display:flex;border-top:1px solid var(--bd);background:var(--sb)}
+.botnav button{flex:1;border:0;background:none;color:var(--mut);font:inherit;font-size:11px;padding:10px 2px;cursor:pointer;position:relative}
+.botnav button.on{color:var(--tx);font-weight:600}
+.botnav button.on::before{content:"";position:absolute;top:0;left:24%;right:24%;height:2px;background:var(--tx);border-radius:0 0 3px 3px}
+.botnav .cnt{position:absolute;top:5px;right:calc(50% - 26px);font-family:var(--mono);font-size:9px;font-weight:700;padding:0 4px;border-radius:8px}
+.botnav .cnt.warn{color:var(--warn);background:var(--warnbg)}.botnav .cnt.crit{color:var(--crit);background:var(--critbg)}
+.sheet{position:absolute;inset:0;background:#000a;display:none;align-items:flex-end;z-index:9}.sheet.open{display:flex}
+.sheetcard{width:100%;background:var(--card);border-top:1px solid var(--bd);border-radius:16px 16px 0 0;padding:8px 12px 16px;animation:up .18s ease}
+@keyframes up{from{transform:translateY(40px);opacity:.4}to{transform:none;opacity:1}}
+.sheetcard .handle{width:36px;height:4px;border-radius:3px;background:var(--bd);margin:6px auto 10px}
+.sgroup{color:var(--mut);font-size:9.5px;text-transform:uppercase;letter-spacing:.06em;padding:10px 4px 4px;font-weight:600}
+.srow{display:flex;align-items:center;gap:11px;width:100%;border:0;background:none;color:var(--tx);font:inherit;font-size:14px;text-align:left;padding:10px 6px;border-radius:7px;cursor:pointer}
+.srow:hover{background:var(--hover)}.srow .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;font-weight:700;padding:0 6px;border-radius:9px}
+.srow .cnt.crit{color:var(--crit);background:var(--critbg)}
+.ghblock{margin-top:12px;padding:11px;border:1px solid var(--bd);background:var(--inset);border-radius:7px;display:flex;align-items:center;gap:10px;font-size:12px;color:var(--mut)}
+.note{margin-top:10px;font-size:11.5px;color:var(--mut);max-width:340px}.note b{color:var(--accent);font-weight:600}
+</style></head>
+<body>
+<div class="page">
+  <div class="lead">
+    <div style="flex:1 1 auto;min-width:280px">
+      <h1>🛰️ HomeLab Monitor — layout <span style="font-size:12px;color:var(--mut)">· rev 6 (converged)</span></h1>
+      <p><b>From the 4-persona review:</b> grouped sidebar + content top bar + searchable/sortable <b>data tables</b> with flat status badges.
+      <b>Overview is the all-hosts fleet table</b> again. Selection is <b>neutral</b> — amber means warning only. Severity shows as a <b>count badge</b>, not a bare dot. GPU keeps a real <b>VRAM + OOM</b> chart.</p>
+    </div>
+    <div class="themeswitch" id="themeswitch">
+      <span class="tlab">Theme</span>
+      <button data-th="dark" class="on">Dark</button><button data-th="light">Light</button><button data-th="system">System</button>
+    </div>
+  </div>
+  <div class="legend">
+    <span><b>Neutral</b> selection · amber = warning · red = critical</span>
+    <span><b>Toolbar</b> search · sort · density on every table</span>
+    <span><b>Overview</b> = fleet table (all hosts)</span>
+    <span><b>Sidebar counts</b> = open issues per section</span>
+  </div>
+
+  <div class="frames">
+    <!-- DESKTOP -->
+    <div>
+      <p class="cap">Desktop · <b>grouped sidebar + table console</b></p>
+      <div class="desk" id="desk">
+        <aside class="side">
+          <div class="brand"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span><span class="ver">v0.9</span></div>
+          <div class="navlist" id="dnav">
+            <div class="group">Monitoring</div>
+            <button class="nrow on" data-t="overview">Overview</button>
+            <button class="nrow" data-t="gpu">GPU</button>
+            <button class="nrow" data-t="models">AI Models</button>
+            <button class="nrow" data-t="containers">Containers<span class="cnt crit">1</span></button>
+            <button class="nrow" data-t="services">Services</button>
+            <button class="nrow" data-t="host">Host</button>
+            <div class="group">Settings</div>
+            <button class="nrow" data-t="hosts">Hosts</button>
+            <button class="nrow" data-t="alerts">Alerts<span class="cnt crit">1</span></button>
+          </div>
+          <div class="foot">
+            <a class="ghstar" id="dghstar"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span id="dghlabel">Star</span> <span class="cnt">128</span></a>
+            <div class="footrow">
+              <button class="thtoggle inproduct-th"><span class="thicon">☾</span><span class="thlabel">Dark</span></button>
+              <button class="thtoggle density-th" id="densityBtn">▤ Compact</button>
+            </div>
+          </div>
+        </aside>
+        <div class="main">
+          <div class="topbar">
+            <span class="envlbl">Host</span>
+            <button class="hpill on"><span class="st ok"></span>ardi</button>
+            <button class="hpill"><span class="st ok"></span>oldie</button>
+            <button class="hpill"><span class="st warn"></span>nas</button>
+            <div class="range"><button>1h</button><button class="on">6h</button><button>24h</button><button>7d</button></div>
+            <span class="spacer"></span>
+            <button class="upd">⬆ v0.9</button>
+            <span class="live"><span class="st ok"></span>3s</span>
+          </div>
+          <div class="content" id="dcontent"></div>
+        </div>
+      </div>
+      <p class="note"><b>Why this converged:</b> the sidebar groups Monitoring vs Settings; the content top bar folds host + range + status into one strip (no double chrome). Every list is a table with a search/sort/<b>Compact</b> toolbar (try Compact, and the GPU/Containers tabs).</p>
+    </div>
+
+    <!-- MOBILE -->
+    <div>
+      <p class="cap">Mobile · <b>fleet-first, AI Models promoted</b></p>
+      <div class="phone">
+        <div class="appbar">
+          <span class="logo">🛰️</span><span class="nm">HomeLab</span>
+          <div class="mtools"><button class="thtoggle inproduct-th"><span class="thicon">☾</span></button></div>
+        </div>
+        <div class="hoststrip" id="mhosts">
+          <span class="hlabel">Host</span>
+          <button class="hpill on"><span class="st ok"></span>ardi</button>
+          <button class="hpill"><span class="st ok"></span>oldie</button>
+          <button class="hpill"><span class="st warn"></span>nas</button>
+          <button class="hpill"><span class="st ok"></span>jellyfin</button>
+          <button class="hpill add">+ add</button>
+        </div>
+        <div class="updstrip" id="mupd"><b>⬆ v0.9 available — what's new</b><span class="x">✕</span></div>
+        <div class="mscroll" id="mcontent"></div>
+        <nav class="botnav" id="mnav">
+          <button class="on" data-t="overview">Overview</button>
+          <button data-t="gpu">GPU</button>
+          <button data-t="models">Models</button>
+          <button data-t="containers">Containers<span class="cnt crit">1</span></button>
+          <button data-t="__more">More</button>
+        </nav>
+        <div class="sheet" id="sheet">
+          <div class="sheetcard">
+            <div class="handle"></div>
+            <div class="sgroup">Monitoring</div>
+            <button class="srow" data-t="services">Services</button>
+            <button class="srow" data-t="host">Host</button>
+            <div class="sgroup">Settings</div>
+            <button class="srow" data-t="hosts">Hosts</button>
+            <button class="srow" data-t="alerts">Alerts<span class="cnt crit">1</span></button>
+            <button class="srow density-th"><span>Compact density</span></button>
+            <div class="ghblock">
+              <a class="ghstar" id="sghstar"><svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>Star <span class="cnt">128</span></a>
+              <span>if it helps, a ⭐ helps me back</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="note"><b>Mobile fixes:</b> <b>AI Models promoted</b> into the bottom bar (Services moved to More). Update strip is dismissible. Star CTA lives only in More now. Tables scroll sideways. Tap <b>More</b>.</p>
+    </div>
+  </div>
+</div>
+
+<script>
+const META={
+  overview:{t:'Overview',s:'All hosts — fleet status at a glance'},
+  gpu:{t:'GPU',s:'NVIDIA GPUs on ardi — util, VRAM, temp, OOM events'},
+  models:{t:'AI Models',s:'Local model servers (ollama · open-webui)'},
+  containers:{t:'Containers',s:'Docker containers on ardi'},
+  services:{t:'Services',s:'systemd units being watched'},
+  host:{t:'Host',s:'CPU, memory, disk & network for ardi'},
+  hosts:{t:'Hosts',s:'Fleet registry — boxes polled over SSH'},
+  alerts:{t:'Alerts',s:'Thresholds & notification channels'},
+};
+function th(label,opts){opts=opts||{};return `<th class="${opts.num?'num':''} ${opts.sort?'sort':''}">${label}${opts.sort?' <span class="car">▾</span>':''}</th>`;}
+function tbar(count,extra){return `<div class="tbar"><label class="search"><span class="ic">⌕</span><input placeholder="Filter…"></label>${extra||''}<button class="tbtn density-th">▤ Compact</button><span class="tcount">${count}</span></div>`;}
+function bdg(s,txt){return `<span class="badge ${s}"><span class="st ${s}"></span>${txt}</span>`;}
+function kpi(stat,val,unit,label){const vc=stat==='ok'?'':stat;return `<div class="kpi"><span class="st ${stat}"></span><div class="v ${vc}">${val}${unit?`<u>${unit}</u>`:''}</div><div class="l">${label}</div></div>`;}
+
+function body(id){
+  if(id==='overview'){
+    const r=(st,h,cpu,ram,gpu,up)=>`<tr><td class="name">${h}</td><td>${st}</td><td class="num">${cpu}</td><td class="num">${ram}</td><td class="num">${gpu}</td><td class="num">${up}</td></tr>`;
+    return tbar('4 hosts')+`<table class="tbl"><thead><tr>${th('Host',{sort:1})}${th('Status')}${th('CPU',{num:1})}${th('RAM',{num:1})}${th('GPU',{num:1})}${th('Uptime',{num:1})}</tr></thead><tbody>
+      ${r(bdg('warn','Warning'),'nas','88%','71%','—','21d')}
+      ${r(bdg('ok','Online'),'ardi','41%','38%','63°C','6d')}
+      ${r(bdg('ok','Online'),'oldie','12%','20%','—','9d')}
+      ${r(bdg('ok','Online'),'jellyfin','29%','44%','51°C','3d')}
+    </tbody></table>`;
+  }
+  if(id==='gpu') return `
+    <div class="grid" style="margin-bottom:12px">
+      ${kpi('warn','63','%','Utilisation')}${kpi('ok','41','°C','Temp')}${kpi('ok','142','W','Power')}${kpi('ok','11.2','/24 GB','VRAM')}</div>
+    <div class="card"><div class="hd"><span class="st ok"></span><span class="lbl">VRAM by service · 6h</span><span class="meta">peak 22.1 / 24 GB · 1 OOM</span></div>
+      <div class="bd"><svg class="vram" viewBox="0 0 320 120" preserveAspectRatio="none">
+        <line x1="0" y1="14" x2="320" y2="14" stroke="var(--crit)" stroke-width="1" stroke-dasharray="4 3" opacity=".7"/>
+        <polygon points="0,120 0,80 60,72 120,60 180,40 240,66 300,58 320,60 320,120" fill="var(--info)" opacity=".5"/>
+        <polygon points="0,120 0,98 60,92 120,86 180,70 240,90 300,86 320,88 320,120" fill="var(--accent)" opacity=".55"/>
+        <g transform="translate(180,40)"><polygon points="0,-9 5,-18 -5,-18" fill="var(--crit)"/></g>
+      </svg><div style="display:flex;gap:14px;margin-top:8px;font-size:11px;color:var(--mut)"><span><span class="st info" style="display:inline-block;background:var(--info)"></span> open-webui</span><span><span class="st warn" style="display:inline-block"></span> immich_ml</span><span style="color:var(--crit)">▲ OOM 02:14 — immich_ml exit 137</span></div></div></div>
+    <table class="tbl"><thead><tr>${th('GPU',{sort:1})}${th('Model')}${th('Util',{num:1})}${th('VRAM',{num:1})}${th('Temp',{num:1})}</tr></thead><tbody>
+      <tr><td class="name">GPU 0</td><td>RTX 3090</td><td class="num">63%</td><td class="num">11.2G</td><td class="num">41°C</td></tr>
+      <tr><td class="name">GPU 1</td><td>RTX 3060</td><td class="num">8%</td><td class="num">1.4G</td><td class="num">34°C</td></tr>
+    </tbody></table>`;
+  if(id==='containers'){
+    const r=(st,nm,cpu,mem,up)=>`<tr><td class="name">${nm}</td><td>${st}</td><td class="num">${cpu}</td><td class="num">${mem}</td><td class="num">${up}</td></tr>`;
+    return tbar('14 containers')+`<table class="tbl"><thead><tr>${th('Name')}${th('Status',{sort:1})}${th('CPU',{num:1})}${th('Mem',{num:1})}${th('Uptime',{num:1})}</tr></thead><tbody>
+      ${r(bdg('crit','Unhealthy'),'immich_ml','—','—','3× ↻')}
+      ${r(bdg('ok','Running'),'immich_server','4%','612M','6d')}
+      ${r(bdg('ok','Running'),'open-webui','2%','341M','6d')}
+      ${r(bdg('ok','Running'),'ollama','11%','5.2G','6d')}
+      ${r(bdg('ok','Running'),'n8n','1%','188M','12d')}
+    </tbody></table>`;
+  }
+  if(id==='services'){
+    const r=(st,nm,desc,up)=>`<tr><td class="name">${nm}</td><td>${st}</td><td>${desc}</td><td class="num">${up}</td></tr>`;
+    return tbar('9 units')+`<table class="tbl"><thead><tr>${th('Unit')}${th('State',{sort:1})}${th('Description')}${th('Uptime',{num:1})}</tr></thead><tbody>
+      ${r(bdg('ok','Active'),'sshd','OpenSSH server','41d')}
+      ${r(bdg('ok','Active'),'docker','Container engine','41d')}
+      ${r(bdg('warn','Degraded'),'smbd','Samba — 1 share offline','12d')}
+      ${r(bdg('ok','Active'),'tailscaled','Tailscale VPN','9d')}
+    </tbody></table>`;
+  }
+  if(id==='models'){
+    const r=(st,nm,srv,vram,tps)=>`<tr><td class="name">${nm}</td><td>${st}</td><td>${srv}</td><td class="num">${vram}</td><td class="num">${tps}</td></tr>`;
+    return tbar('3 loaded')+`<table class="tbl"><thead><tr>${th('Model')}${th('Status',{sort:1})}${th('Server')}${th('VRAM',{num:1})}${th('tok/s',{num:1})}</tr></thead><tbody>
+      ${r(bdg('ok','Loaded'),'llama3.1:70b','ollama · GPU0','9.8G','42')}
+      ${r(bdg('ok','Loaded'),'nomic-embed','ollama · GPU1','0.6G','—')}
+      ${r(bdg('warn','Idle'),'qwen2.5:7b','open-webui · GPU0','—','0')}
+    </tbody></table>`;
+  }
+  if(id==='host') return `<div class="grid" style="margin-bottom:12px">
+      ${kpi('ok','41','%','CPU')}${kpi('ok','38','%','Memory')}${kpi('warn','82','%','Disk /')}${kpi('ok','1.2','Gb/s','Network')}</div>
+    <table class="tbl"><thead><tr>${th('Mount')}${th('Used',{num:1})}${th('Size',{num:1})}${th('Use%',{num:1,sort:1})}</tr></thead><tbody>
+      <tr><td class="name">/</td><td class="num">410G</td><td class="num">500G</td><td class="num">82%</td></tr>
+      <tr><td class="name">/mnt/external</td><td class="num">6.1T</td><td class="num">12T</td><td class="num">51%</td></tr>
+    </tbody></table>`;
+  if(id==='hosts') return tbar('4 hosts','<button class="tbtn on">+ Add host</button>')+`<table class="tbl"><thead><tr>${th('Host')}${th('Address')}${th('Probe')}${th('Last seen',{num:1})}</tr></thead><tbody>
+      <tr><td class="name">ardi</td><td class="num">ardi:22</td><td>${bdg('ok','SSH ok')}</td><td class="num">3s</td></tr>
+      <tr><td class="name">nas</td><td class="num">10.0.0.4</td><td>${bdg('warn','slow')}</td><td class="num">41s</td></tr>
+    </tbody></table>`;
+  if(id==='alerts') return tbar('5 rules','<button class="tbtn on">+ Add rule</button>')+`<table class="tbl"><thead><tr>${th('Rule')}${th('Condition')}${th('Channel')}${th('State',{sort:1})}</tr></thead><tbody>
+      <tr><td class="name">GPU temp</td><td>&gt; 85°C for 5m</td><td>Discord</td><td>${bdg('ok','Armed')}</td></tr>
+      <tr><td class="name">Container down</td><td>any unhealthy</td><td>Discord</td><td>${bdg('crit','Firing')}</td></tr>
+    </tbody></table>`;
+  return tbar('—')+`<table class="tbl"><tbody><tr><td>${META[id].t} — sample</td></tr></tbody></table>`;
+}
+function render(host,id){const m=META[id]||META.overview;
+  if(host==='d') document.getElementById('dcontent').innerHTML=`<div class="phead"><div><div class="ptitle">${m.t}</div><div class="psub">${m.s}</div></div></div>`+body(id);
+  else document.getElementById('mcontent').innerHTML=`<div class="mtitle">${m.t}</div><div class="msub">${m.s}</div>`+body(id);
+}
+// nav
+document.getElementById('dnav').addEventListener('click',e=>{const b=e.target.closest('.nrow');if(!b)return;
+  document.querySelectorAll('#dnav .nrow').forEach(x=>x.classList.remove('on'));b.classList.add('on');render('d',b.dataset.t);});
+const sheet=document.getElementById('sheet');
+document.getElementById('mnav').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;
+  if(b.dataset.t==='__more'){sheet.classList.add('open');return;}
+  document.querySelectorAll('#mnav button').forEach(x=>x.classList.toggle('on',x===b));render('m',b.dataset.t);});
+sheet.addEventListener('click',e=>{if(e.target===sheet){sheet.classList.remove('open');return;}
+  const b=e.target.closest('.srow');if(!b||b.classList.contains('density-th'))return;sheet.classList.remove('open');
+  document.querySelectorAll('#mnav button').forEach(x=>x.classList.remove('on'));
+  document.querySelector('#mnav [data-t="__more"]').classList.add('on');render('m',b.dataset.t);});
+document.getElementById('mhosts').addEventListener('click',e=>{const b=e.target.closest('.hpill');if(!b||b.classList.contains('add'))return;
+  document.querySelectorAll('#mhosts .hpill').forEach(x=>x.classList.remove('on'));b.classList.add('on');});
+document.getElementById('mupd').querySelector('.x').addEventListener('click',()=>document.getElementById('mupd').style.display='none');
+// density (event delegation — buttons are re-rendered inside content)
+document.addEventListener('click',e=>{if(e.target.closest('.density-th')){document.querySelectorAll('.desk,.phone').forEach(f=>f.classList.toggle('dense'));}});
+// theme: dark/light/system
+const mql=window.matchMedia('(prefers-color-scheme: light)');let themePref='dark';
+function applyTheme(){const r=themePref==='system'?(mql.matches?'light':'dark'):themePref;
+  document.documentElement.setAttribute('data-theme',r);
+  document.querySelectorAll('#themeswitch button').forEach(b=>b.classList.toggle('on',b.dataset.th===themePref));
+  const icon=themePref==='system'?'◐':(r==='dark'?'☾':'☀'),name=themePref==='system'?'System':(r==='dark'?'Dark':'Light');
+  document.querySelectorAll('.thicon').forEach(e=>e.textContent=icon);
+  document.querySelectorAll('.inproduct-th .thlabel').forEach(e=>e.textContent=name);}
+mql.addEventListener('change',()=>{if(themePref==='system')applyTheme();});
+document.getElementById('themeswitch').addEventListener('click',e=>{const b=e.target.closest('button');if(!b)return;themePref=b.dataset.th;applyTheme();});
+const CYCLE=['dark','light','system'];
+document.querySelectorAll('.inproduct-th').forEach(b=>b.addEventListener('click',()=>{themePref=CYCLE[(CYCLE.indexOf(themePref)+1)%3];applyTheme();}));
+// star
+document.querySelectorAll('#dghstar,#sghstar').forEach(el=>el.addEventListener('click',ev=>{ev.preventDefault();
+  document.querySelectorAll('.ghstar').forEach(b=>b.classList.add('starred'));
+  const l=document.getElementById('dghlabel');if(l)l.textContent='✓ Starred';}));
+applyTheme();render('d','overview');render('m','overview');
+</script>
+</body></html>

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -382,7 +382,7 @@ a{color:var(--info)}
 <section data-tab="models" hidden>
   <div class="card"><h2>🧠 AI model servers</h2>
     <table class="mtbl"><thead><tr>
-      <th style="width:24px"></th><th>Model</th><th>Server</th><th>Status</th><th>VRAM now</th><th>Peak</th><th>% time</th>
+      <th style="width:24px"></th><th>Model</th><th>Server</th><th>Status</th><th>VRAM now</th><th>Peak</th>
     </tr></thead><tbody id="modelstbl"></tbody></table>
     <p class="cap" style="margin-top:10px">Click a row for its <b>VRAM timeline</b> &amp; details. Recognised servers: Ollama (live VRAM/model), vLLM, HF TGI, llama.cpp, Stable Diffusion, ComfyUI.</p>
   </div>
@@ -755,27 +755,31 @@ function renderModels(){
   const n=D.now, tot=D.mem_total;
   const live=n.models||[], sums=D.model_summary||[];
   const svcSum={}; (D.summary||[]).forEach(s=>svcSum[s.service]=s);
+  // Per-model peak comes from model_summary (keyed by model+service); current VRAM
+  // from n.models. The VRAM-over-time series + %-resident are only available PER
+  // SERVER (D.services/D.summary keyed by service), so they're shown as server-level
+  // stats in the expanded panel — not per-model columns (which caused the "all the
+  // same" bug when several models share one server, e.g. ollama).
+  const peakOf={}; sums.forEach(m=>{peakOf[m.model+'|'+m.service]=m.peak;});
   const seen=new Set(), rows=[];
-  live.forEach(m=>{const k=m.model+'|'+m.service; seen.add(k); rows.push({model:m.model,service:m.service,vram:m.vram,loaded:true});});
+  live.forEach(m=>{const k=m.model+'|'+m.service; seen.add(k); rows.push({model:m.model,service:m.service,vram:m.vram,loaded:true,peak:peakOf[k]});});
   sums.forEach(m=>{const k=m.model+'|'+m.service; if(!seen.has(k)){seen.add(k); rows.push({model:m.model,service:m.service,vram:null,loaded:false,peak:m.peak});}});
   const body=document.getElementById('modelstbl'); if(!body) return;
-  if(!rows.length){ body.innerHTML='<tr><td colspan="7" class="muted">No model server is holding the GPU right now.</td></tr>'; return; }
+  if(!rows.length){ body.innerHTML='<tr><td colspan="6" class="muted">No model server is holding the GPU right now.</td></tr>'; return; }
   body.innerHTML = rows.map((m,i)=>{
     const ss=svcSum[m.service]||{};
-    const peak=m.peak!=null?m.peak:ss.peak;
-    const present=ss.present!=null?ss.present+'%':'—';
     const status=m.loaded?'<span class="badge ok">Loaded</span>':'<span class="badge info">Idle</span>';
     const head=`<tr class="mrow" data-i="${i}"><td><span class="exp">▶</span></td>
       <td><span class="dot" style="background:${colorFor(m.service)}"></span>${esc(m.model)}</td>
       <td class="muted">${esc(m.service)}</td><td>${status}</td>
-      <td>${m.vram?fmtMB(m.vram):'—'}</td><td>${peak!=null?fmtMB(peak):'—'}</td><td class="muted">${present}</td></tr>`;
-    const det=`<tr class="mdet" data-d="${i}"><td colspan="7">
+      <td>${m.vram?fmtMB(m.vram):'—'}</td><td>${m.peak!=null?fmtMB(m.peak):'—'}</td></tr>`;
+    const det=`<tr class="mdet" data-d="${i}"><td colspan="6">
       <div class="grid2">
-        <div class="kv"><div class="k">Server / backend</div><div class="vv">${esc(m.service)}</div></div>
+        <div class="kv"><div class="k">Model</div><div class="vv">${esc(m.model)}</div></div>
         <div class="kv"><div class="k">Current VRAM</div><div class="vv">${m.vram?fmtMB(m.vram):'—'}</div></div>
-        <div class="kv"><div class="k">Peak (range)</div><div class="vv">${peak!=null?fmtMB(peak):'—'}</div></div>
-        <div class="kv"><div class="k">Avg (range)</div><div class="vv">${ss.avg!=null?fmtMB(ss.avg):'—'}</div></div>
-        <div class="kv"><div class="k">% time resident</div><div class="vv">${present}</div></div>
+        <div class="kv"><div class="k">Peak VRAM (range)</div><div class="vv">${m.peak!=null?fmtMB(m.peak):'—'}</div></div>
+        <div class="kv"><div class="k">Server resident %</div><div class="vv">${ss.present!=null?ss.present+'%':'—'}</div></div>
+        <div class="kv"><div class="k">Server avg VRAM</div><div class="vv">${ss.avg!=null?fmtMB(ss.avg):'—'}</div></div>
       </div>${modelSpark(m.service,tot)}</td></tr>`;
     return head+det;
   }).join('');
@@ -794,7 +798,7 @@ function modelSpark(service,tot){
   const marks=evs.map(i=>`<line x1="${(i/den*100).toFixed(1)}" y1="0" x2="${(i/den*100).toFixed(1)}" y2="100" stroke="var(--crit)" stroke-width="1" opacity=".8"/>`).join('');
   return `<svg class="mspark" viewBox="0 0 100 100" preserveAspectRatio="none">`
     + `<polyline fill="none" stroke="${colorFor(service)}" stroke-width="1.5" vector-effect="non-scaling-stroke" points="${pts}"/>${marks}</svg>`
-    + `<div class="mspark-cap">VRAM held by <b>${esc(service)}</b> over the selected range`
+    + `<div class="mspark-cap">Server VRAM — <b>${esc(service)}</b> (shared by all its models) over the selected range`
     + `${evs.length?` · <span style="color:var(--crit)">▲ ${evs.length} OOM event${evs.length>1?'s':''}</span>`:''} · peak axis ${fmtMB(max)}.</div>`;
 }
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -290,6 +290,27 @@ th{font-size:10px;text-transform:uppercase;letter-spacing:.05em}
   .foot{flex-direction:row;border-top:0;margin-left:auto;align-items:center;padding:6px 10px}
   .content{max-width:none}
 }
+/* ═══════════ light/dark parity — tokenize every surface that was hardcoded ═══════════ */
+a{color:var(--info)}
+/* nav group headers — clearer */
+.navgroup{color:var(--tx);opacity:.78;font-size:10px;font-weight:700;border-bottom:1px solid var(--bd);padding:12px 6px 6px;margin:2px 4px 5px}
+/* port chips */
+.portpill{background:var(--inset);color:var(--mut)}
+.portpill:hover{background:var(--hover);border-color:var(--accent);color:var(--accent)}
+/* ALL form fields (overrides the inline background:#0d1117 on Alerts/Hosts inputs) */
+.content input,.content select,.content textarea{background:var(--inset)!important;color:var(--tx)!important;border-color:var(--bd)}
+.content details > pre{background:var(--hover)!important;color:var(--tx)!important}
+/* inset surfaces */
+.kpi,.ins,.ov,.scope-notice,.hosts-key,.hostrow,.hostrow.ok,.hostrow.warn,.hostrow.fail,.hostrow.untested,.lansug,.btn-mini,.runpanel{background:var(--inset)}
+.hcheck .rem,.runpanel .note,.runpanel pre.out,.runpanel input[type=password],.osbadge,.hostrow .tg-edit{background:var(--hover)}
+/* update modal surfaces */
+.umodal pre.cmd,.umodal .notes code,.umodal .notes pre,.umodal .notes th,.umodal .btn{background:var(--inset)}
+/* range: standalone .rb is a pill; only the top-bar group is segmented */
+.rb{background:var(--inset);border:1px solid var(--bd);border-radius:6px;color:var(--mut)}
+.rb.on{background:var(--sel);border-color:var(--mut);color:var(--tx);box-shadow:none}
+#controls .ranges .rb{border:0;border-right:1px solid var(--bd);border-radius:0;font-family:var(--mono);font-size:11.5px;padding:4px 9px}
+#controls .ranges .rb:last-child{border-right:0}
+#controls .ranges .rb.on{background:var(--sel);color:var(--tx)}
 </style></head><body><div class="app"><aside class="side" id="sidebar"></aside><main class="main"><div class="topbar" id="topbar"></div><div class="content">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
@@ -620,6 +641,7 @@ function applyTheme(){
   const name = themePref==='system' ? 'System' : (r==='dark'?'Dark':'Light');
   const ic = document.querySelector('#themeBtn .thicon'), nm = document.querySelector('#themeBtn .thlabel');
   if(ic) ic.textContent = icon; if(nm) nm.textContent = name;
+  if(typeof buildCharts === 'function') buildCharts();   // re-colour charts for the new theme
 }
 function initTheme(){
   applyTheme();
@@ -921,12 +943,12 @@ function buildCharts(){
       evIdx.forEach(({i})=>{const px=x.getPixelForValue(i); ctx.strokeStyle='#f85149';ctx.lineWidth=1.5;ctx.beginPath();ctx.moveTo(px,a.top);ctx.lineTo(px,a.bottom);ctx.stroke();
         ctx.fillStyle='#f85149';ctx.beginPath();ctx.moveTo(px-5,a.top);ctx.lineTo(px+5,a.top);ctx.lineTo(px,a.top+8);ctx.fill();});
       ctx.restore();}};
-    mk('vram',{type:'line',data:{labels,datasets:ds},options:baseOpts(tot,'GB',v=>Math.round(v/1024)+'G',true),plugins:[overlay]});
+    mk('vram',{type:'line',data:{labels,datasets:ds},options:baseOpts(tot,'GB',v=>Math.round(v/1024)+'G',true),plugins:[areaBg,overlay]});
     mk('gpu2',{type:'line',data:{labels,datasets:[
       {label:'GPU util %',data:D.total.util,borderColor:'#4dabf7',backgroundColor:'#4dabf733',fill:true,pointRadius:0,tension:.3,yAxisID:'y'},
       {label:'Power W',data:D.total.power,borderColor:'#ff922b',borderWidth:1.5,pointRadius:0,tension:.3,yAxisID:'y1'},
       {label:'Temp °C',data:D.total.temp,borderColor:'#f783ac',borderWidth:1,pointRadius:0,tension:.3,yAxisID:'y1'}]},
-      options:dualOpts(labels)});
+      options:dualOpts(labels),plugins:[areaBg]});
   }
   if(TAB==='host'){
     const ramPctArr=D.total.ram_used.map((u,i)=>D.total.ram_total[i]?Math.round(u/D.total.ram_total[i]*100):0);
@@ -934,18 +956,23 @@ function buildCharts(){
       {label:'CPU %',data:D.total.cpu,borderColor:'#3fb950',backgroundColor:'#3fb95033',fill:true,pointRadius:0,tension:.3,yAxisID:'y'},
       {label:'RAM %',data:ramPctArr,borderColor:'#a371f7',borderWidth:1.5,pointRadius:0,tension:.3,yAxisID:'y'},
       {label:'Load',data:D.total.load1,borderColor:'#e3b341',borderWidth:1,pointRadius:0,tension:.3,yAxisID:'y1'}]},
-      options:dualOpts(labels,100)});
+      options:dualOpts(labels,100),plugins:[areaBg]});
   }
 }
-function baseOpts(max,unit,cb,stacked){return{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
-  scales:{x:{grid:{color:'#21262d'},ticks:{color:'#8b949e',maxTicksLimit:10,autoSkip:true}},
-   y:{stacked:!!stacked,min:0,max:max*1.02,grid:{color:'#21262d'},ticks:{color:'#8b949e',callback:cb}}},
-  plugins:{legend:{labels:{color:'#e6edf3',boxWidth:12,filter:i=>i.text!=='capacity'}},tooltip:{callbacks:{label:c=>c.dataset.label+': '+fmtMB(c.parsed.y)}}}};}
-function dualOpts(labels,ymax){return{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
-  scales:{x:{grid:{color:'#21262d'},ticks:{color:'#8b949e',maxTicksLimit:10,autoSkip:true}},
-   y:{position:'left',min:0,max:ymax||100,grid:{color:'#21262d'},ticks:{color:'#8b949e'}},
-   y1:{position:'right',min:0,grid:{drawOnChartArea:false},ticks:{color:'#8b949e'}}},
-  plugins:{legend:{labels:{color:'#e6edf3',boxWidth:12}}}};}
+// Read a theme token at draw time so charts re-colour with the theme.
+const cv = n => (getComputedStyle(document.documentElement).getPropertyValue(n)||'').trim() || '#888';
+// Fill the plot area with a subtle inset so the data lines stand out on both themes.
+const areaBg = {id:'areaBg',beforeDraw(c){const a=c.chartArea; if(!a) return; const x=c.ctx;
+  x.save(); x.fillStyle=cv('--inset'); x.fillRect(a.left,a.top,a.right-a.left,a.bottom-a.top); x.restore();}};
+function baseOpts(max,unit,cb,stacked){const grid=cv('--free'),tick=cv('--mut'),leg=cv('--tx');return{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
+  scales:{x:{grid:{color:grid},ticks:{color:tick,maxTicksLimit:10,autoSkip:true}},
+   y:{stacked:!!stacked,min:0,max:max*1.02,grid:{color:grid},ticks:{color:tick,callback:cb}}},
+  plugins:{legend:{labels:{color:leg,boxWidth:12,filter:i=>i.text!=='capacity'}},tooltip:{callbacks:{label:c=>c.dataset.label+': '+fmtMB(c.parsed.y)}}}};}
+function dualOpts(labels,ymax){const grid=cv('--free'),tick=cv('--mut'),leg=cv('--tx');return{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
+  scales:{x:{grid:{color:grid},ticks:{color:tick,maxTicksLimit:10,autoSkip:true}},
+   y:{position:'left',min:0,max:ymax||100,grid:{color:grid},ticks:{color:tick}},
+   y1:{position:'right',min:0,grid:{drawOnChartArea:false},ticks:{color:tick}}},
+  plugins:{legend:{labels:{color:leg,boxWidth:12}}}};}
 function mk(id,cfg){ if(charts[id])charts[id].destroy(); charts[id]=new Chart(document.getElementById(id),cfg); }
 
 // ── Alerts (settings) tab ─────────────────────────────────────────────────────

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -5,8 +5,15 @@
 <link rel="alternate icon" href="/favicon.ico">
 <script src="/static/chart.min.js" onerror="this.remove();var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"></script>
 <style>
-:root{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
---crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff}
+:root{--mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,Consolas,monospace}
+:root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
+--crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;
+--canvas:#0a0e14;--inset:#0d1117;--hover:#161b22;--sel:#1c232e;--sb:#0b0f15;
+--okbg:#3fb95018;--warnbg:#d2992218;--critbg:#f8514918}
+[data-theme="light"]{--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;--free:#eaeef2;
+--crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;
+--canvas:#f6f8fa;--inset:#f6f8fa;--hover:#eef1f4;--sel:#e7ebf0;--sb:#f6f8fa;
+--okbg:#1a7f3714;--warnbg:#9a670014;--critbg:#cf222e14}
 *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--tx);font:15px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{max-width:1140px;margin:0 auto;padding:22px 18px 70px}
 header{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
@@ -195,7 +202,95 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .scope-notice{display:flex;gap:10px;align-items:flex-start;background:#0d1117;border:1px dashed var(--bd);border-radius:9px;padding:10px 13px;color:var(--mut);font-size:13px;margin-bottom:14px}
 .scope-notice .ic{font-size:16px;line-height:1.3}
 .scope-notice b{color:var(--tx)}
-</style></head><body><div class="wrap">
+
+/* ═══════════ rev 6 migration — Portainer-style shell + enterprise restyle (additive; overrides win by source order) ═══════════ */
+body{background:var(--canvas)}
+.app{display:grid;grid-template-columns:212px 1fr;min-height:100vh}
+.side{background:var(--sb);border-right:1px solid var(--bd);display:flex;flex-direction:column;position:sticky;top:0;height:100vh;z-index:7}
+.sbrand{display:flex;align-items:center;gap:9px;padding:14px 15px 12px;border-bottom:1px solid var(--bd)}
+.sbrand .logo{font-size:17px}.sbrand .nm{font-size:13.5px;font-weight:600;white-space:nowrap;overflow:hidden}
+.sbrand .ver{margin-left:auto;font-family:var(--mono)}
+.navlist{flex:1 1 auto;overflow:auto;padding:8px}
+.navgroup{color:var(--mut);font-size:9.5px;text-transform:uppercase;letter-spacing:.08em;padding:12px 9px 5px;font-weight:600}
+.nrow{display:flex;align-items:center;gap:9px;width:100%;border:0;background:none;color:var(--mut);font:inherit;font-size:13px;text-align:left;padding:8px 10px;border-radius:6px;cursor:pointer}
+.nrow:hover{background:var(--hover);color:var(--tx)}
+.nrow.on{background:var(--sel);color:var(--tx);font-weight:600}
+.nrow .tdot{width:7px;height:7px;border-radius:2px;margin-left:auto}
+.foot{border-top:1px solid var(--bd);padding:10px;display:flex;flex-direction:column;gap:9px}
+.foot .ghstar{align-self:flex-start}
+.footrow{display:flex;align-items:center;gap:8px;justify-content:space-between;flex-wrap:wrap}
+.thtoggle{display:inline-flex;align-items:center;gap:6px;border:0;background:none;color:var(--mut);font:inherit;font-size:12px;cursor:pointer;padding:3px 2px}
+.thtoggle:hover{color:var(--tx)}
+.themeswitch{display:flex;border:1px solid var(--bd);border-radius:6px;overflow:hidden}
+.themeswitch button{border:0;border-right:1px solid var(--bd);background:var(--card);color:var(--mut);font:inherit;font-size:11px;padding:4px 9px;cursor:pointer}
+.themeswitch button:last-child{border-right:0}.themeswitch button.on{background:var(--hover);color:var(--tx);font-weight:600}
+.main{min-width:0;display:flex;flex-direction:column}
+.topbar{display:flex;align-items:center;gap:8px;padding:9px 16px;border-bottom:1px solid var(--bd);background:var(--bg);flex-wrap:wrap;position:sticky;top:0;z-index:6}
+.topbar .envlbl{color:var(--mut);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+.content{padding:16px;max-width:1180px;flex:1 1 auto}
+/* host pills in the top bar — flat, neutral selection */
+#hostbar{padding:0;border:0;gap:6px}
+#hostbar .label{color:var(--mut);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+.hpill{background:var(--inset);border:1px solid var(--bd);border-radius:5px;padding:3px 9px 3px 7px;font-size:12px;font-family:var(--mono)}
+.hpill:hover{border-color:var(--mut)}
+.hpill.on{border-color:var(--mut);background:var(--sel);color:var(--tx)}
+.hpill .pdot{width:7px;height:7px;border-radius:2px}
+.hpill.add{font-family:inherit}
+/* range relocate into the top bar as a flat segmented control */
+#controls{margin:0;padding:0;border:0;background:none}
+#controls .ranges{gap:0;border:1px solid var(--bd);border-radius:5px;overflow:hidden;display:inline-flex;align-items:center}
+.rb{background:var(--inset);border:0;border-right:1px solid var(--bd);border-radius:0;color:var(--mut);font-size:11.5px;padding:4px 9px;font-family:var(--mono)}
+.rb:last-child{border-right:0}
+.rb.on{background:var(--sel);border-color:var(--bd);color:var(--tx)}
+#controls .spacer{display:none}#controls .tg{margin-left:8px;font-size:12px}
+.live{margin-left:auto;font-family:var(--mono);font-size:12px}
+.pulse{width:8px;height:8px;border-radius:2px;animation:none}
+.upd{border-radius:5px;background:var(--inset);border-color:var(--bd);color:var(--accent)}
+/* enterprise flat surfaces */
+.card{background:var(--card);border:1px solid var(--bd);border-radius:7px;padding:14px 15px;margin:0 0 12px}
+h2{font-size:12px}
+.kpi{background:var(--inset);border:1px solid var(--bd);border-radius:6px}
+.kpi .v{font-family:var(--mono);font-size:19px;font-variant-numeric:tabular-nums}
+table{font-size:12.5px}
+th{font-size:10px;text-transform:uppercase;letter-spacing:.05em}
+.fleet-tbl tbody tr:hover td{background:var(--hover)}
+.fleet-tbl .status .d{border-radius:2px}
+/* badges flat (square + word; colour is not the only channel) */
+.badge{border-radius:4px;font-weight:600;padding:2px 8px}
+.badge.crit{color:var(--crit);background:var(--critbg);border-color:transparent}
+.badge.warn{color:var(--warn);background:var(--warnbg);border-color:transparent}
+.badge.ok{color:var(--ok);background:var(--okbg);border-color:transparent}
+.badge.info{color:var(--mut);background:var(--inset);border-color:var(--bd)}
+.sdot{border-radius:2px}.dot{border-radius:2px}
+.rb.on{box-shadow:none}
+/* AI Models — expandable rows + per-model VRAM timeline */
+.mtbl td{vertical-align:middle}
+.mrow{cursor:pointer}
+.mrow .exp{display:inline-block;width:12px;color:var(--mut);transition:transform .15s;font-size:10px}
+.mrow.open .exp{transform:rotate(90deg)}
+.mdet{display:none}.mdet.open{display:table-row}
+.mdet>td{background:var(--inset);padding:12px 14px}
+.mdet .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px;margin-bottom:11px}
+.mdet .kv .k{color:var(--mut);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
+.mdet .kv .vv{font-family:var(--mono);font-size:14px;margin-top:2px}
+.mspark{width:100%;height:48px;display:block;background:var(--card);border:1px solid var(--bd);border-radius:6px;margin-top:4px}
+.mspark-cap{color:var(--mut);font-size:11px;margin-top:5px}
+/* density */
+.dense .content{padding:11px 16px}
+.dense th,.dense td{padding:5px 9px}
+.dense .nrow{padding:6px 10px}.dense .card{padding:11px 12px}
+/* responsive: sidebar folds to a top bar */
+@media(max-width:860px){
+  .app{grid-template-columns:1fr}
+  .side{position:static;height:auto;flex-direction:row;flex-wrap:wrap;align-items:center;border-right:0;border-bottom:1px solid var(--bd)}
+  .sbrand{border-bottom:0;border-right:1px solid var(--bd)}
+  .navlist{display:flex;flex-wrap:wrap;flex:1 1 100%;order:3;padding:6px;gap:2px}
+  .navgroup{display:none}
+  .nrow{width:auto}.nrow .tdot{margin-left:6px}
+  .foot{flex-direction:row;border-top:0;margin-left:auto;align-items:center;padding:6px 10px}
+  .content{max-width:none}
+}
+</style></head><body><div class="app"><aside class="side" id="sidebar"></aside><main class="main"><div class="topbar" id="topbar"></div><div class="content">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
 <a class="ghstar" id="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub">
@@ -264,10 +359,11 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 
 <!-- ───────── AI Models ───────── -->
 <section data-tab="models" hidden>
-  <div class="cols">
-    <div class="card"><h2>🧠 Models loaded now</h2><table><tbody id="modelstbl"></tbody></table>
-      <p class="cap">Recognised servers: Ollama (live VRAM/model), vLLM, HF TGI, llama.cpp, Stable Diffusion, ComfyUI.</p></div>
-    <div class="card"><h2>🧠 Models (selected range)</h2><table><thead><tr><th>Model</th><th>Server</th><th>Peak VRAM</th></tr></thead><tbody id="msumtbl"></tbody></table></div>
+  <div class="card"><h2>🧠 AI model servers</h2>
+    <table class="mtbl"><thead><tr>
+      <th style="width:24px"></th><th>Model</th><th>Server</th><th>Status</th><th>VRAM now</th><th>Peak</th><th>% time</th>
+    </tr></thead><tbody id="modelstbl"></tbody></table>
+    <p class="cap" style="margin-top:10px">Click a row for its <b>VRAM timeline</b> &amp; details. Recognised servers: Ollama (live VRAM/model), vLLM, HF TGI, llama.cpp, Stable Diffusion, ComfyUI.</p>
   </div>
 </section>
 
@@ -412,7 +508,7 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 <p class="cap">Self-hosted &amp; open source • single container • no Prometheus/Grafana required • history downsampled on read.
 GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker API.
 <br>Ideas welcome — see <a href="https://github.com/SikamikanikoBG/homelab-monitor/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">CONTRIBUTING.md</a> · issues &amp; PRs always open.</p>
-</div>
+</div></main></div>
 
 <!-- ───────── Update-available modal ───────── -->
 <div class="umodal" id="updmodal" role="dialog" aria-modal="true" aria-labelledby="updtitle">
@@ -475,26 +571,69 @@ function fmtLabels(L){ if(!L.length)return[]; const md=(L[L.length-1]-L[0])>2*86
   return md?(d.getMonth()+1)+'/'+d.getDate()+' '+hm:hm;});}
 
 // ── Tab navigation ────────────────────────────────────────────────────────────
-const tabBtn = t => `<button class="tab" data-t="${t.id}"><span class="tdot" id="ndot-${t.id}" style="display:none"></span>${t.label}</button>`;
+// rev6: nav rows live in a grouped sidebar (Monitoring / Settings), both always
+// visible — no gear drawer. tdot = per-section attention square (set in renderHealth).
+const tabBtn = t => `<button class="nrow" data-t="${t.id}"><span>${t.label}</span><span class="tdot" id="ndot-${t.id}" style="display:none"></span></button>`;
 const isSettingsTab = id => !!(TABS.find(t=>t.id===id)||{}).settings;
 function buildNav(){
-  // Monitoring tabs go in the main row; settings tabs (Hosts, Alerts) live in the
-  // gear's sub-nav. Adding a monitor still = one TABS entry + one <section>.
-  document.getElementById('nav').innerHTML = TABS.filter(t=>!t.settings).map(tabBtn).join('');
-  document.getElementById('subnav').innerHTML =
-    '<button class="tab back" data-back="1">← Monitoring</button>' + TABS.filter(t=>t.settings).map(tabBtn).join('');
-  document.querySelectorAll('#nav .tab, #subnav .tab').forEach(b=>
-    b.onclick = b.dataset.back ? leaveSettings : (()=>showTab(b.dataset.t)));
-  document.getElementById('gearbtn').onclick = () =>
-    SETTINGS_OPEN ? leaveSettings() : showTab((TABS.find(t=>t.settings)||{}).id || 'overview');
+  const nl = document.getElementById('navlist'); if(!nl) return;
+  nl.innerHTML =
+    '<div class="navgroup">Monitoring</div>' + TABS.filter(t=>!t.settings).map(tabBtn).join('') +
+    '<div class="navgroup">Settings</div>'   + TABS.filter(t=>t.settings).map(tabBtn).join('');
+  nl.querySelectorAll('.nrow').forEach(b => b.onclick = () => showTab(b.dataset.t));
 }
-// The drawer just swaps which nav row is visible. showTab() is the single source
-// of truth and calls this, so deep links (#hosts) open in settings mode too.
-function setSettingsMode(on){
-  SETTINGS_OPEN = on;
-  document.getElementById('nav').hidden = on;
-  document.getElementById('subnav').hidden = !on;
-  document.getElementById('gearbtn').classList.toggle('on', on);
+// Drawer is gone; keep the name as a no-op so showTab() needn't change shape.
+function setSettingsMode(on){ SETTINGS_OPEN = on; }
+
+// Build the Portainer-style shell once, relocating the existing header/host/range/
+// star elements into the sidebar + top bar (so their markup stays untouched).
+function mountShell(){
+  const side = document.getElementById('sidebar'); if(!side) return;
+  side.innerHTML = '<div class="sbrand"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span></div>'
+    + '<div class="navlist" id="navlist"></div><div class="foot" id="foot"></div>';
+  const ver = document.getElementById('ver'); if(ver) document.querySelector('.sbrand').appendChild(ver);
+  const tb = document.getElementById('topbar');
+  const hb = document.getElementById('hostbar'); if(hb) tb.appendChild(hb);
+  const ctr = document.getElementById('controls'); if(ctr) tb.appendChild(ctr);
+  const upd = document.getElementById('updbadge'); if(upd) tb.appendChild(upd);
+  const live = document.querySelector('header .live'); if(live) tb.appendChild(live);
+  const foot = document.getElementById('foot');
+  const star = document.getElementById('ghstar'); if(star) foot.appendChild(star);
+  document.querySelectorAll('header .star-cta').forEach(s => foot.appendChild(s));
+  foot.insertAdjacentHTML('beforeend',
+    '<div class="footrow">'
+    + '<button class="thtoggle" id="themeBtn"><span class="thicon">☾</span><span class="thlabel">Dark</span></button>'
+    + '<button class="thtoggle" id="densityBtn">▤ Compact</button></div>'
+    + '<div class="themeswitch" id="themeswitch"><button data-th="dark">Dark</button><button data-th="light">Light</button><button data-th="system">System</button></div>');
+  ['header', '.topnav', '.sub'].forEach(sel => { const el = document.querySelector('.content > ' + sel); if(el) el.remove(); });
+}
+
+// ── Theme (dark / light / system) + density ──────────────────────────────────
+const _mql = window.matchMedia('(prefers-color-scheme: light)');
+let themePref = localStorage.getItem('hl_theme') || 'system';
+function applyTheme(){
+  const r = themePref==='system' ? (_mql.matches?'light':'dark') : themePref;
+  document.documentElement.setAttribute('data-theme', r);
+  const ts = document.getElementById('themeswitch');
+  if(ts) ts.querySelectorAll('button').forEach(b => b.classList.toggle('on', b.dataset.th===themePref));
+  const icon = themePref==='system' ? '◐' : (r==='dark'?'☾':'☀');
+  const name = themePref==='system' ? 'System' : (r==='dark'?'Dark':'Light');
+  const ic = document.querySelector('#themeBtn .thicon'), nm = document.querySelector('#themeBtn .thlabel');
+  if(ic) ic.textContent = icon; if(nm) nm.textContent = name;
+}
+function initTheme(){
+  applyTheme();
+  _mql.addEventListener('change', () => { if(themePref==='system') applyTheme(); });
+  const ts = document.getElementById('themeswitch');
+  if(ts) ts.addEventListener('click', e => { const b=e.target.closest('button'); if(!b) return;
+    themePref=b.dataset.th; localStorage.setItem('hl_theme',themePref); applyTheme(); });
+  const tbtn = document.getElementById('themeBtn');
+  if(tbtn) tbtn.addEventListener('click', () => { const C=['dark','light','system'];
+    themePref=C[(C.indexOf(themePref)+1)%3]; localStorage.setItem('hl_theme',themePref); applyTheme(); });
+  const dbtn = document.getElementById('densityBtn');
+  if(dbtn) dbtn.addEventListener('click', () => { const on=document.body.classList.toggle('dense');
+    localStorage.setItem('hl_dense', on?'1':'0'); dbtn.classList.toggle('on', on); });
+  if(localStorage.getItem('hl_dense')==='1'){ document.body.classList.add('dense'); if(dbtn) dbtn.classList.add('on'); }
 }
 function leaveSettings(){ showTab(LAST_MONITOR_TAB || 'overview'); }
 function showTab(id){
@@ -502,7 +641,7 @@ function showTab(id){
   if(!isSettingsTab(id)){ LAST_MONITOR_TAB=id; localStorage.setItem('hl_montab',id); }
   setSettingsMode(isSettingsTab(id));
   if(location.hash.slice(1)!==id) history.replaceState(null,'','#'+id);
-  document.querySelectorAll('.tab').forEach(b=>b.classList.toggle('on',b.dataset.t===id));
+  document.querySelectorAll('.nrow').forEach(b=>b.classList.toggle('on',b.dataset.t===id));
   document.querySelectorAll('section[data-tab]').forEach(s=>s.hidden = s.dataset.tab!==id);
   document.getElementById('controls').hidden = !(TABS.find(t=>t.id===id)||{}).charts;
   buildCharts();   // charts can only size on a visible canvas, so build on show
@@ -561,14 +700,8 @@ function renderData(){
     `<tr><td><span class="dot" style="background:${colorFor(s.service)}"></span>${esc(s.service)}</td><td>${fmtMB(s.peak)}</td><td>${fmtMB(s.avg)}</td><td>${s.present}%</td></tr>`).join('')
     : '<tr><td class="muted">No GPU activity yet.</td></tr>';
 
-  // AI models
-  document.getElementById('modelstbl').innerHTML = (n.models&&n.models.length)? n.models.map(m=>
-    `<tr><td><span class="dot" style="background:${colorFor(m.service)}"></span>${esc(m.model)}</td>
-     <td class="muted">${esc(m.service)}</td><td>${m.vram?fmtMB(m.vram):'<span class="pill">loaded</span>'}</td></tr>`).join('')
-    : '<tr><td class="muted">No model server is holding the GPU right now.</td></tr>';
-  document.getElementById('msumtbl').innerHTML = D.model_summary.length? D.model_summary.map(m=>
-    `<tr><td>${esc(m.model)}</td><td class="muted">${esc(m.service)}</td><td>${fmtMB(m.peak)}</td></tr>`).join('')
-    : '<tr><td colspan="3" class="muted">No per-model VRAM captured yet.</td></tr>';
+  // AI models — expandable rows + per-model VRAM timeline (see renderModels)
+  renderModels();
 
   // Host KPIs + disks — only when local is the active host. Otherwise
   // renderHostTab() owns these panels with the remote's polled data.
@@ -588,6 +721,59 @@ function renderData(){
   }
 
   buildCharts();
+}
+
+// ── AI Models: expandable rows + per-model VRAM timeline ──────────────────────
+// Joins three existing sources (no new API): n.models (loaded now), D.model_summary
+// (peak per model over range), D.summary (per-service peak/avg/%time). The expanded
+// panel draws a VRAM-over-time sparkline from D.services[service] with OOM markers
+// from D.events — the timeline the AI-engineer review asked for.
+function renderModels(){
+  if(!D) return;
+  const n=D.now, tot=D.mem_total;
+  const live=n.models||[], sums=D.model_summary||[];
+  const svcSum={}; (D.summary||[]).forEach(s=>svcSum[s.service]=s);
+  const seen=new Set(), rows=[];
+  live.forEach(m=>{const k=m.model+'|'+m.service; seen.add(k); rows.push({model:m.model,service:m.service,vram:m.vram,loaded:true});});
+  sums.forEach(m=>{const k=m.model+'|'+m.service; if(!seen.has(k)){seen.add(k); rows.push({model:m.model,service:m.service,vram:null,loaded:false,peak:m.peak});}});
+  const body=document.getElementById('modelstbl'); if(!body) return;
+  if(!rows.length){ body.innerHTML='<tr><td colspan="7" class="muted">No model server is holding the GPU right now.</td></tr>'; return; }
+  body.innerHTML = rows.map((m,i)=>{
+    const ss=svcSum[m.service]||{};
+    const peak=m.peak!=null?m.peak:ss.peak;
+    const present=ss.present!=null?ss.present+'%':'—';
+    const status=m.loaded?'<span class="badge ok">Loaded</span>':'<span class="badge info">Idle</span>';
+    const head=`<tr class="mrow" data-i="${i}"><td><span class="exp">▶</span></td>
+      <td><span class="dot" style="background:${colorFor(m.service)}"></span>${esc(m.model)}</td>
+      <td class="muted">${esc(m.service)}</td><td>${status}</td>
+      <td>${m.vram?fmtMB(m.vram):'—'}</td><td>${peak!=null?fmtMB(peak):'—'}</td><td class="muted">${present}</td></tr>`;
+    const det=`<tr class="mdet" data-d="${i}"><td colspan="7">
+      <div class="grid2">
+        <div class="kv"><div class="k">Server / backend</div><div class="vv">${esc(m.service)}</div></div>
+        <div class="kv"><div class="k">Current VRAM</div><div class="vv">${m.vram?fmtMB(m.vram):'—'}</div></div>
+        <div class="kv"><div class="k">Peak (range)</div><div class="vv">${peak!=null?fmtMB(peak):'—'}</div></div>
+        <div class="kv"><div class="k">Avg (range)</div><div class="vv">${ss.avg!=null?fmtMB(ss.avg):'—'}</div></div>
+        <div class="kv"><div class="k">% time resident</div><div class="vv">${present}</div></div>
+      </div>${modelSpark(m.service,tot)}</td></tr>`;
+    return head+det;
+  }).join('');
+  body.querySelectorAll('.mrow').forEach(r=>r.onclick=()=>{
+    const i=r.dataset.i, d=body.querySelector(`.mdet[data-d="${i}"]`);
+    r.classList.toggle('open'); if(d) d.classList.toggle('open');
+  });
+}
+function modelSpark(service,tot){
+  const arr=(D.services&&D.services[service])||[];
+  if(!arr.length) return '<div class="mspark-cap muted">No VRAM history captured for this server in the selected range.</div>';
+  const max=Math.max(tot||1, ...arr), n=arr.length, den=(n-1)||1;
+  const pts=arr.map((v,i)=>`${(i/den*100).toFixed(1)},${(100-(v/max*100)).toFixed(1)}`).join(' ');
+  const labels=D.labels||[];
+  const evs=(D.events||[]).map(e=>{let best=0,bd=1e18; labels.forEach((t,i)=>{const dd=Math.abs(t-e.ts); if(dd<bd){bd=dd;best=i;}}); return best;});
+  const marks=evs.map(i=>`<line x1="${(i/den*100).toFixed(1)}" y1="0" x2="${(i/den*100).toFixed(1)}" y2="100" stroke="var(--crit)" stroke-width="1" opacity=".8"/>`).join('');
+  return `<svg class="mspark" viewBox="0 0 100 100" preserveAspectRatio="none">`
+    + `<polyline fill="none" stroke="${colorFor(service)}" stroke-width="1.5" vector-effect="non-scaling-stroke" points="${pts}"/>${marks}</svg>`
+    + `<div class="mspark-cap">VRAM held by <b>${esc(service)}</b> over the selected range`
+    + `${evs.length?` · <span style="color:var(--crit)">▲ ${evs.length} OOM event${evs.length>1?'s':''}</span>`:''} · peak axis ${fmtMB(max)}.</div>`;
 }
 
 // ── Renderers (status tabs: Overview cards, Containers, Services) ──────────────
@@ -1428,7 +1614,9 @@ function refreshLocalOnlyNotices(){
 }
 
 // ── Wire-up ───────────────────────────────────────────────────────────────────
+mountShell();
 buildNav();
+initTheme();
 document.querySelectorAll('.rb').forEach(b=>b.onclick=()=>{R=b.dataset.r;localStorage.setItem('hl_range',R);
   document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));loadData();});
 document.querySelector(`.rb[data-r="${R}"]`)?.classList.add('on');


### PR DESCRIPTION
Reskins and reorganizes the dashboard to the **rev 6** layout converged via a 4-persona design review (home-lab enthusiast, AI engineer, sysadmin, devil's advocate). **No backend / `app.py` / `probe.py` changes** — every existing renderer, element ID and API call is preserved; this is a front-end migration.

## What changed
- **Grouped left sidebar** (Monitoring / Settings) + content top bar; the gear settings-drawer is gone (both groups always visible). `mountShell()` relocates the existing header / host pills / range / star into the new frame so their markup stays untouched.
- **Theme: dark / light / system** — tokenized palette, `prefers-color-scheme` with live OS re-resolution, persisted in `localStorage`. **Compact density** toggle.
- **Neutral selection; amber = warning only** — fixes the old `--accent`==`--warn` collision (every persona flagged it). Flat status badges (square + word, colorblind-safe).
- **AI Models** tab: expandable rows + **per-model VRAM timeline with OOM markers** (`renderModels()`), joined from existing data (`n.models` + `D.model_summary` + `D.summary` + `D.services` + `D.events`).
- **Light-theme parity**: every previously theme-blind surface tokenized (port chips, form fields incl. inline-styled Alerts/Hosts inputs, host rows, LAN suggestions, run panels, KPI tiles, update-modal code blocks, links). Charts read theme tokens via `cv()`, gained a plot-area background, and rebuild on theme switch.
- **Responsive**: sidebar folds to a top bar below 860px.

## Preserved verbatim
Fleet table, GPU charts (stacked VRAM + OOM overlay, util/power/temp), Containers/Services tables with port pills, the full Hosts registry (Test / Run-on-remote / Scan LAN / inline edit), Alerts config, update modal, GitHub star CTA, 15s polling, hash routing, multi-host scope notices.

## Testing
Deployed to the ardi dev container (`:9801`, built from this branch) and exercised both themes end-to-end. JS syntax-checked.

## Docs
- `design/migration-parity.md` — 22-row current→rev6 parity checklist.
- `design/nav-mockups.html` — clickable rev6 prototype.

## Known follow-up
Chart dataset line colors are fixed hues (fine on both themes); no other known theme gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)