### PR TITLE
Release v0.11.0 — AI Models detect-all + caller attribution

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,38 +163,123 @@ def _http_json(ip, port, path, timeout=2):
     return json.loads(body) if r.status < 400 else None
 
 def probe_ollama(ip):
-    d = _http_json(ip, 11434, "/api/ps")
-    return [(m["name"], (m.get("size_vram") or 0) / 1048576 or None) for m in (d or {}).get("models", [])]
-def probe_vllm(ip):
-    d = _http_json(ip, 8000, "/v1/models");  return [(m["id"], None) for m in (d or {}).get("data", [])]
+    """Ollama: models loaded *now* (with live VRAM) from /api/ps; if none are loaded,
+    fall back to the pulled catalogue (/api/tags) so the server still shows as Idle."""
+    ps = _http_json(ip, 11434, "/api/ps")
+    loaded = [(m["name"], (m.get("size_vram") or 0) / 1048576 or None)
+              for m in (ps or {}).get("models", []) if m.get("name")]
+    if loaded:
+        return loaded
+    tags = _http_json(ip, 11434, "/api/tags")
+    return [(m["name"], None) for m in (tags or {}).get("models", []) if m.get("name")]
+
+def _openai_models(*ports):
+    """Factory for the OpenAI-compatible `GET /v1/models` shape (`data[].id`), shared by
+    vLLM, llama.cpp/llama-server, LocalAI, faster-whisper-server/Speaches, koboldcpp,
+    tabbyAPI, text-generation-webui, LM Studio, xinference, … — they differ only by port.
+    Tries each candidate port until one answers with a non-empty model list."""
+    def fn(ip):
+        for p in ports:
+            d = _http_json(ip, p, "/v1/models")
+            data = (d or {}).get("data")
+            if data:
+                return [(m.get("id"), None) for m in data if m.get("id")]
+        return []
+    return fn
+
 def probe_tgi(ip):
-    d = _http_json(ip, 80, "/info") or _http_json(ip, 3000, "/info")
+    """HF Text-Generation-Inference / Text-Embeddings-Inference: `GET /info` → model_id."""
+    d = _http_json(ip, 80, "/info") or _http_json(ip, 3000, "/info") or _http_json(ip, 8080, "/info")
     return [(d["model_id"], None)] if d and d.get("model_id") else []
-def probe_llamacpp(ip):
-    d = _http_json(ip, 8080, "/v1/models"); return [(m["id"], None) for m in (d or {}).get("data", [])]
+
+def probe_koboldcpp(ip):
+    d = _http_json(ip, 5001, "/api/v1/model")
+    if d and d.get("result"):
+        return [(d["result"], None)]
+    return _openai_models(5001)(ip)
+
+def probe_invokeai(ip):
+    """InvokeAI v4+: `GET /api/v2/models/` → models[].name (its installed catalogue)."""
+    d = _http_json(ip, 9090, "/api/v2/models/")
+    return [(m.get("name"), None) for m in (d or {}).get("models", []) if m.get("name")]
+
 def probe_a1111(ip):
-    d = _http_json(ip, 7860, "/sdapi/v1/options"); m = (d or {}).get("sd_model_checkpoint")
+    """AUTOMATIC1111 / SD.Next / Forge: the currently-loaded checkpoint. Kept to a single
+    entry so the server's GPU VRAM (from nvidia-smi) attributes cleanly to it."""
+    m = (_http_json(ip, 7860, "/sdapi/v1/options") or {}).get("sd_model_checkpoint")
     return [(m, None)] if m else []
+
 def probe_comfy(ip):
     return [("ComfyUI graph", None)] if _http_json(ip, 8188, "/system_stats") is not None else []
 
