### PR TITLE
feat(updates): per-host OS/kernel update availability + fleet badge

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the build context tiny and avoid stat-ing runtime/data dirs that may be
+# root-owned (e.g. a dev bind-mount's ./data-dev), which breaks `docker build`.
+.git
+__pycache__/
+*.pyc
+data/
+data-dev/
+*.bak
+docker-compose*.yml

--- a/app.py
+++ b/app.py
@@ -41,6 +41,11 @@ HOST_ROOT    = os.environ.get("HOST_ROOT", "/rootfs")          # host / mounted 
 PORT         = int(os.environ.get("PORT", "9800"))
 PRESSURE_MB  = int(os.environ.get("PRESSURE_FREE_MB", "2048"))
 CHECK_UPDATES = os.environ.get("CHECK_UPDATES", "true").strip().lower() not in ("0", "false", "no", "off")
+# Per-host "a newer OS release exists" check. The probe reads pending *package*
+# updates offline; detecting a whole new distro release needs the network, so the
+# hub does it centrally (endoflife.date). Air-gapped users can switch off just
+# this network lookup and keep the offline package counts.
+CHECK_OS_UPDATES = os.environ.get("CHECK_OS_UPDATES", "true").strip().lower() not in ("0", "false", "no", "off")
 UPDATE_REPO   = os.environ.get("UPDATE_REPO", "SikamikanikoBG/homelab-monitor")
 # Split cache: once we know there's an update, the answer won't change for hours
 # so we can cache it long. But "no update found" / network errors should expire
@@ -856,6 +861,30 @@ def _auto_updates_local():
             return m.group(1) != "0"
     return None
 
+def _updates_local():
+    """Pending updates for the hub's own host. We only trust the pre-rendered
+    update-notifier file (read through HOST_ROOT) — running a package manager
+    here would query the *container*, not the host, so on non-apt hosts (or
+    without the file) we return None and the UI shows 'needs elevated read'. The
+    hub's network-side new-release check still works from os.version_id."""
+    txt = _rt(_hp("/var/lib/update-notifier/updates-available"))
+    if not txt:
+        return None
+    out = {"count": None, "security": None, "kernel": None,
+           "source": "apt", "checked": "cached"}
+    # Same line-by-line parse as the probe: the security line gives the security
+    # count, the first other count-bearing line gives the total (wording varies).
+    for line in txt.splitlines():
+        m = re.search(r"(\d+)", line)
+        if not m:
+            continue
+        n, low = int(m.group(1)), line.lower()
+        if "securit" in low:
+            out["security"] = n
+        elif out["count"] is None and ("update" in low or "package" in low or "can be" in low):
+            out["count"] = n
+    return out
+
 def _local_sec():
     return {
         "firewall":        _local_firewall(),
@@ -865,6 +894,7 @@ def _local_sec():
         "fail2ban":        _fail2ban_local(),
         "reboot_required": _reboot_local(),
         "auto_updates":    _auto_updates_local(),
+        "updates":         _updates_local(),
     }
 
 # ── Health monitors: Docker containers + systemd services ──────────────────────
@@ -1391,10 +1421,160 @@ def collect_update():
         _UPDATE_CACHE.update({"at": now, "data": data})
     return data
 
