### PR TITLE
feat: run without a GPU, keep host metrics live, Setup panel + accurate CPU temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,16 @@ capability check — per-host versions land in subsequent releases. See
 broader design and follow-up slices.
 
 ## Quick start
-Requirements: Docker, and — for the GPU panels — an NVIDIA GPU with the
-[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
-(No GPU? The container, service and host panels still work fine.)
+**Only requirement: Docker.** The container starts on any host — no GPU needed.
+A GPU is auto-detected and its panels light up when present; without one, the
+container, service and host panels (incl. temperature) all work fine. Open the
+dashboard's **Setup & requirements** panel (on Overview) to see exactly what's
+detected and how to enable anything missing — nothing fails silently, and the
+container never refuses to start because a piece is absent.
+
+For the GPU panels specifically you'll want an NVIDIA GPU with the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html);
+if the Setup panel says the GPU isn't detected, it shows the one-line command to enable it.
 
 **Option A — pre-built image (recommended).** No clone, no build:
 

--- a/app.py
+++ b/app.py
@@ -85,8 +85,20 @@ if _PROM_OK:
         "model_vram":        Gauge("homelab_model_loaded_vram_mb","Model VRAM loaded (MB)",             ["server", "model"]),
     }
 LOCK = threading.Lock()
-DB = sqlite3.connect(DB_PATH, check_same_thread=False)
-DB.execute("PRAGMA journal_mode=WAL")
+# Open the history DB, but never let a missing/unwritable /data mount kill the
+# whole container at import — a newbie who forgets the `./data:/data` mount should
+# still get a running dashboard (with a diagnostics warning), not a crash loop.
+# Fall back to an in-memory DB so the app boots; history just doesn't persist.
+DB_EPHEMERAL = False
+try:
+    DB = sqlite3.connect(DB_PATH, check_same_thread=False)
+    DB.execute("PRAGMA journal_mode=WAL")
+except sqlite3.OperationalError as e:
+    print(f"WARNING: cannot open DB at {DB_PATH} ({e}); "
+          f"falling back to in-memory (history will not persist). "
+          f"Mount a writable ./data:/data to keep history.", flush=True)
+    DB = sqlite3.connect(":memory:", check_same_thread=False)
+    DB_EPHEMERAL = True
 DB.executescript("""
 CREATE TABLE IF NOT EXISTS samples(ts INTEGER PRIMARY KEY, util REAL, mem_used REAL, mem_total REAL, power REAL, temp REAL);
 CREATE TABLE IF NOT EXISTS proc(ts INTEGER, service TEXT, mem REAL);
@@ -115,7 +127,7 @@ for col in ("cpu REAL", "ram_used REAL", "ram_total REAL", "load1 REAL", "ctemp 
 DB.commit()
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
-          "procs": [], "models": [], "callers": [], "host": {}}
+          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "at": 0}
@@ -1303,12 +1315,15 @@ def build_overview(now, docker, systemd):
     """One status card per subsystem for the Overview tab. New monitors append here."""
     cards = []
     g = now.get("gpu") or {}
-    tot = g.get("mem_total") or 1
-    used, used_pct = g.get("mem_used", 0), round((g.get("mem_used", 0) / tot) * 100)
-    cards.append({"key": "gpu", "label": "GPU",
-                  "status": "crit" if (tot - used) < PRESSURE_MB else "warn" if used_pct >= 85 else "ok",
-                  "metric": f"{used_pct}% VRAM",
-                  "detail": f"{round(g.get('util', 0))}% util · {round(g.get('temp', 0))}°C"})
+    # Only show the GPU card when a GPU is actually present — otherwise a GPU-less
+    # host would show a misleading frozen "0% VRAM · 0°C" tile.
+    if g.get("available"):
+        tot = g.get("mem_total") or 1
+        used, used_pct = g.get("mem_used", 0), round((g.get("mem_used", 0) / tot) * 100)
+        cards.append({"key": "gpu", "label": "GPU",
+                      "status": "crit" if (tot - used) < PRESSURE_MB else "warn" if used_pct >= 85 else "ok",
+                      "metric": f"{used_pct}% VRAM",
+                      "detail": f"{round(g.get('util', 0))}% util · {round(g.get('temp', 0))}°C"})
     h = now.get("host") or {}
     ram_pct = round(h["ram_used"] / h["ram_total"] * 100) if h.get("ram_total") else 0
     worst_disk = (h.get("disks") or [{}])[0].get("pct", 0)
@@ -1569,6 +1584,76 @@ def os_updates_summary():
             new_release.append({"host": name, "label": rel.get("label")})
     return {"hosts_behind": hosts_behind, "total_updates": total,
             "security": security, "new_release": new_release}
+
+# ── Local capability diagnostics ──────────────────────────────────────────────
+# A "which requirements are met?" checklist for the hub's own host, in the SAME
+# {checks:[{id,label,status,detail,remedy?}], summary} shape the remote probe_host()
+# already produces — so the dashboard renders both with one code path. The point:
+# a deploy that's missing an optional mount (or has no GPU) should STILL run and
+# clearly say what's degraded and how to fix it, instead of failing cryptically.
+
+def _diag(checks, cid, label, status, detail, remedy=None):
+    item = {"id": cid, "label": label, "status": status, "detail": detail}
+    if remedy:
+        item["remedy"] = remedy
+    checks.append(item)
+
+def local_diagnostics():
+    checks = []
+    # GPU (optional) — info, not a failure: the monitor is useful without one.
+    if LATEST.get("gpu_avail"):
+        _diag(checks, "nvidia", "NVIDIA GPU", "ok",
+              f"nvidia-smi OK · {round(LATEST.get('mem_total') or 0)} MB VRAM")
+    else:
+        _diag(checks, "nvidia", "NVIDIA GPU", "info",
+              "no GPU detected — GPU panels are hidden (everything else works)",
+              {"where": "on the host — only if it actually has an NVIDIA GPU",
+               "cmd": "sudo nvidia-ctk runtime configure --runtime=docker --set-as-default\n"
+                      "sudo systemctl restart docker"})
+    # Docker socket — powers Containers + Services + model APIs.
+    try:
+        json.loads(_docker("/version"))
+        _diag(checks, "docker", "Docker socket", "ok", f"reachable at {DOCKER_SOCK}")
+    except Exception:
+        _diag(checks, "docker", "Docker socket", "warn",
+              "not reachable — Containers & model panels are limited",
+              {"where": "in docker-compose.yml volumes:",
+               "cmd": "- /var/run/docker.sock:/var/run/docker.sock:ro"})
+    # Host root — disk usage for the real host rather than the container.
+    if os.path.isdir(HOST_ROOT):
+        _diag(checks, "host_root", "Host filesystem", "ok", f"mounted at {HOST_ROOT}")
+    else:
+        _diag(checks, "host_root", "Host filesystem", "warn",
+              "host root not mounted — disk stats show the container only",
+              {"where": "in docker-compose.yml volumes:",
+               "cmd": "- /:/rootfs:ro"})
+    # systemd D-Bus — optional Services panel.
+    bus = (os.environ.get("DBUS_SYSTEM_BUS_ADDRESS", "").split("unix:path=")[-1]
+           or "/run/dbus/system_bus_socket")
+    if os.path.exists(bus):
+        _diag(checks, "dbus", "systemd D-Bus", "ok", "socket present — Services panel enabled")
+    else:
+        _diag(checks, "dbus", "systemd D-Bus", "info",
+              "socket not mounted — the Services (systemd) panel is unavailable",
+              {"where": "in docker-compose.yml volumes:",
+               "cmd": "- /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro"})
+    # History persistence — in-memory fallback when /data isn't writable.
+    if DB_EPHEMERAL:
+        _diag(checks, "data", "History storage", "warn",
+              "running in-memory — history resets on restart",
+              {"where": "in docker-compose.yml volumes:",
+               "cmd": "- ./data:/data"})
+    else:
+        _diag(checks, "data", "History storage", "ok", f"persisting to {DB_PATH}")
+    # Host metrics — /proc + thermal sensors (needs pid:host and the rootfs mount).
+    if os.path.exists("/proc/stat") and glob.glob("/sys/class/thermal/thermal_zone*/temp"):
+        _diag(checks, "host_metrics", "Host metrics", "ok", "CPU / RAM / temperature readable")
+    elif os.path.exists("/proc/stat"):
+        _diag(checks, "host_metrics", "Host metrics", "info",
+              "CPU / RAM readable; no thermal sensors exposed on this host")
+    else:
+        _diag(checks, "host_metrics", "Host metrics", "warn", "/proc not readable — host metrics limited")
+    return {"checks": checks, "summary": _summarize(checks)}
 
 def health_scan():
     HEALTH["docker"]  = collect_docker()
@@ -2542,17 +2627,32 @@ def sample_callers(conts, ai_names):
     return edges
 
 def sample_once():
-    g = smi(["--query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
-             "--format=csv,noheader,nounits"]).splitlines()[0].split(",")
-    util, mem_used, mem_total, power, temp = (float(x.strip() or 0) for x in g)
     conts = containers()
     nm = {c["id"]: c["name"] for c in conts}
+
+    # ── GPU half ──────────────────────────────────────────────────────────────
+    # Isolated in its own try/except so a flaky, missing or slow nvidia-smi can
+    # NEVER block the host metrics below. Before this, an exception here aborted
+    # the whole sample, freezing CPU/RAM/temperature on every poll (and forever on
+    # a GPU-less host). Now a GPU failure just degrades the GPU panel to "absent"
+    # while temperature & friends keep refreshing.
+    util = mem_used = mem_total = power = temp = 0.0
     procs = {}
-    for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
-        if line.strip():
-            pid, mem = (p.strip() for p in line.split(","))
-            svc = service_for_pid(pid, nm)
-            procs[svc] = procs.get(svc, 0) + float(mem or 0)
+    gpu_avail = False
+    try:
+        g = smi(["--query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
+                 "--format=csv,noheader,nounits"]).splitlines()[0].split(",")
+        util, mem_used, mem_total, power, temp = (float(x.strip() or 0) for x in g)
+        for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
+            if line.strip():
+                pid, mem = (p.strip() for p in line.split(","))
+                svc = service_for_pid(pid, nm)
+                procs[svc] = procs.get(svc, 0) + float(mem or 0)
+        gpu_avail = True
+    except Exception as e:
+        # Log only on the ok→fail edge so a permanently GPU-less host doesn't spam.
+        if LATEST.get("gpu_avail"):
+            print("GPU sample failed (continuing without GPU):", e, flush=True)
 
     # Detect models from EVERY recognised AI server, not just the ones holding the GPU
     # right now — so a server that has unloaded its model (e.g. OLLAMA_KEEP_ALIVE
@@ -2581,9 +2681,13 @@ def sample_once():
     host = read_host()
     ts = int(time.time())
     with LOCK:
+        # When the GPU is absent/failed, store NULL for the GPU columns (not 0) so
+        # history charts skip the gap via AVG() instead of showing a fake 0 dip;
+        # the host columns are always real.
+        gcols = (util, mem_used, mem_total, power, temp) if gpu_avail else (None,)*5
         DB.execute("INSERT OR REPLACE INTO samples(ts,util,mem_used,mem_total,power,temp,cpu,ram_used,ram_total,load1,ctemp)"
                    " VALUES(?,?,?,?,?,?,?,?,?,?,?)",
-                   (ts, util, mem_used, mem_total, power, temp, host["cpu"], host["ram_used"],
+                   (ts, *gcols, host["cpu"], host["ram_used"],
                     host["ram_total"], host["load1"], host["ctemp"]))
         for svc, mem in procs.items():
             DB.execute("INSERT INTO proc VALUES(?,?,?)", (ts, svc, mem))
@@ -2597,6 +2701,7 @@ def sample_once():
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))
         DB.commit()
     LATEST.update(ts=ts, util=util, mem_used=mem_used, mem_total=mem_total, power=power, temp=temp,
+                  gpu_avail=gpu_avail,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
@@ -2759,9 +2864,11 @@ def favicon():
 def api_health():
     """Current state of the status monitors (Docker + systemd) plus a light GPU/host
     snapshot. Cheap and DB-free, so the dashboard can poll it often."""
+    gpu_avail = LATEST.get("gpu_avail")
     now = {"gpu": {"util": LATEST["util"], "mem_used": LATEST["mem_used"],
-                   "mem_total": LATEST["mem_total"] or 24576, "power": LATEST["power"],
-                   "temp": LATEST["temp"]},
+                   "mem_total": (LATEST["mem_total"] or 24576) if gpu_avail else 0,
+                   "power": LATEST["power"], "temp": LATEST["temp"],
+                   "available": bool(gpu_avail)},
            "host": enrich_os_upgrade(LATEST["host"])}
     docker  = HEALTH["docker"]  or {"available": False, "reason": "warming up…",
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}
@@ -2771,6 +2878,7 @@ def api_health():
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd, "update": update,
                     "os_updates": os_updates_summary(),
+                    "diagnostics": local_diagnostics(),
                     "overview": build_overview(now, docker, systemd)})
 
 @app.route("/metrics")

--- a/app.py
+++ b/app.py
@@ -428,6 +428,78 @@ def read_disks():
             pass
     return sorted(out, key=lambda d: -d["pct"])[:6]
 
+# hwmon drivers / thermal-zone types that expose the real CPU die/core sensors.
+_CPU_HWMON = ("coretemp", "k10temp", "zenpower", "cpu_thermal", "cpu-thermal")
+_CPU_ZONE  = ("x86_pkg_temp", "cpu_thermal", "cpu-thermal")
+
+def _cpu_temp_c():
+    """CPU temperature in °C matching `sensors`' CPU cores. The old code took the
+    max of every thermal zone, which on many boards grabs a chipset/PCH/NVMe or a
+    mis-calibrated package sensor 10-20 °C above the cores (dashboard showed 51 °C
+    while `sensors` showed Core N at 37 °C). Prefer the coretemp/k10temp hwmon and
+    report the hottest *core*; then a CPU-typed thermal zone; then, as a last
+    resort, the old hottest-plausible-zone so exotic/ARM boards still report.
+    Mirrors probe.py's _cpu_temp_c so local and remote agree."""
+    best = None
+    try:
+        for hw in glob.glob("/sys/class/hwmon/hwmon*"):
+            try:
+                name = open(hw + "/name").read().strip()
+            except Exception:
+                continue
+            if name not in _CPU_HWMON:
+                continue
+            cores, allt = [], []
+            for inp in glob.glob(hw + "/temp*_input"):
+                try:
+                    t = int(open(inp).read().strip()) / 1000.0
+                except Exception:
+                    continue
+                if not (0 < t < 130):
+                    continue
+                allt.append(t)
+                try:
+                    lbl = open(inp[:-6] + "_label").read().strip().lower()
+                except Exception:
+                    lbl = ""
+                if lbl.startswith("core"):          # Intel "Core N" — exclude Package
+                    cores.append(t)
+            pick = max(cores) if cores else (max(allt) if allt else None)
+            if pick is not None and (best is None or pick > best):
+                best = pick
+        if best is not None:
+            return round(best, 1)
+    except Exception:
+        pass
+    try:
+        for z in glob.glob("/sys/class/thermal/thermal_zone*"):
+            try:
+                ztype = open(z + "/type").read().strip().lower()
+            except Exception:
+                continue
+            if ztype in _CPU_ZONE or "cpu" in ztype:
+                try:
+                    t = int(open(z + "/temp").read().strip()) / 1000.0
+                except Exception:
+                    continue
+                if 0 < t < 130 and (best is None or t > best):
+                    best = t
+        if best is not None:
+            return round(best, 1)
+    except Exception:
+        pass
+    try:
+        for z in glob.glob("/sys/class/thermal/thermal_zone*/temp"):
+            try:
+                t = int(open(z).read().strip()) / 1000.0
+                if 10 < t < 130 and (best is None or t > best):
+                    best = t
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return round(best, 1) if best is not None else None
+
 def read_host():
     h = {"cores": os.cpu_count() or 1}
     try: h["cpu"] = _cpu_pct()
@@ -444,11 +516,7 @@ def read_host():
     except Exception: h["load1"] = 0
     try: h["uptime"] = int(float(open("/proc/uptime").read().split()[0]))
     except Exception: h["uptime"] = 0
-    t = 0
-    for f in glob.glob("/sys/class/thermal/thermal_zone*/temp"):
-        try: t = max(t, int(open(f).read().strip()) / 1000)
-        except Exception: pass
-    h["ctemp"] = round(t, 1)
+    h["ctemp"] = _cpu_temp_c()
     h["disks"] = read_disks()
     # Slow-changing context (OS / hardware / network / security) for the System,
     # Network and Security tabs. Cached so it isn't recomputed on every 10 s sample.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,14 @@ services:
     security_opt:
       - apparmor=unconfined
     environment:
+      # GPU is auto-detected, never required. These env vars let the NVIDIA
+      # container runtime inject nvidia-smi *when it's present*; on a host with no
+      # GPU (or no nvidia runtime) they're simply inert and the dashboard runs
+      # without the GPU panels. This is why there's no hard `deploy.devices`
+      # reservation below — that would refuse to start on a GPU-less host. If you
+      # have a GPU but the dashboard's Setup tab says it isn't detected, run:
+      #   sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+      #   sudo systemctl restart docker
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: utility   # injects nvidia-smi into the container
       PORT: "9800"                          # dashboard served on 0.0.0.0:9800 (LAN/VPN reachable)
@@ -39,10 +47,7 @@ services:
       # systemd service health (optional): expose the host's D-Bus system socket
       # read-only. Remove this line and the Services panel just shows "unavailable".
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+    # NOTE: intentionally no `deploy.resources.reservations.devices: nvidia` here.
+    # A hard GPU reservation makes `docker compose up` fail on any host without the
+    # NVIDIA runtime — the monitor is useful without a GPU, so we let it start
+    # everywhere and auto-use the GPU via the NVIDIA_* env vars above when present.

--- a/probe.py
+++ b/probe.py
@@ -76,16 +76,72 @@ def read_cpu():
         return {}
 
 
-def read_temp():
-    """Hottest plausible CPU temp from /sys/class/thermal. Coarse, but matches
-    what the hub itself reports for its own box (app.py takes the max zone too).
+# hwmon drivers that expose the actual CPU die/core sensors (Intel/AMD/ARM).
+_CPU_HWMON = ("coretemp", "k10temp", "zenpower", "cpu_thermal", "cpu-thermal")
+# thermal_zone *types* that are the CPU (never acpitz/pch/nvme/wifi).
+_CPU_ZONE  = ("x86_pkg_temp", "cpu_thermal", "cpu-thermal")
 
-    Taking the *max* — not the first zone — matters on boxes that expose an
-    `acpitz` board/ambient sensor alongside the real `x86_pkg_temp`/`coretemp`
-    die sensor. `acpitz` sorts first (thermal_zone0) and reads ~ambient, so the
-    old first-match logic under-reported the CPU by 20-30 °C (e.g. a Celeron
-    reading 28 °C off acpitz while its package sat at 59 °C)."""
+def _cpu_temp_c():
+    """CPU temperature in °C that matches what `sensors` shows for the CPU cores.
+
+    The old logic took the max of *every* /sys/class/thermal zone, which on many
+    boards grabs a chipset/PCH/NVMe or an mis-calibrated package sensor reading
+    10-20 °C hotter than the cores — so the dashboard showed e.g. 51 °C while
+    `sensors` showed Core N at 37 °C. We now prefer the coretemp/k10temp hwmon and
+    report the hottest *core*; then a CPU-typed thermal zone; and only as a last
+    resort the old hottest-plausible-zone (so exotic/ARM boards still report)."""
     best = None
+    # 1) hwmon coretemp/k10temp/zenpower — the real die/core sensors.
+    try:
+        for hw in glob.glob("/sys/class/hwmon/hwmon*"):
+            try:
+                name = open(hw + "/name").read().strip()
+            except Exception:
+                continue
+            if name not in _CPU_HWMON:
+                continue
+            cores, allt = [], []
+            for inp in glob.glob(hw + "/temp*_input"):
+                try:
+                    t = int(open(inp).read().strip()) / 1000.0
+                except Exception:
+                    continue
+                if not (0 < t < 130):
+                    continue
+                allt.append(t)
+                try:
+                    lbl = open(inp[:-6] + "_label").read().strip().lower()
+                except Exception:
+                    lbl = ""
+                if lbl.startswith("core"):          # Intel "Core N" — exclude Package
+                    cores.append(t)
+            pick = max(cores) if cores else (max(allt) if allt else None)
+            if pick is not None and (best is None or pick > best):
+                best = pick
+        if best is not None:
+            return round(best, 1)
+    except Exception:
+        pass
+    # 2) thermal zones explicitly typed as the CPU.
+    try:
+        for z in glob.glob("/sys/class/thermal/thermal_zone*"):
+            try:
+                ztype = open(z + "/type").read().strip().lower()
+            except Exception:
+                continue
+            if ztype in _CPU_ZONE or "cpu" in ztype:
+                try:
+                    t = int(open(z + "/temp").read().strip()) / 1000.0
+                except Exception:
+                    continue
+                if 0 < t < 130 and (best is None or t > best):
+                    best = t
+        if best is not None:
+            return round(best, 1)
+    except Exception:
+        pass
+    # 3) last resort: hottest plausible zone (original behaviour) so we still
+    #    report *something* on boards without coretemp or a CPU-typed zone.
     try:
         for z in glob.glob("/sys/class/thermal/thermal_zone*/temp"):
             try:
@@ -96,7 +152,12 @@ def read_temp():
                 continue
     except Exception:
         pass
-    return {"ctemp": round(best, 1)} if best is not None else {}
+    return round(best, 1) if best is not None else None
+
+
+def read_temp():
+    t = _cpu_temp_c()
+    return {"ctemp": t} if t is not None else {}
 
 
 def read_disks():

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -111,6 +111,14 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .oslist li{display:flex;justify-content:space-between;gap:12px;padding:8px 10px;border:1px solid var(--bd);border-radius:8px;background:#0d1117;margin-top:6px;font-size:13px}
 .oslist .hn{font-weight:600;color:var(--tx)}
 .oslist .meta{color:var(--mut);text-align:right}
+/* Setup/requirements: degraded banner + per-check remedy command */
+.diagbanner{margin:0 0 12px;padding:9px 12px;border:1px solid var(--warn);background:#d2992218;color:var(--tx);border-radius:8px;font-size:13px;display:flex;align-items:center;gap:10px}
+.diagbanner a{color:var(--info);text-decoration:none;font-weight:600}
+.diagbanner .x{margin-left:auto;background:none;border:0;color:var(--mut);font-size:18px;cursor:pointer;line-height:1;padding:0 2px}
+.diagbanner .x:hover{color:var(--tx)}
+.diagrem{margin-top:6px}
+.diagrem .where{color:var(--mut);font-size:12px}
+.diagrem pre{background:#0d1117;border:1px solid var(--bd);border-radius:6px;padding:7px 9px;margin:4px 0 0;font-size:12px;white-space:pre-wrap;word-break:break-all;color:var(--tx);font-family:ui-monospace,Menlo,Consolas,monospace}
 .umodal{position:fixed;inset:0;background:#0008;display:none;align-items:center;justify-content:center;z-index:50;padding:18px}
 .umodal.show{display:flex}
 .umodal .box{background:var(--card);border:1px solid var(--bd);border-radius:12px;max-width:640px;width:100%;max-height:84vh;display:flex;flex-direction:column}
@@ -374,8 +382,18 @@ a{color:var(--info)}
 <span class="spacer"></span><label class="tg"><input type="checkbox" id="auto" checked> auto-refresh</label>
 </div></div>
 
+<!-- Degraded-setup banner: shown on any tab when a requirement isn't met. -->
+<div class="diagbanner" id="diagbanner" hidden></div>
+
 <!-- ───────── Overview = All hosts (fleet table) ───────── -->
 <section data-tab="overview">
+  <div class="card" id="diagcard" hidden>
+    <h2>🩺 Setup &amp; requirements</h2>
+    <div class="fleet-meta">What the monitor can see on this hub, and how to enable anything that's missing. The dashboard keeps running even when optional pieces aren't mounted — no GPU required.</div>
+    <div style="overflow-x:auto">
+      <table class="sectbl" style="margin-top:10px"><thead><tr><th>Requirement</th><th>Status</th><th>Detail</th></tr></thead><tbody id="diagbody"></tbody></table>
+    </div>
+  </div>
   <div class="card">
     <h2>🛰️ All hosts</h2>
     <div class="fleet-meta" id="fleet_meta">Every registered host at a glance. Click a row to focus that host in the other tabs.</div>
@@ -636,6 +654,7 @@ let LAST_MONITOR_TAB = localStorage.getItem('hl_montab') || 'overview';
 if(!TABS.some(t=>t.id===LAST_MONITOR_TAB && !t.settings)) LAST_MONITOR_TAB='overview';
 let SETTINGS_OPEN = false;
 let charts = {}, D = null, HH = null;
+let DIAG_DISMISSED = false;   // user dismissed the degraded-setup banner this session
 
 // Multi-machine state. CURRENT_HOST is the active host context for per-host
 // tabs (GPU/Containers/Services/Host). The Overview tab is fleet-wide and
@@ -921,6 +940,43 @@ function renderHealth(){
       osb.classList.remove('show');
     }
   }
+
+  // Setup/requirements checklist + degraded banner. The dashboard runs even when
+  // pieces are missing; this is how the user finds out what's limited and how to fix it.
+  const diag = HH.diagnostics || {}, checks = diag.checks || [];
+  const dbody = document.getElementById('diagbody'), dcard = document.getElementById('diagcard');
+  if(dbody && checks.length){
+    dbody.innerHTML = checks.map(c=>{
+      const r = c.remedy;
+      const rem = r ? `<div class="diagrem">${r.where?`<div class="where">${esc(r.where)}</div>`:''}`
+                      + `<pre>${esc(r.cmd||'')}</pre></div>` : '';
+      return `<tr class="${c.status}"><td><span class="sdot" style="background:${SC[c.status]}"></span>${esc(c.label)}</td>`
+        + `<td><span class="badge ${c.status}">${SEC_TAG[c.status]||esc(c.status)}</span></td>`
+        + `<td class="muted">${esc(c.detail||'')}${rem}</td></tr>`;
+    }).join('');
+    if(dcard) dcard.hidden = false;
+  }
+  const overall = (diag.summary||{}).overall;
+  const banner = document.getElementById('diagbanner');
+  if(banner){
+    const bad = checks.filter(c=>c.status==='warn'||c.status==='fail');
+    if((overall==='warn'||overall==='fail') && bad.length && !DIAG_DISMISSED){
+      banner.innerHTML = `⚠️ ${bad.length} setup item${bad.length>1?'s':''} need attention — some features are limited. `
+        + `<a href="#" id="diaggo">See Setup &amp; requirements</a><button class="x" id="diagx" title="Dismiss">×</button>`;
+      banner.hidden = false;
+      document.getElementById('diaggo').onclick = e=>{e.preventDefault(); showTab('overview');
+        const dc=document.getElementById('diagcard'); if(dc) dc.scrollIntoView({behavior:'smooth'});};
+      document.getElementById('diagx').onclick = ()=>{ DIAG_DISMISSED=true; banner.hidden=true; };
+    } else {
+      banner.hidden = true;
+    }
+  }
+
+  // Hide GPU-specific tabs when the hub has no GPU, so a GPU-less box doesn't show
+  // empty "0% VRAM" panels. (GPU is hub-local; remotes keep their own scope.)
+  const gpuPresent = !!(HH.now && HH.now.gpu && HH.now.gpu.available);
+  ['gpu','models'].forEach(id=>document.querySelectorAll(`[data-t="${id}"]`)
+    .forEach(el=>{ el.style.display = gpuPresent ? '' : 'none'; }));
 
   // Overview status cards used to live here too — same guard as #insights.
   const ovEl = document.getElementById('ovcards');


### PR DESCRIPTION
Two reports, one theme — the monitor assumed a GPU host and over-reported temps. Three fixes across **two commits**.

## Commit 1 — resilient startup, live temperature, requirements panel
**Stale temperature / frozen overview.** `sample_once()` ran nvidia-smi first; any hiccup raised *before* `read_host()`+`LATEST.update()`, freezing CPU/RAM/temp every cycle (forever on a GPU-less box). The GPU half is now isolated in try/except — GPU degrades to "absent" while host metrics keep refreshing (GPU history stored NULL, not a fake 0). `now.gpu.available` flows to the UI.

**Won't start without requirements.** The app no longer dies at import — an unwritable `/data` falls back to an in-memory DB instead of crash-looping. And the published `docker-compose.yml` drops the hard `deploy.devices: nvidia` reservation that made `docker compose up` fail on a GPU-less host. Single file, one command, **starts anywhere**; the GPU is auto-used when the runtime is present.

**Tell the user what's missing.** New `local_diagnostics()` mirrors the remote `probe_host()` checklist for the hub (nvidia/docker/host_root/dbus/data/proc), surfaced at `/api/health.diagnostics` and rendered as a **Setup & requirements** panel on Overview + a dismissible banner when degraded, each with a copy-paste remedy. GPU overview card + GPU/AI-Models tabs hide when there's no GPU.

## Commit 2 — accurate CPU temperature
`read_temp`/`ctemp` took the max of *every* thermal zone, grabbing a chipset/PCH/NVMe or mis-calibrated package sensor 10-20°C above the cores (dashboard 51°C vs `sensors` Core N 37°C). New `_cpu_temp_c()` prefers the coretemp/k10temp hwmon and reports the hottest **core**; then a CPU-typed zone; then the old max-zone as last resort.

## Verified (dev :9801 + throwaway containers)
- No-GPU container: boots healthy, **host temp keeps refreshing**, GPU cleanly absent, diagnostics reports it.
- Unwritable `/data`: boots in-memory with a warn banner, no crash-loop.
- GPU host: all checks green.
- Temp: ardi 48→46°C (core vs package), cloudy now tracks cores (~52 loaded / ~37 idle) not the ~60°C package zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)