-PROBES = [("ollama", probe_ollama), ("vllm", probe_vllm),
-          ("text-generation-inference", probe_tgi), ("tgi", probe_tgi),
-          ("llama.cpp", probe_llamacpp), ("llamacpp", probe_llamacpp), ("ggml", probe_llamacpp),
-          ("automatic1111", probe_a1111), ("stable-diffusion-webui", probe_a1111), ("sd-webui", probe_a1111),
-          ("comfyui", probe_comfy)]
+# (key-substring → probe). The key is matched against the container's image AND name,
+# first match wins, so order specific→generic. Most servers speak the OpenAI
+# /v1/models shape and differ only by their default internal port.
+PROBES = [
+    ("ollama",                     probe_ollama),
+    ("vllm",                       _openai_models(8000)),
+    ("text-generation-inference",  probe_tgi),
+    ("text-embeddings-inference",  probe_tgi),
+    ("faster-whisper",             _openai_models(8000)),
+    ("speaches",                   _openai_models(8000)),
+    ("whisper",                    _openai_models(8000, 9000)),
+    ("localai",                    _openai_models(8080)),
+    ("local-ai",                   _openai_models(8080)),
+    ("llama.cpp",                  _openai_models(8080, 8000)),
+    ("llama-server",               _openai_models(8080, 8000)),
+    ("llamacpp",                   _openai_models(8080, 8000)),
+    ("ggml",                       _openai_models(8080, 8000)),
+    ("koboldcpp",                  probe_koboldcpp),
+    ("tabbyapi",                   _openai_models(5000)),
+    ("exllama",                    _openai_models(5000)),
+    ("text-generation-webui",      _openai_models(5000)),
+    ("oobabooga",                  _openai_models(5000)),
+    ("lmstudio",                   _openai_models(1234)),
+    ("lm-studio",                  _openai_models(1234)),
+    ("xinference",                 _openai_models(9997)),
+    ("xorbits",                    _openai_models(9997)),
+    ("aphrodite",                  _openai_models(2242)),
+    ("mistral-rs",                 _openai_models(1234, 8080)),
+    ("infinity",                   _openai_models(7997)),
+    ("invokeai",                   probe_invokeai),
+    ("invoke-ai",                  probe_invokeai),
+    ("automatic1111",              probe_a1111),
+    ("stable-diffusion-webui",     probe_a1111),
+    ("sd-webui",                   probe_a1111),
+    ("sdnext",                     probe_a1111),
+    ("comfyui",                    probe_comfy),
+]
 
-def probe_models(ct):
-    img, name, ip = ct.get("image", "").lower(), ct.get("name", "").lower(), ct.get("ip")
-    if not ip:
-        return []
+def _match_probe(ct):
+    """Return the probe fn for a container whose image/name matches a known server, else None."""
+    img, name = ct.get("image", "").lower(), ct.get("name", "").lower()
     for key, fn in PROBES:
         if key in img or key in name:
-            try:
-                return [(m, v) for m, v in fn(ip) if m]
-            except Exception:
-                return []
-    return []
+            return fn
+    return None
+
+CATALOG_MAX = 15   # max idle "available" models listed per server before collapsing to a count
+
+def probe_models(ct):
+    fn = _match_probe(ct)
+    if not fn:
+        return []
+    # Host-networked servers have no per-container IP; the hub shares the host net
+    # namespace, so localhost reaches them on their published/default port.
+    ip = ct.get("ip") or "127.0.0.1"
+    try:
+        found = [(m, v) for m, v in fn(ip) if m]
+    except Exception:
+        return []
+    loaded = [x for x in found if x[1] is not None]
+    idle   = [x for x in found if x[1] is None]
+    # Collapse an oversized idle catalogue (faster-whisper, for one, exposes its full
+    # upstream registry of 400+ models) into a single summary row so it can't flood
+    # the panel. Loaded models and small catalogues (e.g. your pulled Ollama models)
+    # are kept verbatim.
+    if len(idle) > CATALOG_MAX:
+        idle = [(f"{len(idle)} models available", None)]
+    return loaded + idle
 
 # ── Host metrics (read from /proc, /sys, statvfs — host values via shared kernel)
 def _cpu_pct():
@@ -2006,7 +2091,8 @@ def sample_once():
     g = smi(["--query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
              "--format=csv,noheader,nounits"]).splitlines()[0].split(",")
     util, mem_used, mem_total, power, temp = (float(x.strip() or 0) for x in g)
-    nm = {c["id"]: c["name"] for c in containers()}
+    conts = containers()
+    nm = {c["id"]: c["name"] for c in conts}
     procs = {}
     for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
         if line.strip():
@@ -2014,15 +2100,26 @@ def sample_once():
             svc = service_for_pid(pid, nm)
             procs[svc] = procs.get(svc, 0) + float(mem or 0)
 
-    by_name = {c["name"]: c for c in containers()}
+    # Detect models from EVERY recognised AI server, not just the ones holding the GPU
+    # right now — so a server that has unloaded its model (e.g. OLLAMA_KEEP_ALIVE
+    # expired) or sits between requests still shows up as Idle instead of vanishing.
+    # Probes are independent 2 s-timeout HTTP calls, so run them in parallel.
+    ai = [c for c in conts if _match_probe(c)]
     models = []