+# ── Newer-OS-release check (endoflife.date) ───────────────────────────────────
+# The probe reports each host's pending *package* updates offline. Detecting that
+# a whole new distro release exists needs to know the latest upstream version, so
+# the hub fetches it once per distro from endoflife.date and caches it (same split
+# TTL as the app-update check). os_upgrade_for() then compares a host's
+# version_id against the newest cycle — pure cache read, no network at serve time.
+# Degrades silently on any error so an offline hub never lights up the UI red.
+
+# os-release ID → endoflife.date product slug. Rolling distros (arch, gentoo,
+# nixos, tumbleweed, void) have no fixed release to be "behind" → intentionally
+# absent so they're skipped.
+# Verified against endoflife.date's /api/<slug>.json (slugs are not always the
+# obvious os-release ID — Leap is "opensuse", Rocky is "rocky-linux").
+_EOL_SLUG = {
+    "ubuntu": "ubuntu", "pop": "ubuntu", "neon": "ubuntu", "elementary": "ubuntu",
+    "debian": "debian", "raspbian": "debian",
+    "linuxmint": "linuxmint",
+    "opensuse-leap": "opensuse", "opensuse": "opensuse", "sles": "sles",
+    "fedora": "fedora",
+    "almalinux": "almalinux", "rocky": "rocky-linux", "rhel": "rhel",
+    "centos": "centos",
+    "amzn": "amazon-linux", "alpine": "alpine",
+}
+_DISTRO_NAME = {
+    "ubuntu": "Ubuntu", "debian": "Debian", "linuxmint": "Linux Mint",
+    "opensuse": "openSUSE Leap", "sles": "SLES", "fedora": "Fedora",
+    "almalinux": "AlmaLinux", "rocky-linux": "Rocky Linux", "rhel": "RHEL",
+    "centos": "CentOS", "amazon-linux": "Amazon Linux", "alpine": "Alpine",
+}
+_OS_REL_CACHE = {}        # slug -> {"at": ts, "cycles": [str, ...] | None}
+_OS_REL_LOCK  = threading.Lock()
+
+def _fetch_eol_cycles(slug):
+    """Fetch the list of release cycles for one distro from endoflife.date.
+    Returns a list of cycle strings (e.g. ['15.6','15.5',...]) or None on error."""
+    try:
+        req = urllib.request.Request(
+            f"https://endoflife.date/api/{slug}.json",
+            headers={"Accept": "application/json",
+                     "User-Agent": f"homelab-monitor/{VERSION}"})
+        with urllib.request.urlopen(req, timeout=8) as r:
+            payload = json.loads(r.read())
+        return [str(c.get("cycle")) for c in payload if c.get("cycle") is not None]
+    except Exception:
+        return None
+
+def collect_os_releases():
+    """Refresh the endoflife cache for every distro present in the fleet. Cheap:
+    only fetches slugs whose cache entry is stale, and only ones we actually have
+    a host for. Called from health_scan(); never raises out."""
+    if not CHECK_OS_UPDATES:
+        return
+    slugs = set()
+    for _name, host in _iter_fleet_hosts():
+        osid = ((host or {}).get("os") or {}).get("id")
+        slug = _EOL_SLUG.get((osid or "").lower())
+        if slug:
+            slugs.add(slug)
+    now = int(time.time())
+    for slug in slugs:
+        with _OS_REL_LOCK:
+            ent = _OS_REL_CACHE.get(slug)
+            if ent:
+                ttl = UPDATE_TTL_POSITIVE if ent.get("cycles") else UPDATE_TTL_NEGATIVE
+                if (now - ent["at"]) < ttl:
+                    continue
+        cycles = _fetch_eol_cycles(slug)
+        with _OS_REL_LOCK:
+            _OS_REL_CACHE[slug] = {"at": now, "cycles": cycles}
+
+def os_upgrade_for(os_id, version_id):
+    """Compare a host's distro version against the newest known cycle (cache only,
+    no network). Returns {"new_release": {current, candidate, label}} when a newer
+    release exists, else None.
+
+    endoflife.date returns cycles newest-first, so we locate the host's own cycle
+    in that list and flag it behind only when newer cycles sit before it. We rely
+    on list order rather than numeric comparison because some distros renumber
+    (openSUSE Leap went 42.x → 15.x), which would fool a plain version compare."""
+    if not CHECK_OS_UPDATES or not os_id or not version_id:
+        return None
+    slug = _EOL_SLUG.get(os_id.lower())
+    if not slug:
+        return None
+    with _OS_REL_LOCK:
+        ent = _OS_REL_CACHE.get(slug)
+    cycles = (ent or {}).get("cycles")
+    if not cycles:
+        return None
+    try:
+        idx = None
+        if version_id in cycles:
+            idx = cycles.index(version_id)
+        else:                                   # host "12.5" → match cycle "12"
+            major = version_id.split(".")[0]
+            if major in cycles:
+                idx = cycles.index(major)
+        if idx is not None and idx > 0:         # newer cycles listed before it
+            candidate = cycles[0]
+            name = _DISTRO_NAME.get(slug, slug)
+            return {"new_release": {"current": version_id, "candidate": candidate,
+                                    "label": f"{name} {candidate}"}}
+    except Exception:
+        return None
+    return None
+
+def enrich_os_upgrade(host):
+    """Attach (or clear) host['os_upgrade'] from the cached endoflife data. We
+    mutate the dict in place — and it's a shared cached snapshot — so we must also
+    drop a stale key once a host is no longer behind. Returns the same dict."""
+    if host is not None:
+        os_ = host.get("os") or {}
+        up = os_upgrade_for(os_.get("id"), os_.get("version_id"))
+        if up:
+            host["os_upgrade"] = up
+        else:
+            host.pop("os_upgrade", None)
+    return host
+
+def _iter_fleet_hosts():
+    """Yield (name, host_block) for the hub itself plus every remote with data.
+    Used by both the endoflife refresh and the /api/health fleet update summary."""
+    yield "local", _local_now_snapshot()
+    with HOST_DATA_LOCK:
+        items = list(HOST_DATA.items())
+    for name, entry in items:
+        host = (entry.get("data") or {}).get("host")
+        if host:
+            yield name, host
+
+def os_updates_summary():
+    """Fleet-wide roll-up that drives the header badge: how many hosts are behind,
+    total pending updates, security count, and which hosts have a newer release."""
+    hosts_behind = total = security = 0
+    new_release = []
+    for name, host in _iter_fleet_hosts():
+        upd = ((host or {}).get("sec") or {}).get("updates") or {}
+        cnt = upd.get("count") or 0
+        sec = upd.get("security") or 0
+        rel = (enrich_os_upgrade(host) or {}).get("os_upgrade", {}).get("new_release")
+        total += cnt
+        security += sec
+        if cnt > 0 or rel:
+            hosts_behind += 1
+        if rel:
+            new_release.append({"host": name, "label": rel.get("label")})
+    return {"hosts_behind": hosts_behind, "total_updates": total,
+            "security": security, "new_release": new_release}
+
 def health_scan():
     HEALTH["docker"]  = collect_docker()
     HEALTH["systemd"] = collect_systemd()
     HEALTH["update"]  = collect_update()
