### PR TITLE
fix(mcp): correct registry image-label casing — v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.14.2](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.2) — 2026-06-09
+- **Fix:** correct the `io.modelcontextprotocol.server.name` image label to match the
+  publisher namespace casing (`io.github.SikamikanikoBG/homelab-monitor`) so the
+  image passes the official MCP Registry's OCI ownership check. `server.json` trimmed
+  to a ≤100-char description and the placeholder remote dropped (OCI/stdio entry is
+  the canonical one for a self-hosted server). Discoverability only — no runtime changes.
+
 ## [0.14.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.1) — 2026-06-09
 - **MCP registry packaging** — the image is now publishable to the official
   [MCP Registry](https://registry.modelcontextprotocol.io): added the

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY launch.py             /app/launch.py
 
 # Identifies this image to the official MCP Registry (registry.modelcontextprotocol.io),
 # which validates OCI-packaged servers by matching this label to the published name.
-LABEL io.modelcontextprotocol.server.name="io.github.sikamikanikobg/homelab-monitor"
+LABEL io.modelcontextprotocol.server.name="io.github.SikamikanikoBG/homelab-monitor"
 
 ENV PORT=8099 \
     MCP_PORT=9810

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.14.1"
+VERSION      = "0.14.2"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.sikamikanikobg/homelab-monitor",
+  "name": "io.github.SikamikanikoBG/homelab-monitor",
   "title": "HomeLab Monitor",
-  "description": "Self-hosted homelab dashboard with a built-in read-only MCP server. Covers hosts, Docker containers, GPU/VRAM, systemd services, AI models, alerts and disk. Streamable-HTTP on :9810.",
-  "version": "0.14.1",
+  "description": "Self-hosted homelab dashboard with a built-in read-only MCP server (hosts, Docker, GPU, services).",
+  "version": "0.14.2",
   "websiteUrl": "https://sikamikanikobg.github.io/homelab-monitor/mcp/",
   "repository": {
     "url": "https://github.com/SikamikanikoBG/homelab-monitor",
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/sikamikaniko123/homelab-monitor:0.14.1",
+      "identifier": "docker.io/sikamikaniko123/homelab-monitor:0.14.2",
       "transport": {
         "type": "stdio"
       },
@@ -34,12 +34,6 @@
           "default": "stdio"
         }
       ]
-    }
-  ],
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "http://YOUR-HUB:9810/mcp"
     }
   ],
   "_meta": {


### PR DESCRIPTION
v0.14.1's `io.modelcontextprotocol.server.name` label was lowercased; the official MCP Registry requires an exact-case match to the publisher namespace (`io.github.SikamikanikoBG/*`). Fixes the label casing + finalizes server.json. Discoverability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)