-    for svc, mem in procs.items():
-        found = probe_models(by_name.get(svc, {}))
-        if len(found) == 1 and found[0][1] is None:
-            models.append((svc, found[0][0], round(mem)))
-        else:
+    if ai:
+        with ThreadPoolExecutor(max_workers=min(8, len(ai))) as ex:
+            found_lists = list(ex.map(probe_models, ai))
+        for ct, found in zip(ai, found_lists):
+            svc = ct["name"]
+            smem = procs.get(svc)                         # MB this server holds on the GPU now
+            api_vram = any(v is not None for _, v in found)
             for mdl, vram in found:
-                models.append((svc, mdl, round(vram) if vram else None))
+                if vram is not None:                      # server reported its own VRAM (Ollama)
+                    models.append((svc, mdl, round(vram)))
+                elif not api_vram and len(found) == 1 and smem:
+                    models.append((svc, mdl, round(smem)))  # single model ↔ all the server's VRAM
+                else:
+                    models.append((svc, mdl, None))         # server up but idle / can't attribute
 
     host = read_host()
     ts = int(time.time())
@@ -2034,7 +2131,8 @@ def sample_once():
         for svc, mem in procs.items():
             DB.execute("INSERT INTO proc VALUES(?,?,?)", (ts, svc, mem))
         for svc, mdl, vram in models:
-            DB.execute("INSERT INTO models VALUES(?,?,?,?)", (ts, svc, mdl, vram))
+            if vram is not None:          # persist only VRAM-bearing rows; idle catalogue
+                DB.execute("INSERT INTO models VALUES(?,?,?,?)", (ts, svc, mdl, vram))  # lives in LATEST only
         if ts % 360 < INTERVAL:
             for t in ("samples", "proc", "models", "events"):
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))

--- a/app.py
+++ b/app.py
@@ -86,6 +86,7 @@ DB.executescript("""
 CREATE TABLE IF NOT EXISTS samples(ts INTEGER PRIMARY KEY, util REAL, mem_used REAL, mem_total REAL, power REAL, temp REAL);
 CREATE TABLE IF NOT EXISTS proc(ts INTEGER, service TEXT, mem REAL);
 CREATE TABLE IF NOT EXISTS models(ts INTEGER, service TEXT, model TEXT, vram REAL);
+CREATE TABLE IF NOT EXISTS edges(ts INTEGER, caller TEXT, server TEXT, conns INTEGER);
 CREATE TABLE IF NOT EXISTS events(ts INTEGER, service TEXT, kind TEXT, detail TEXT);
 CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT);
 CREATE TABLE IF NOT EXISTS hosts(
@@ -98,6 +99,7 @@ CREATE TABLE IF NOT EXISTS hosts(
 );
 CREATE INDEX IF NOT EXISTS idx_proc_ts   ON proc(ts);
 CREATE INDEX IF NOT EXISTS idx_models_ts ON models(ts);
+CREATE INDEX IF NOT EXISTS idx_edges_ts  ON edges(ts);
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_event ON events(ts, service, kind);
 """)
 for col in ("cpu REAL", "ram_used REAL", "ram_total REAL", "load1 REAL", "ctemp REAL"):
@@ -108,7 +110,7 @@ for col in ("cpu REAL", "ram_used REAL", "ram_total REAL", "load1 REAL", "ctemp 
 DB.commit()
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
-          "procs": [], "models": [], "host": {}}
+          "procs": [], "models": [], "callers": [], "host": {}}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "at": 0}
@@ -134,8 +136,12 @@ def containers():
         for ct in json.loads(_docker("/containers/json")):
             nets = (ct.get("NetworkSettings") or {}).get("Networks") or {}
             ip = next((n.get("IPAddress") for n in nets.values() if n.get("IPAddress")), None)
+            ports = set()
+            for pm in (ct.get("Ports") or []):
+                if pm.get("PrivatePort"): ports.add(pm["PrivatePort"])
+                if pm.get("PublicPort"):  ports.add(pm["PublicPort"])
             out.append({"id": ct["Id"][:12], "name": (ct.get("Names") or ["/?"])[0].lstrip("/"),
-                        "image": ct.get("Image", ""), "ip": ip})
+                        "image": ct.get("Image", ""), "ip": ip, "ports": sorted(ports)})
         _ct_cache.update(list=out, at=time.time())
     except Exception as e:
         print("docker list error:", e, flush=True)
