### PR TITLE
docs: CHANGELOG + auto-updating version badge + theme toggle in roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to **HomeLab Monitor** are documented here. The format is
+loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
+project follows semantic-ish versioning. Each entry links to its full GitHub
+release notes.
+
+## [0.12.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.12.0) — 2026-06-02
+- **Container disk that's actually right** — the Containers tab now counts each
+  container's true footprint (writable layer **plus** its volumes & bind mounts;
+  mounts shared between containers are excluded), so heavy containers like Ollama
+  and Immich show their real GB instead of a near-empty writable layer.
+- **AI Models** now recognises **WhisperX / whisper-asr-webservice** and a dozen
+  more servers (SGLang, Triton, Wyoming voice, OpenLLM, LiteLLM, GPUStack,
+  Cortex/Jan, …).
+- Time-range picker now shows on **every** tab.
+- Sidebar brand no longer truncates.
+
+## [0.11.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.11.0) — 2026-05-31
+- **AI Models: detect-all + caller attribution** — every recognised model server
+  is listed (and stays listed as **Idle** when its model unloads), with a
+  **"Driven by"** breakdown showing which services are calling each server.
+
+## [0.10.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.10.0) — 2026-05-31
+- **System / Network / Security tabs** — host inventory (OS, kernel, arch, init
+  system, hardware), per-host network interfaces & listening sockets, and a
+  read-only security posture check (firewall, SSH hardening, SELinux/AppArmor,
+  fail2ban, reboot-pending, auto-updates).
+
+## [0.9.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.9.1) — 2026-05-31
+- Accurate remote CPU temperatures.
+
+## [0.9.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.9.0) — 2026-05-30
+- **Container & Service vital signs** — per-container and per-systemd-unit health,
+  uptime, memory and ports.
+
+## [0.8.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.8.0) — 2026-05-30
+- **Multi-machine monitoring** — register other boxes over SSH from the Hosts tab
+  and see every host's vitals side-by-side. No agents, just SSH + Python 3.
+
+## [0.7.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.7.0) — 2026-05-29
+- **Self-healthcheck** — `/healthz` liveness endpoint + Docker `HEALTHCHECK`.
+
+## [0.6.3](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.6.3) — 2026-05-29
+- Rendered release notes in the in-app update modal.
+
+## [0.6.2](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.6.2) — 2026-05-29
+- Faster recovery from negative update-check results.
+
+## [0.6.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.6.1) — 2026-05-29
+- Branded GitHub star button + contribution nudge.
+
+## [0.6.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.6.0) — 2026-05-29
+- In-UI update notification + favicon.
+
+## [0.5.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.5.0) — 2026-05-28
+- **Alerting (Discord + ntfy.sh)** — edge-triggered push notifications, configured
+  entirely from the Alerts tab.
+
+## [0.4.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.4.1) — 2026-05-26
+- Accurate Prometheus label series.
+
+## [0.4.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.4.0) — 2026-05-26
+- **Prometheus `/metrics` endpoint** — standard scrape endpoint reading from the
+  in-memory snapshot (no extra polling).
+
+## [0.2.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.2.0) — 2026-05-25
+- Local-AI model drill-down, contention intelligence & host health.
+
+---
+
+_Older tags exist in the repository history. For the authoritative, complete
+notes of any release see the
+[GitHub releases page](https://github.com/SikamikanikoBG/homelab-monitor/releases)._

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Unique cloners (14d)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSikamikanikoBG%2Fhomelab-monitor%2Fstats%2Fclones-unique.json&style=social&logo=git&cacheSeconds=300)](https://github.com/SikamikanikoBG/homelab-monitor)
 
 [![website](https://img.shields.io/badge/docs-sikamikanikobg.github.io%2Fhomelab--monitor-d29922?logo=readthedocs&logoColor=white)](https://sikamikanikobg.github.io/homelab-monitor/)
-![version](https://img.shields.io/badge/version-0.10.0-blue)
+[![version](https://img.shields.io/github/v/release/SikamikanikoBG/homelab-monitor?color=blue&label=version)](https://github.com/SikamikanikoBG/homelab-monitor/blob/main/CHANGELOG.md)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
 ![gpu](https://img.shields.io/badge/GPU-NVIDIA-76B900?logo=nvidia&logoColor=white)
@@ -14,7 +14,7 @@
 
 > 🆕 **v0.12.0** — **Container disk that's actually right**: the Containers tab now counts each container's true footprint — writable layer **plus its volumes & bind mounts** (mounts shared between containers are excluded), so Ollama and Immich finally show their real GBs instead of a near-empty writable layer. Plus **AI Models** now recognises **WhisperX / whisper-asr-webservice** and a dozen more servers (SGLang, Triton, Wyoming voice, OpenLLM, LiteLLM, GPUStack, Cortex/Jan…), the **time-range picker shows on every tab**, and the sidebar brand no longer truncates. [Release notes →](https://github.com/SikamikanikoBG/homelab-monitor/releases)
 >
-> 🛰️ **Source, issues and roadmap live on [GitHub](https://github.com/SikamikanikoBG/homelab-monitor).** If HomeLab Monitor saves you a browser tab, a ⭐ there genuinely helps other home-labbers find it.
+> 🛰️ **Source, issues and roadmap live on [GitHub](https://github.com/SikamikanikoBG/homelab-monitor).** See the [full changelog](CHANGELOG.md) for what changed in every release. If HomeLab Monitor saves you a browser tab, a ⭐ there genuinely helps other home-labbers find it.
 
 A small, friendly dashboard for a self-hosted home lab. One container gives you a
 single page that answers the everyday questions: **is the GPU busy and which model
@@ -359,6 +359,7 @@ disk usage, and model VRAM in a single view.
 
 A few things that would be nice to add next (PRs very welcome):
 
+- [Light/dark theme toggle](https://github.com/SikamikanikoBG/homelab-monitor/issues/10) (good first issue)
 - Per-model VRAM history timeline
 - Multi-GPU layouts
 - Telegram alerting (Discord + ntfy already supported — see **Alerts** tab)


### PR DESCRIPTION
Discoverability / funnel improvements surfaced by the daily intelligence digest (2026-06-02). These are doc-only — no app code touched.

## What changed
- **`CHANGELOG.md` (new)** — Keep-a-Changelog-style file with one entry per release (v0.2.0 → v0.12.0), each linking to its full GitHub release notes. Linked from the README header.
- **Auto-updating version badge** — the header badge was hardcoded at `0.10.0` (stale; we're on 0.12.0). Replaced with a shields `github/v/release` badge that tracks the latest release automatically and links to the changelog. No more manual bumps.
- **Roadmap** — surfaced [#10 Light/dark theme toggle](https://github.com/SikamikanikoBG/homelab-monitor/issues/10) (the highest-traffic open issue, a good-first-issue) so curious visitors have a visible payoff path.

## Why
The digest flagged that release notes (`/releases` got 3 views) and the changelog story are invisible to returning visitors, and that the version badge had gone stale. A maintained changelog + active-development signal is a strong star trigger for utility repos.

## Not included (deliberately)
- "Lead with Docker over git clone" and "embed the demo gif inline" — **already done** on `main`.
- Docker Hub listing mirror — handled separately (it's the live Hub overview, not a repo file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)