### PR TITLE
Release 0.13.1 — mobile-friendly UI, smarter OS-upgrade hint, YouTube demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.13.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.13.1) — 2026-06-07
+- **Mobile-friendly dashboard** — the dense tables (Containers, Services, AI
+  Models, Network) no longer push the whole page sideways on a phone; each one
+  now scrolls within its card. Verified no horizontal overflow down to 360px.
+- **Smarter OS-upgrade hint** — a host is now offered the **next reachable**
+  release instead of the newest one, so e.g. an Ubuntu 22.04 LTS box is pointed
+  at 24.04 rather than a newer LTS it can't `do-release-upgrade` to directly.
+- **Fix:** an empty amber banner could show on every tab even when setup was
+  healthy (the diagnostics banner's `display` overrode its hidden state).
+- Demo video now embedded from **YouTube** on the README and landing page.
+
 ## [0.13.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.13.0) — 2026-06-06
 - **Windows host monitoring** — register and monitor a **Windows** machine over
   SSH, agentless, via a built-in **PowerShell probe** (no install). Same fleet

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 **One page for your whole home lab & AI rig — GPU, containers, services, disks. No agents, no Prometheus/Grafana, no cloud.**
 
-<a href="https://github.com/SikamikanikoBG/homelab-monitor/raw/main/docs/demo.mp4">
-  <img src="docs/demo.gif" alt="HomeLab Monitor — a 65-second tour of the dashboard" width="820">
+<a href="https://youtu.be/5uf2rG-RzcU" title="Watch the HomeLab Monitor demo on YouTube">
+  <img src="https://img.youtube.com/vi/5uf2rG-RzcU/maxresdefault.jpg" alt="HomeLab Monitor — watch the 65-second demo on YouTube" width="820">
 </a>
 
-<sub>▶ <a href="https://github.com/SikamikanikoBG/homelab-monitor/raw/main/docs/demo.mp4"><b>Watch the full HD demo (MP4, ~65s)</b></a> — the GIF above is a muted preview.</sub>
+<sub>▶ <a href="https://youtu.be/5uf2rG-RzcU"><b>Watch the 65-second demo on YouTube</b></a> — HD, with sound.</sub>
 
 Your home lab grew into a couple of machines, a Pi, and a GPU that's mysteriously always busy. HomeLab Monitor gives you one self-hosted page that answers the real questions: **which model is holding the GPU, which container is eating RAM, what's filling your disks**, and **is anything down** — across every box over SSH: Linux, a Pi, even Windows. Readable from your phone over the VPN.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@
 **One page for your whole home lab & AI rig — GPU, containers, services, disks. No agents, no Prometheus/Grafana, no cloud.**
 
 <a href="https://youtu.be/5uf2rG-RzcU" title="Watch the HomeLab Monitor demo on YouTube">
-  <img src="https://img.youtube.com/vi/5uf2rG-RzcU/maxresdefault.jpg" alt="HomeLab Monitor — watch the 65-second demo on YouTube" width="820">
+  <img src="docs/demo.gif" alt="HomeLab Monitor — a 65-second tour of the dashboard" width="820">
 </a>
-
-<sub>▶ <a href="https://youtu.be/5uf2rG-RzcU"><b>Watch the 65-second demo on YouTube</b></a> — HD, with sound.</sub>
 
 Your home lab grew into a couple of machines, a Pi, and a GPU that's mysteriously always busy. HomeLab Monitor gives you one self-hosted page that answers the real questions: **which model is holding the GPU, which container is eating RAM, what's filling your disks**, and **is anything down** — across every box over SSH: Linux, a Pi, even Windows. Readable from your phone over the VPN.
 

--- a/app.py
+++ b/app.py
@@ -1632,10 +1632,13 @@ def os_upgrade_for(os_id, version_id):
     endoflife.date returns cycles newest-first, so we locate the host's own cycle
     and flag it behind only when newer cycles sit before it (list order, not a
     numeric compare — openSUSE Leap renumbered 42.x → 15.x). The candidate is the
-    newest *qualifying* newer cycle, NOT just cycles[0]: it must be already
-    released, still supported, and — if the host is on an LTS — itself LTS. That
-    stops us telling a 24.04-LTS host to 'upgrade' to a short-lived interim (or an
-    unreleased) release."""
+    *nearest* qualifying newer cycle (smallest jump), NOT the newest one: distro
+    upgrade tooling only moves one release/LTS at a time, so a 22.04-LTS host's
+    actionable target is 24.04, not whatever the latest LTS happens to be. Each
+    candidate must be already released, still supported, and — if the host is on
+    an LTS — itself LTS. That keeps us from telling a 24.04-LTS host to 'upgrade'
+    to a short-lived interim (or an unreleased) release, and from telling a
+    22.04-LTS host to jump to a newer LTS it can't reach directly."""
     if not CHECK_OS_UPDATES or not os_id or not version_id:
         return None
     slug = _EOL_SLUG.get(os_id.lower())
@@ -1668,7 +1671,10 @@ def os_upgrade_for(os_id, version_id):
             if eol in (False, None): return True
             return str(eol) > today
         candidate = None
-        for c in cycles[:idx]:                  # strictly-newer entries, newest-first
+        # Walk strictly-newer entries nearest-first (reversed: newest-first list →
+        # closest-to-host first) so we recommend the next reachable release, not the
+        # newest. The filters still skip any non-qualifying step in between.
+        for c in reversed(cycles[:idx]):
             if released(c) and supported(c) and (not host_is_lts or c.get("lts")):
                 candidate = c["cycle"]
                 break

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.13.0"
+VERSION      = "0.13.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -146,6 +146,7 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .osu-sum .lead{font-size:13.5px;color:var(--tx);font-weight:600;margin-right:2px}
 /* Setup/requirements: degraded banner + per-check remedy command */
 .diagbanner{margin:0 0 12px;padding:9px 12px;border:1px solid var(--warn);background:#d2992218;color:var(--tx);border-radius:8px;font-size:13px;display:flex;align-items:center;gap:10px}
+.diagbanner[hidden]{display:none}   /* the class's display:flex would otherwise beat the hidden attr (see .nav) → empty amber bar */
 .diagbanner a{color:var(--info);text-decoration:none;font-weight:600}
 .diagbanner .x{margin-left:auto;background:none;border:0;color:var(--mut);font-size:18px;cursor:pointer;line-height:1;padding:0 2px}
 .diagbanner .x:hover{color:var(--tx)}
@@ -382,6 +383,25 @@ th{font-size:10px;text-transform:uppercase;letter-spacing:.05em}
   .nrow{width:auto}.nrow .tdot{margin-left:6px}
   .foot{flex-direction:row;border-top:0;margin-left:auto;align-items:center;padding:6px 10px}
   .content{max-width:none}
+}
+/* ──────────── phone polish (≤680px) ──────────── */
+@media(max-width:680px){
+  /* Dense, JS-rendered data tables get their OWN horizontal scroll so a wide table
+     can't widen the whole page (the page-level h-scroll that wrecks mobile layouts).
+     The Overview fleet/diag tables already live in an overflow-x wrapper; these
+     don't, so we turn the table itself into the scroll container. */
+  [data-tab="containers"] table,
+  [data-tab="services"] table,
+  [data-tab="models"] table,
+  .ntbl{display:block;width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch}
+  /* short-celled tables read better swiped than crammed */
+  [data-tab="containers"] table{white-space:nowrap}
+  /* keep the header/live stamp from being clipped at the right edge */
+  header{gap:8px}
+  .live{font-size:11px}
+  /* tighter gutters reclaim width for content on small screens */
+  .content{padding-left:13px;padding-right:13px}
+  .card{padding:13px 13px}
 }
 /* ═══════════ light/dark parity — tokenize every surface that was hardcoded ═══════════ */
 a{color:var(--info)}

--- a/website/assets/extra.css
+++ b/website/assets/extra.css
@@ -178,6 +178,21 @@
     0 8px 20px -8px rgba(88, 166, 255, 0.18);
 }
 