@@ -210,7 +216,17 @@ def probe_a1111(ip):
     return [(m, None)] if m else []
 
 def probe_comfy(ip):
-    return [("ComfyUI graph", None)] if _http_json(ip, 8188, "/system_stats") is not None else []
+    """ComfyUI: list installed checkpoints from /object_info (real model names). It has no
+    'currently loaded' concept, so checkpoints show Idle and the server's GPU VRAM
+    (nvidia-smi) attributes to the card. Falls back to a sentinel if it's up but bare."""
+    if _http_json(ip, 8188, "/system_stats") is None:
+        return []
+    info = _http_json(ip, 8188, "/object_info/CheckpointLoaderSimple") or {}
+    try:
+        names = info["CheckpointLoaderSimple"]["input"]["required"]["ckpt_name"][0]
+    except Exception:
+        names = []
+    return [(n, None) for n in names] or [("ComfyUI (no checkpoints)", None)]
 
 # (key-substring → probe). The key is matched against the container's image AND name,
 # first match wins, so order specific→generic. Most servers speak the OpenAI
@@ -2087,6 +2103,80 @@ def service_for_pid(pid, nm):
     except Exception:
         return f"pid:{pid}"
 
+# ── Caller attribution ────────────────────────────────────────────────────────
+# "Which service is driving Ollama?" Ollama's API never reveals its callers, so we
+# observe it from the outside: for each container we read its OWN ESTABLISHED sockets
+# (/proc/<pid>/net/tcp[6] — visible because the hub runs as root in the host PID ns)
+# and match the REMOTE port against the ports a model server listens on. A caller
+# reaching a server via host.docker.internal collapses onto the gateway IP, so the
+# port — not the IP — is what identifies the server. Sampled every tick: long-lived
+# LLM streams are caught reliably, sub-second calls (e.g. embeddings) are approximate.
+_cpid_cache = {"at": 0, "map": {}}
+def container_pids(nm):
+    """Map container-name → one representative host PID (any pid shares the netns),
+    by scanning /proc once. Cached briefly; the PID is only used to read net/tcp."""
+    if time.time() - _cpid_cache["at"] < 25 and _cpid_cache["map"]:
+        return _cpid_cache["map"]
+    out = {}
+    try:
+        for pid in os.listdir("/proc"):
+            if not pid.isdigit():
+                continue
+            try:
+                with open(f"/proc/{pid}/cgroup") as f:
+                    h = HEX64.search(f.read())
+            except Exception:
+                continue
+            if h:
+                name = nm.get(h.group(0)[:12])
+                if name and name not in out:
+                    out[name] = pid
+    except Exception:
+        pass
+    _cpid_cache.update(at=time.time(), map=out)
+    return out
+
+def _est_remote_ports(pid):
+    """Remote ports (int) of a pid's ESTABLISHED TCP connections (state 01)."""
+    ports = []
+    for fn in (f"/proc/{pid}/net/tcp", f"/proc/{pid}/net/tcp6"):
+        try:
+            with open(fn) as f:
+                next(f, None)
+                for line in f:
+                    p = line.split()
+                    if len(p) > 3 and p[3] == "01":
+                        try:
+                            ports.append(int(p[2].split(":")[1], 16))
+                        except Exception:
+                            pass
+        except Exception:
+            pass
+    return ports
+
+def sample_callers(conts, ai_names):
+    """{(caller, server): conn_count} for this instant. The hub's own containers are
+    excluded so their probe traffic doesn't masquerade as real model usage."""
+    targets = {}                                    # remote port → server name
+    for c in conts:
+        if c["name"] in ai_names:
+            for p in (c.get("ports") or []):
+                targets.setdefault(p, c["name"])
+    if not targets:
+        return {}
+    nm = {c["id"]: c["name"] for c in conts}
+    selfish = {c["name"] for c in conts
+               if "homelab-monitor" in c["image"].lower() or "gpu-monitor" in c["image"].lower()}
+    edges = {}
+    for name, pid in container_pids(nm).items():
+        if name in selfish:
+            continue
+        for port in _est_remote_ports(pid):
+            srv = targets.get(port)
+            if srv and srv != name:
+                edges[(name, srv)] = edges.get((name, srv), 0) + 1
+    return edges
+
 def sample_once():
     g = smi(["--query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
              "--format=csv,noheader,nounits"]).splitlines()[0].split(",")