+    collect_os_releases()
     HEALTH["at"]      = int(time.time())
 
 # ── Settings (UI-managed; persisted in SQLite, no env required) ───────────────
@@ -2582,7 +2762,7 @@ def api_health():
     now = {"gpu": {"util": LATEST["util"], "mem_used": LATEST["mem_used"],
                    "mem_total": LATEST["mem_total"] or 24576, "power": LATEST["power"],
                    "temp": LATEST["temp"]},
-           "host": LATEST["host"]}
+           "host": enrich_os_upgrade(LATEST["host"])}
     docker  = HEALTH["docker"]  or {"available": False, "reason": "warming up…",
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}
     systemd = HEALTH["systemd"] or {"available": False, "reason": "warming up…",
@@ -2590,6 +2770,7 @@ def api_health():
     update  = HEALTH["update"]  or {"available": False, "current": VERSION}
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd, "update": update,
+                    "os_updates": os_updates_summary(),
                     "overview": build_overview(now, docker, systemd)})
 
 @app.route("/metrics")
@@ -2698,7 +2879,7 @@ def api_host_data(name):
     """Per-host metric snapshot. `local` is the hub itself; remotes are served
     from the in-memory cache populated by host_poller()."""
     if name == "local":
-        return jsonify({"name": "local", "host": _local_now_snapshot(),
+        return jsonify({"name": "local", "host": enrich_os_upgrade(_local_now_snapshot()),
                         "at": int(time.time()), "online": True})
     with HOST_DATA_LOCK:
         entry = HOST_DATA.get(name)
@@ -2710,7 +2891,7 @@ def api_host_data(name):
                         "at": (entry or {}).get("at"),
                         "host": None})
     age = int(time.time()) - int(entry["at"])