+/* YouTube demo embed — same framed look as .hl-gif, responsive 16:9 */
+.hl-hero .hl-video {
+  max-width: 920px; width: 100%;
+  margin: 8px auto 0;
+  aspect-ratio: 16 / 9;
+  border: 2px solid rgba(255, 255, 255, 0.22);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 30px 80px -20px rgba(0, 0, 0, 0.7),
+    0 8px 20px -8px rgba(88, 166, 255, 0.18);
+}
+.hl-hero .hl-video iframe { width: 100%; height: 100%; border: 0; display: block; }
+
 .hl-hero .hl-badges {
   margin-top: 22px;
   display: flex; gap: 8px; justify-content: center; flex-wrap: wrap;
@@ -400,7 +415,8 @@
     padding: 14px 18px;        /* taller for thumbs */
     font-size: 0.95rem;
   }
-  .hl-hero .hl-gif {
+  .hl-hero .hl-gif,
+  .hl-hero .hl-video {
     border-radius: 10px;
     border-width: 1px;
     box-shadow:

--- a/website/index.md
+++ b/website/index.md
@@ -21,7 +21,13 @@ cockpit.
   <a class="md-button" href="https://hub.docker.com/r/sikamikaniko123/homelab-monitor" target="_blank" rel="noopener">Docker Hub →</a>
 </div>
 
-![A short walkthrough of the dashboard](screenshots/demo.gif){ .hl-gif }
+<div class="hl-video">
+  <iframe src="https://www.youtube-nocookie.com/embed/5uf2rG-RzcU?rel=0"
+          title="HomeLab Monitor — dashboard demo"
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen></iframe>
+</div>
 
 <p class="hl-badges">
   <span><span class="hl-dot"></span>One container · <code>docker compose up -d</code></span>


### PR DESCRIPTION
Patch release.

- Mobile-friendly dashboard: dense tables (Containers/Services/AI Models/Network) scroll within their card instead of pushing the page sideways; no horizontal overflow down to 360px.
- OS-upgrade hint points to the next reachable release (e.g. Ubuntu 22.04 → 24.04, not a newer LTS it can't reach directly).
- Fix: empty amber diagnostics banner showing on every tab when setup was healthy.
- Demo embedded from YouTube on README + landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)