@@ -2121,6 +2211,9 @@ def sample_once():
                 else:
                     models.append((svc, mdl, None))         # server up but idle / can't attribute
 
+    # Attribute model-server traffic to its callers (who is driving Ollama, etc.).
+    edges = sample_callers(conts, {c["name"] for c in ai})
+
     host = read_host()
     ts = int(time.time())
     with LOCK:
@@ -2133,13 +2226,17 @@ def sample_once():
         for svc, mdl, vram in models:
             if vram is not None:          # persist only VRAM-bearing rows; idle catalogue
                 DB.execute("INSERT INTO models VALUES(?,?,?,?)", (ts, svc, mdl, vram))  # lives in LATEST only
+        for (caller, server), n in edges.items():
+            DB.execute("INSERT INTO edges VALUES(?,?,?,?)", (ts, caller, server, n))
         if ts % 360 < INTERVAL:
-            for t in ("samples", "proc", "models", "events"):
+            for t in ("samples", "proc", "models", "edges", "events"):
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))
         DB.commit()
     LATEST.update(ts=ts, util=util, mem_used=mem_used, mem_total=mem_total, power=power, temp=temp,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
-                  models=[{"service": s, "model": m, "vram": v} for s, m, v in models], host=host)
+                  models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
+                  callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
+                                 key=lambda x: -x["conns"]), host=host)
 
 def oom_scan():
     targets = ({p["service"] for p in LATEST["procs"]} |
@@ -2257,6 +2354,12 @@ def api_data():
                                 for s, m, pk, av in cur.execute(
                                     "SELECT service,model,MAX(vram),AVG(vram) FROM models WHERE ts>=? AND vram IS NOT NULL "
                                     "GROUP BY service,model", (since,)).fetchall()), key=lambda x: -x["peak"])
+        # Caller attribution: connection-seconds per (caller → server) over the range.
+        # Each sample of `conns` open connections represents INTERVAL seconds of traffic.
+        callers = sorted(({"caller": c, "server": s, "seconds": int((tot or 0) * INTERVAL), "samples": n}
+                          for c, s, tot, n in cur.execute(
+                              "SELECT caller,server,SUM(conns),COUNT(DISTINCT ts) FROM edges WHERE ts>=? "
+                              "GROUP BY caller,server", (since,)).fetchall()), key=lambda x: -x["seconds"])
         evs = [{"ts": t, "service": s, "kind": k, "detail": d}
                for t, s, k, d in cur.execute("SELECT ts,service,kind,detail FROM events WHERE ts>=? ORDER BY ts",
                                               (since,)).fetchall()]