-    return jsonify({"name": name, "host": entry["data"].get("host", {}),
+    return jsonify({"name": name, "host": enrich_os_upgrade(entry["data"].get("host", {})),
                     "at": entry["at"], "online": age < INTERVAL * 3,
                     "stale_for": age if age >= INTERVAL * 3 else 0,
                     "error": entry.get("error")})
@@ -2725,7 +2906,7 @@ def api_fleet():
 
     # Local row
     rows.append({"name": "local", "label": socket.gethostname() + " (this hub)",
-                 "ssh_target": None, "host": _local_now_snapshot(),
+                 "ssh_target": None, "host": enrich_os_upgrade(_local_now_snapshot()),
                  "at": int(time.time()), "online": True, "is_local": True,
                  "last_check": {"summary": {"overall": "ok"}}})
 
@@ -2739,7 +2920,7 @@ def api_fleet():
                 "name": h["name"],
                 "label": h["name"],
                 "ssh_target": h["ssh_target"],
-                "host": data.get("host") if data else None,
+                "host": enrich_os_upgrade(data.get("host")) if data else None,
                 "at": at,
                 "online": online,
                 "is_local": False,

--- a/probe.py
+++ b/probe.py
@@ -896,6 +896,149 @@ def _auto_updates():
     return None
 
 
+# ── Pending package updates ───────────────────────────────────────────────────
+# Strictly cached / offline: we read what the host's package manager already
+# computed (its daily timer), never triggering a network refresh and never
+# assuming root. Each reader returns {count, security, kernel, source}; any field
+# we can't determine stays None so the UI shows a neutral "needs elevated read"
+# instead of a misleading zero. The hub adds the "newer OS release available"
+# signal separately (it needs the network, which the probe deliberately avoids).
+
+def _parse_updates_file(txt):
+    """Parse update-notifier's pre-rendered text. Its wording varies across
+    releases ('N updates can be applied immediately.' / 'M of these updates are
+    standard security updates.'), so we go line-by-line: the line that mentions
+    security gives the security count, the first other count-bearing line gives
+    the total. Returns (count, security), either possibly None."""
+    count = security = None
+    for line in txt.splitlines():
+        m = re.search(r"(\d+)", line)
+        if not m:
+            continue
+        n, low = int(m.group(1)), line.lower()
+        if "securit" in low:
+            security = n
+        elif count is None and ("update" in low or "package" in low or "can be" in low):
+            count = n
+    return count, security
+
+
+def _apt_updates():
+    out = {"count": None, "security": None, "kernel": None, "source": "apt"}
+    # update-notifier pre-renders the counts (with the security split) into a file
+    # any user can read — no apt invocation, no lock, no refresh.
+    txt = _read_text("/var/lib/update-notifier/updates-available")
+    if txt:
+        out["count"], out["security"] = _parse_updates_file(txt)
+    # If the file was missing (no update-notifier) or we still need the kernel
+    # signal it can't give, fall back to the cached upgradable list. `apt list
+    # --upgradable` reads only the on-disk lists — it does not hit the network.
+    if out["count"] is None or out["kernel"] is None:
+        rc, txt2 = _run(["apt", "list", "--upgradable"], timeout=6)
+        if rc is not None and txt2:
+            pkgs = [l for l in txt2.splitlines()
+                    if "/" in l.split(" ", 1)[0] and "]" in l]
+            if out["count"] is None:
+                out["count"] = len(pkgs)
+            if out["security"] is None:
+                out["security"] = sum(1 for l in pkgs if "-security" in l.lower())
+            out["kernel"] = any(l.split("/", 1)[0].startswith(("linux-image", "linux-generic"))
+                                for l in pkgs)
+    return out
+
+
+def _zypper_updates():
+    out = {"count": None, "security": None, "kernel": None, "source": "zypper"}
+    # --no-refresh keeps it offline; status column 'v' marks an available update.
+    rc, txt = _run(["zypper", "--non-interactive", "--no-refresh", "--quiet",
+                    "list-updates"], timeout=8)
+    if rc is not None and txt:
+        names = []
+        for l in txt.splitlines():
+            parts = [p.strip() for p in l.split("|")]
+            if len(parts) >= 3 and parts[0] == "v":
+                names.append(parts[2])
+        if names or "No updates found" in txt:
+            out["count"] = len(names)
+            out["kernel"] = any(n.startswith("kernel-") for n in names)
+    rc2, txt2 = _run(["zypper", "--non-interactive", "--no-refresh", "--quiet",
+                      "list-patches", "--category", "security"], timeout=8)
+    if rc2 is not None and txt2:
+        out["security"] = sum(1 for l in txt2.splitlines()
+                              if "security" in l.lower() and "|" in l)
+    return out
+
+
+def _dnf_updates():
+    out = {"count": None, "security": None, "kernel": None, "source": "dnf"}
+    bin_ = "dnf" if _which("dnf") else "yum"
+    # -C = cache-only (no network). rc 100 = updates available, 0 = none.
+    rc, txt = _run([bin_, "-C", "-q", "check-update"], timeout=10)
+    if rc in (0, 100):
+        names = []
+        for l in txt.splitlines():
+            l = l.strip()
+            if not l or l.startswith(("Obsoleting", "Last metadata", "Security:")):
+                continue
+            parts = l.split()
+            if len(parts) >= 3 and "." in parts[0]:   # name.arch  version  repo
+                names.append(parts[0])
+        out["count"] = len(names)
+        out["kernel"] = any(n.startswith("kernel") for n in names)
+    rc2, txt2 = _run([bin_, "-C", "-q", "updateinfo", "list", "security"], timeout=10)
+    if rc2 == 0 and txt2:
+        out["security"] = sum(1 for l in txt2.splitlines() if l.strip())
+    return out
+
+
+def _pacman_updates():
+    out = {"count": None, "security": None, "kernel": None, "source": "pacman"}
+    # `pacman -Qu` compares against the cached sync DB — no refresh. Arch has no
+    # security categorisation, so `security` stays None by design.
+    rc, txt = _run(["pacman", "-Qu"], timeout=6)
+    if rc is not None:
+        names = [l.split()[0] for l in txt.splitlines() if l.strip()]
+        out["count"] = len(names)
+        out["kernel"] = any(n.startswith("linux") for n in names)
+    return out
+
+
+def _apk_updates():
+    out = {"count": None, "security": None, "kernel": None, "source": "apk"}
+    rc, txt = _run(["apk", "version", "-l", "<"], timeout=6)
+    if rc is not None and txt:
+        names = []
+        for l in txt.splitlines():
+            l = l.strip()
+            if not l or l.startswith(("Installed", "WARNING")):
+                continue
+            names.append(l.split()[0])
+        out["count"] = len(names)
+        out["kernel"] = any(n.startswith("linux-") for n in names)
+    return out
+
+
+def read_updates():
+    try:
+        if _which("apt") or _which("apt-get"):
+            res = _apt_updates()
+        elif _which("zypper"):
+            res = _zypper_updates()
+        elif _which("dnf") or _which("yum"):
+            res = _dnf_updates()
+        elif _which("pacman"):
+            res = _pacman_updates()
+        elif _which("apk"):
+            res = _apk_updates()
+        else:
+            return None
+    except Exception:
+        return None
+    if res is not None:
+        res["checked"] = "cached"
+    return res
+
+
 def read_sec():
     return {"sec": {
         "firewall":        _firewall(),
@@ -905,6 +1048,7 @@ def read_sec():
         "fail2ban":        _fail2ban(),
         "reboot_required": _reboot_required(),
         "auto_updates":    _auto_updates(),
+        "updates":         read_updates(),
     }}
 
 
@@ -926,7 +1070,7 @@ def main():
             "hostname": socket.gethostname(),
         },
         "at": int(time.time()),
-        "probe_version": "0.6",
+        "probe_version": "0.7",
     }
     json.dump(data, sys.stdout, separators=(",", ":"))
     sys.stdout.write("\n")

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -104,6 +104,13 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .upd{display:none;align-items:center;gap:5px;font-size:12px;color:var(--info);text-decoration:none;border:1px solid #58a6ff55;border-radius:20px;padding:2px 10px;background:#58a6ff11;cursor:pointer;font:inherit}
 .upd:hover{border-color:var(--info)}
 .upd.show{display:inline-flex}
+/* OS/kernel-updates badge — amber to distinguish from the blue app-update one */
+.upd.osupd{color:var(--warn);border-color:#d2992255;background:#d2992211}
+.upd.osupd:hover{border-color:var(--warn)}
+.oslist{list-style:none;margin:8px 0 0;padding:0}
+.oslist li{display:flex;justify-content:space-between;gap:12px;padding:8px 10px;border:1px solid var(--bd);border-radius:8px;background:#0d1117;margin-top:6px;font-size:13px}
+.oslist .hn{font-weight:600;color:var(--tx)}
+.oslist .meta{color:var(--mut);text-align:right}
 .umodal{position:fixed;inset:0;background:#0008;display:none;align-items:center;justify-content:center;z-index:50;padding:18px}
 .umodal.show{display:flex}
 .umodal .box{background:var(--card);border:1px solid var(--bd);border-radius:12px;max-width:640px;width:100%;max-height:84vh;display:flex;flex-direction:column}
@@ -340,6 +347,7 @@ a{color:var(--info)}
 </style></head><body><div class="app"><aside class="side" id="sidebar"></aside><main class="main"><div class="topbar" id="topbar"></div><div class="content">
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
+<button type="button" class="upd osupd" id="osupdbadge" title="One or more machines have OS/kernel updates pending — click for details">⬆ <span id="osupdtext">updates</span></button>
 <a class="ghstar" id="ghstar" href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub">
 <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 <span id="ghlabel">Star</span> <span class="cnt" id="ghcount"></span></a>
@@ -375,11 +383,11 @@ a{color:var(--info)}
       <table class="fleet-tbl" id="fleet_tbl">
         <thead>
           <tr>
-            <th>Host</th><th>Status</th><th>OS / Arch</th><th>CPU</th><th>RAM</th><th>GPU</th>
+            <th>Host</th><th>Status</th><th>OS / Arch</th><th>Updates</th><th>CPU</th><th>RAM</th><th>GPU</th>
             <th>Load 1m</th><th>Uptime</th><th>Temp</th><th>Disks</th>
           </tr>
         </thead>
-        <tbody><tr><td colspan="10" class="muted" style="padding:14px">Loading fleet…</td></tr></tbody>
+        <tbody><tr><td colspan="11" class="muted" style="padding:14px">Loading fleet…</td></tr></tbody>
       </table>
     </div>
   </div>
@@ -589,6 +597,21 @@ GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker A
     </div>
   </div>
 </div>
+
+<!-- ───────── OS-updates modal ───────── -->
+<div class="umodal" id="osupdmodal" role="dialog" aria-modal="true" aria-labelledby="osupdtitle">
+  <div class="box">
+    <div class="hd">
+      <strong id="osupdtitle">OS updates available</strong>
+      <button class="x" type="button" id="osupdclose" aria-label="Close">×</button>
+    </div>
+    <div class="bd">
+      <div class="muted" id="osupdsummary"></div>
+      <ul class="oslist" id="osupdlist"></ul>
+      <div class="muted" style="margin-top:12px;font-size:12px">Counts are read from each host's package manager (cached, no refresh). Click a host row in the All-hosts table to see its full Security tab.</div>
+    </div>
+  </div>
+</div>
 <script>
 // ── Tab registry. Add a monitor: append one entry here + a matching <section
 //    data-tab="..."> above + a render in renderData()/renderHealth(). ──────────
@@ -658,6 +681,7 @@ function mountShell(){
   const hb = document.getElementById('hostbar'); if(hb) tb.appendChild(hb);
   const ctr = document.getElementById('controls'); if(ctr) tb.appendChild(ctr);
   const upd = document.getElementById('updbadge'); if(upd) tb.appendChild(upd);
+  const osupd = document.getElementById('osupdbadge'); if(osupd) tb.appendChild(osupd);
   const live = document.querySelector('header .live'); if(live) tb.appendChild(live);
   const foot = document.getElementById('foot');
   const star = document.getElementById('ghstar'); if(star) foot.appendChild(star);
@@ -882,6 +906,22 @@ function renderHealth(){
     ub.classList.remove('show');
   }
 
+  // OS/kernel-updates badge — visible when any machine in the fleet is behind on
+  // packages or has a newer distro release available.
+  const osu = HH.os_updates || {};
+  const osb = document.getElementById('osupdbadge');
+  if(osb){
+    if(osu.hosts_behind > 0){
+      const sec = osu.security ? ` · ${osu.security} security` : '';
+      document.getElementById('osupdtext').textContent =
+        `${osu.hosts_behind} host${osu.hosts_behind===1?'':'s'} behind${sec}`;
+      osb.classList.add('show');
+      osb.onclick = () => openOsUpdateModal(osu);
+    } else {
+      osb.classList.remove('show');
+    }
+  }
+
   // Overview status cards used to live here too — same guard as #insights.
   const ovEl = document.getElementById('ovcards');
   if(ovEl){
@@ -993,6 +1033,29 @@ function openUpdateModal(up){
   document.getElementById('updmodal').classList.add('show');
 }
 function closeUpdateModal(){ document.getElementById('updmodal').classList.remove('show'); }
+
+// ── OS-updates modal ──────────────────────────────────────────────────────────
+function openOsUpdateModal(osu){
+  const parts = [];
+  if(osu.total_updates)  parts.push(`${osu.total_updates} package update${osu.total_updates===1?'':'s'} pending`);
+  if(osu.security)       parts.push(`${osu.security} security`);
+  if((osu.new_release||[]).length) parts.push(`${osu.new_release.length} new OS release${osu.new_release.length===1?'':'s'}`);
+  document.getElementById('osupdsummary').textContent =
+    `${osu.hosts_behind} machine${osu.hosts_behind===1?'':'s'} behind` + (parts.length ? ' — ' + parts.join(' · ') : '') + '.';
+  // The /api/health summary only carries the new-release labels per host; the
+  // per-package counts live on each host's Security tab, so we list the
+  // new-release machines here and point at the table for the rest.
+  const byHost = {};
+  (osu.new_release||[]).forEach(r => { byHost[r.host] = r.label; });
+  const names = Object.keys(byHost);
+  const list = document.getElementById('osupdlist');
+  list.innerHTML = names.length
+    ? names.map(n => `<li><span class="hn">${esc(n==='local'?'this hub':n)}</span>`
+        + `<span class="meta">⬆ ${esc(byHost[n])} available</span></li>`).join('')
+    : '<li><span class="meta">Package updates pending — open a host\'s Security tab for the per-host counts.</span></li>';
+  document.getElementById('osupdmodal').classList.add('show');
+}
+function closeOsUpdateModal(){ document.getElementById('osupdmodal').classList.remove('show'); }
 
 // ── Charts (only built for the visible tab) ───────────────────────────────────
 function buildCharts(){
@@ -1570,10 +1633,20 @@ function renderFleet(){
       ? `<span class="pct" style="font-weight:500">${esc(osname)}</span>` +
         (os.arch ? `<span class="abs">${esc(os.arch)}</span>` : '')
       : '<span class="muted">—</span>';
+    // Updates: pending package count (+ security/kernel) and any newer OS release.
+    const u = (h.sec||{}).updates, orel = (h.os_upgrade||{}).new_release, ufr = [];
+    if(u && u.count!=null){
+      if(u.count===0) ufr.push('<span class="pct" style="color:var(--ok)">✓</span><span class="abs">up to date</span>');
+      else ufr.push(`<span class="pct" style="color:${u.security?'var(--crit)':'var(--warn)'};font-weight:600">${u.count}</span>` +
+        `<span class="abs">${u.security?u.security+' sec':'pending'}${u.kernel?' · kernel':''}</span>`);
+    }
+    if(orel) ufr.push(`<span class="abs" style="color:var(--warn)">⬆ ${esc(orel.candidate)} available</span>`);
+    const updc = ufr.length ? ufr.join('') : '<span class="muted">—</span>';
     return `<tr data-h="${esc(r.name)}">
       <td class="hostcell">${esc(r.label||r.name)}<span class="sub">${esc(subline)}</span></td>
       <td><span class="status ${st}"><span class="d"></span>${st}</span>${stale}</td>
       <td>${osc}</td>
+      <td>${updc}</td>
       <td>${cpu}</td>
       <td>${ram}</td>
       <td>${gpu}</td>
@@ -1804,6 +1877,22 @@ async function renderSecurity(){
   if(au==null)                add('Auto-updates','info','unknown');
   else                        add('Auto-updates', au?'ok':'warn', au?'enabled':'disabled');
 
+  // Pending package updates (counts the host's package manager already computed —
+  // cached, no refresh). null ⇒ couldn't read; 0 ⇒ up to date; >0 ⇒ behind.
+  const upd = sec.updates;
+  if(upd==null || upd.count==null) add('Updates available','info','needs elevated read / unknown');
+  else if(upd.count===0)           add('Updates available','ok','up to date');
+  else {
+    const bits = [`${upd.count} update${upd.count===1?'':'s'} pending`];
+    if(upd.security)             bits.push(`${upd.security} security`);
+    if(upd.kernel)               bits.push('kernel update pending');
+    add('Updates available', upd.security ? 'crit' : 'warn', bits.join(' · '));
+  }
+
+  // Newer OS release (hub-side check via endoflife.date; attached to the host block).
+  const nr = (currentHostBlock().os_upgrade||{}).new_release;
+  if(nr) add('New OS release','warn', `${esc(nr.label)} available — you're on ${esc(nr.current)}`);
+
   // Exposed ports (derived from the network listen list)
   const uniq = [...new Set(((currentHostBlock().net||{}).listen||[]).filter(s=>s.exposed).map(s=>s.port))].sort((a,b)=>a-b);
   if(uniq.length){
@@ -1944,7 +2033,9 @@ document.getElementById('pubkey_show_cmd').onclick = () => {
 // Update modal: close via × button, Escape, or backdrop click; copy command to clipboard.
 document.getElementById('updclose').onclick = closeUpdateModal;
 document.getElementById('updmodal').addEventListener('click', e => { if(e.target.id==='updmodal') closeUpdateModal(); });
-document.addEventListener('keydown', e => { if(e.key==='Escape') closeUpdateModal(); });
+document.getElementById('osupdclose').onclick = closeOsUpdateModal;
+document.getElementById('osupdmodal').addEventListener('click', e => { if(e.target.id==='osupdmodal') closeOsUpdateModal(); });
+document.addEventListener('keydown', e => { if(e.key==='Escape'){ closeUpdateModal(); closeOsUpdateModal(); } });
 document.getElementById('updcopy').onclick = async () => {
   const b = document.getElementById('updcopy'), t = b.textContent;
   const ok = await copyText(document.getElementById('updcmd').textContent);


### PR DESCRIPTION
## What & why
The Security tab showed current kernel, `reboot_required` and whether auto-updates are *configured* — but never the thing that actually prompts action: **"this machine is behind."** This adds it.

Per host:
- **Pending package updates** — count, security split, and a kernel-update-pending flag.
- **Newer OS release** — best-effort "a whole new distro version is out" (e.g. *openSUSE Leap 16.0 available, you're on 15.6*).

Surfaced as **Security-tab rows**, an **"Updates" column** in the All-hosts table, and an amber **fleet header badge** (mirrors the existing app-self-update badge) with a modal.

## Design
Split by who can do the work cheaply:
- **Probe (offline):** `read_updates()` reads counts the host's own package manager already computed — **cached only, no refresh, no network, no sudo** (apt/zypper/dnf/pacman/apk). Unknown fields stay `null` → UI shows "needs elevated read", never a misleading zero. `probe_version` 0.6 → 0.7.
- **Hub (network, cached):** new-release detection needs the latest upstream version, so the hub does it centrally — `collect_os_releases()` fetches **endoflife.date** per distro in the fleet and caches it exactly like `collect_update()`. `os_upgrade_for()` compares the host's `version_id` using **list order** (robust to openSUSE Leap's 42.x→15.x renumber). Gated by `CHECK_OS_UPDATES` (default on) for air-gapped hubs.

Enrichment is attached at serve time to `/api/host_data`, `/api/fleet` and `/api/health` (which gains an `os_updates` fleet summary).

## Verified on the live fleet (dev, :9801)
- **ardi (Leap 15.6):** → *openSUSE Leap 16.0 available* ✓
- **cloudy (Ubuntu):** apt offline path → *49 updates pending* + *Ubuntu 26.04 available* ✓
- **oldie (offline):** graceful `null`, no false signal ✓
- Dashboard serves 200 with the new rows/badge/modal; JS syntax-checked.

Also adds a `.dockerignore` (the build context was walking a root-owned dev `data-dev/.ssh` and failing).

## Not in this PR
Push-notifier integration (alert when a host gains security updates / a new release) — left as a small follow-on; this PR is badge + tab + column only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)