@@ -2271,7 +2374,7 @@ def api_data():
         insights = build_insights(total, services, mem_total, evs, LATEST["host"])
     return jsonify({"version": VERSION, "range": rng, "bucket_sec": bk, "labels": labels, "total": total,
                     "services": services, "other": other, "summary": summary, "model_summary": model_summary,
-                    "events": evs, "insights": insights, "pressure_free_mb": PRESSURE_MB,
+                    "callers": callers, "events": evs, "insights": insights, "pressure_free_mb": PRESSURE_MB,
                     "mem_total": mem_total, "peak_mem": peak, "now": LATEST})
 
 @app.route("/healthz")

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.10.0"
+VERSION      = "0.11.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/scripts/attrib_probe.py
+++ b/scripts/attrib_probe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Prototype: attribute model-server traffic to the calling container.
+
+For every running container we read its OWN socket table (/proc/<pid>/net/tcp[6],
+visible because we run as root in the host PID namespace) and count ESTABLISHED
+connections whose REMOTE port belongs to a recognised model server. A caller
+reaching the server via host.docker.internal hits the published port; a caller on
+the same docker network hits the container's private port — we map both, so either
+wiring is caught. Remote IP is ignored on purpose (host.docker.internal collapses
+every caller onto the gateway IP) — the port is what identifies the server.
+"""
+import json, subprocess, os
+
+AI_KEYS = ("ollama", "vllm", "whisper", "speaches", "localai", "llama.cpp", "llama-server",
+           "koboldcpp", "tabbyapi", "text-generation", "lmstudio", "xinference", "aphrodite",
+           "infinity", "comfyui", "automatic1111", "stable-diffusion", "sd-webui", "invokeai")
+
+def sh(*a):
+    return subprocess.run(a, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout.decode("utf-8", "replace")
+
+def est_remote_ports(pid):
+    """Set of remote ports (int) of this pid's ESTABLISHED TCP connections."""
+    ports = set()
+    for fn in (f"/proc/{pid}/net/tcp", f"/proc/{pid}/net/tcp6"):
+        try:
+            with open(fn) as f:
+                next(f, None)
+                for line in f:
+                    p = line.split()
+                    if len(p) > 3 and p[3] == "01":          # 01 = TCP_ESTABLISHED
+                        ports.add(int(p[2].split(":")[1], 16))  # rem_address = IP:PORT(hex)
+        except Exception:
+            pass
+    return ports
+
+ids = sh("docker", "ps", "-q").split()
+cts = json.loads(sh("docker", "inspect", *ids)) if ids else []
+
+# Build: per container → (name, pid, is_ai, ports it serves). target_port → server name.
+meta, targets = [], {}
+for c in cts:
+    name = c["Name"].lstrip("/")
+    pid = c.get("State", {}).get("Pid") or 0
+    image = (c.get("Config", {}) or {}).get("Image", "").lower()
+    is_ai = any(k in image or k in name.lower() for k in AI_KEYS)
+    pubs, privs = set(), set()
+    for cport, binds in ((c.get("NetworkSettings", {}) or {}).get("Ports") or {}).items():
+        try:
+            privs.add(int(cport.split("/")[0]))
+        except Exception:
+            pass
+        for b in (binds or []):
+            hp = b.get("HostPort")
+            if hp:
+                pubs.add(int(hp))
+    meta.append({"name": name, "pid": pid, "is_ai": is_ai})
+    if is_ai:
+        for p in pubs | privs:
+            targets.setdefault(p, name)
+
+print(f"recognised servers + their ports: "
+      f"{ {targets[p]: [q for q in targets if targets[q]==targets[p]] for p in targets} }\n")
+
+edges = {}
+for m in meta:
+    if not m["pid"]:
+        continue
+    hit = est_remote_ports(m["pid"]) & set(targets)
+    for port in hit:
+        server = targets[port]
+        if server == m["name"]:
+            continue
+        edges[(m["name"], server, port)] = edges.get((m["name"], server, port), 0) + 1
+
+if not edges:
+    print("no caller→server edges at this instant")
+else:
+    print("CALLER".ljust(20), "→  SERVER".ljust(18), "PORT")
+    for (caller, server, port), n in sorted(edges.items()):
+        print(caller.ljust(20), "→ ", server.ljust(16), port)

--- a/scripts/attrib_test.py
+++ b/scripts/attrib_test.py
@@ -1,0 +1,11 @@
+import app, sys
+pid = sys.argv[1] if len(sys.argv) > 1 else None
+if pid:
+    print("ports for pid", pid, ":", sorted(set(app._est_remote_ports(pid))))
+conts = app.containers()
+ai = {c["name"] for c in conts if app._match_probe(c)}
+print("ai servers:", ai)
+nm = {c["id"]: c["name"] for c in conts}
+pm = app.container_pids(nm)
+print("pid map size:", len(pm))
+print("edges:", app.sample_callers(conts, ai))

--- a/scripts/gen.py
+++ b/scripts/gen.py
@@ -1,0 +1,9 @@
+import urllib.request, json
+data = json.dumps({"model": "gemma3:1b",
+                   "prompt": "write an extremely long and detailed essay about the history of the universe",
+                   "stream": True, "keep_alive": 120,
+                   "options": {"num_predict": 6000}}).encode()
+req = urllib.request.Request("http://host.docker.internal:11434/api/generate", data=data)
+r = urllib.request.urlopen(req, timeout=180)
+for _ in r:
+    pass

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -825,16 +825,29 @@ function renderModels(){
         <td>${m.peak!=null?fmtMB(m.peak):'—'}</td>
         <td>${m.avg!=null?fmtMB(m.avg):'—'}</td>
         <td class="vbars"><div class="vbar" title="peak ${m.peak!=null?fmtMB(m.peak):'—'}"><i style="width:${pW}%;background:${c}"></i></div>
-          <div class="vbar" title="avg ${m.avg!=null?fmtMB(m.avg):'—'}"><i style="width:${aW}%;background:${c}99"></i></div></td></tr>`;
+          <div class="vbar" title="avg ${m.avg!=null?fmtMB(m.avg):'—'}"><i style="width:${aW}%;background:${c};opacity:.5"></i></div></td></tr>`;
     }).join('');
     return `<div class="card">
       <h2 style="display:flex;align-items:center;gap:8px;text-transform:none;font-size:13px;color:var(--tx)">
         <span class="dot" style="background:${c}"></span>${esc(svc)}
         <span class="pill" style="margin-left:auto;text-transform:none">resident ${ss.present!=null?ss.present+'%':'—'} · server peak ${ss.peak!=null?fmtMB(ss.peak):'—'}</span></h2>
       ${modelSpark(svc,tot)}
+      ${callersFor(svc)}
       <table style="margin-top:12px"><thead><tr><th>Model</th><th>Status</th><th>Now</th><th>Peak</th><th>Avg</th><th>Peak·Avg</th></tr></thead><tbody>${rows}</tbody></table>
     </div>`;
   }).join('');
+}
+// Caller attribution — "who is driving this server", from connection-seconds (D.callers).
+function callersFor(svc){
+  const all=(D.callers||[]).filter(c=>c.server===svc).sort((a,b)=>b.seconds-a.seconds);
+  if(!all.length) return '';
+  const tot=all.reduce((s,c)=>s+(c.seconds||0),0)||1;
+  const live=new Set(((D.now&&D.now.callers)||[]).filter(c=>c.server===svc).map(c=>c.caller));
+  const chips=all.map(c=>{const pct=Math.round(c.seconds/tot*100), m=Math.round(c.seconds/60);
+    return `<span class="pill" style="text-transform:none" title="${c.seconds}s of connection time over the range${live.has(c.caller)?' · active now':''}">`
+      +`${live.has(c.caller)?'🟢 ':''}${esc(c.caller)} <b>${pct}%</b>${m?` · ${m}m`:''}</span>`;}).join(' ');
+  return `<div class="mspark-cap" style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">`
+    +`<span>Driven by</span> ${chips}</div>`;
 }
 function modelSpark(service,tot){
   const arr=(D.services&&D.services[service])||[];

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -407,7 +407,7 @@ a{color:var(--info)}
 <!-- ───────── AI Models ───────── -->
 <section data-tab="models" hidden>
   <div id="modelsbody"></div>
-  <p class="cap">One panel per model <b>server</b>: its VRAM timeline (shared by the models it hosts) plus each model's own peak &amp; average. Recognised servers: Ollama, vLLM, HF TGI, llama.cpp, Stable Diffusion, ComfyUI.</p>
+  <p class="cap">One panel per model <b>server</b>: its VRAM timeline (shared by the models it hosts) plus each model's own peak &amp; average. A server is shown even while <b>Idle</b> (model unloaded / between requests), so nothing vanishes when VRAM is released. Recognised: Ollama, vLLM, llama.cpp, LocalAI, HF TGI/TEI, faster-whisper/Speaches, koboldcpp, tabbyAPI, text-generation-webui, LM Studio, xinference, Aphrodite, Infinity, Stable Diffusion (A1111/Forge/SD.Next), InvokeAI, ComfyUI.</p>
 </section>
 
 <!-- ───────── Containers ───────── -->
@@ -812,7 +812,7 @@ function renderModels(){
   live.forEach(m=>{const arr=bySvc[m.service]=bySvc[m.service]||[]; if(!arr.some(x=>x.model===m.model)) arr.push({model:m.model,peak:null,avg:null,vram:m.vram});});
   const host=document.getElementById('modelsbody'); if(!host) return;
   const services=Object.keys(bySvc);
-  if(!services.length){ host.innerHTML='<div class="card"><div class="muted">No model server has held the GPU in the selected range.</div></div>'; return; }
+  if(!services.length){ host.innerHTML='<div class="card"><div class="muted">No recognised AI model server is running. Start one (Ollama, vLLM, faster-whisper, Stable Diffusion, …) and it will appear here.</div></div>'; return; }
   const maxV=Math.max(tot||1, ...sums.map(m=>m.peak||0));
   host.innerHTML = services.map(svc=>{
     const ss=svcSum[svc]||{}, c=colorFor(svc);


### PR DESCRIPTION
Promotes v0.11.0 to main: AI Models tab now detects every recognised server (Loaded/Idle, ~20 server types), shows ComfyUI checkpoint names, adds caller attribution ("Driven by"), and fixes the Peak·Avg avg-bar rendering. See #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)