### PR TITLE
fix(mcp): allow remote HTTP clients (421 fix); v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.14.3](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.3) — 2026-06-09
+- **Fix:** the built-in MCP server over HTTP rejected remote clients with **421
+  Misdirected Request**. The MCP SDK's DNS-rebinding guard only trusts a
+  `localhost` Host header, so the documented `claude mcp add --transport http
+  homelab http://YOUR-HUB:9810/mcp` failed whenever the hub was reached by name or
+  IP. The HTTP/SSE transport now disables that localhost-only check by default
+  (safe — every tool is read-only), and a new `MCP_ALLOWED_HOSTS` (plus optional
+  `MCP_ALLOWED_ORIGINS`) env lets you lock it back down to specific hosts. stdio
+  is unaffected.
+
 ## [0.14.2](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.2) — 2026-06-09
 - **Fix:** correct the `io.modelcontextprotocol.server.name` image label to match the
   publisher namespace casing (`io.github.SikamikanikoBG/homelab-monitor`) so the

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.14.2"
+VERSION      = "0.14.3"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       PORT: "9800"                          # dashboard served on 0.0.0.0:9800 (LAN/VPN reachable)
       MCP_PORT: "9810"                       # built-in read-only MCP server on 0.0.0.0:9810/mcp
       # ENABLE_MCP: "0"                      # uncomment to run the dashboard without the MCP server
+      # MCP_ALLOWED_HOSTS: "YOUR-HUB:9810"  # lock the MCP HTTP transport to specific Host headers
+                                            # (host:* wildcards ok). Unset = reachable from anywhere
+                                            # on your homelab (default; safe — MCP tools are read-only).
       SAMPLE_INTERVAL: "10"                 # seconds between samples
       RETENTION_DAYS: "180"                 # how long history is kept
       PRESSURE_FREE_MB: "2048"              # free VRAM below this counts as "pressure"

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -18,6 +18,14 @@ Transports (env `MCP_TRANSPORT`):
 Config:
   * `HOMELAB_MONITOR_URL`  base URL of the monitor   (default http://localhost:9800)
   * `HOMELAB_HTTP_TIMEOUT` per-request timeout, sec  (default 10)
+  * `MCP_ALLOWED_HOSTS`    comma-separated Host allow-list for the HTTP transport
+                           (e.g. "YOUR-HUB:9810"; `host:*` wildcards ok). Unset →
+                           the SDK's localhost-only DNS-rebinding check is turned
+                           OFF so the server is reachable across the homelab by
+                           name/IP, matching the documented `claude mcp add …
+                           http://YOUR-HUB:9810/mcp`. Set it to lock back down.
+  * `MCP_ALLOWED_ORIGINS`  comma-separated Origin allow-list (only consulted when
+                           `MCP_ALLOWED_HOSTS` is set).
 
 Guardrails: **read-only**. There are no write tools. Any future write capability
 (run a probe, restart a container, apply an OS update) must be opt-in, clearly
@@ -33,6 +41,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import homelab_client as hc  # noqa: E402
 from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp.server.transport_security import TransportSecuritySettings  # noqa: E402
 
 INSTRUCTIONS = (
     "Read-only access to a HomeLab Monitor instance — everything the dashboard shows "
@@ -196,17 +205,44 @@ def changelog_resource() -> str:
 
 # ── entrypoint ───────────────────────────────────────────────────────────────
 
+def _transport_security():
+    """DNS-rebinding protection for the HTTP/SSE transport.
+
+    The MCP SDK ships a Host/Origin allow-list that, by default, only accepts
+    `localhost`/`127.0.0.1`. That's the right default for a stdio server a browser
+    might reach, but this transport deliberately binds 0.0.0.0 so the homelab can
+    reach it — under that default it returns **421 Misdirected Request** to anyone
+    connecting by hostname or IP, breaking the documented `claude mcp add …
+    http://YOUR-HUB:9810/mcp`.
+
+    So: if `MCP_ALLOWED_HOSTS` is set we honour it (exact or `host:*` patterns,
+    plus matching `MCP_ALLOWED_ORIGINS`); otherwise we turn the check off, which
+    is safe here because every tool is read-only.
+    """
+    hosts = [h.strip() for h in os.environ.get("MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+    if not hosts:
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    origins = [o.strip() for o in os.environ.get("MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+
+
 def main():
     transport = (os.environ.get("MCP_TRANSPORT") or "stdio").strip().lower()
     if transport in ("http", "streamable-http", "streamable_http"):
         mcp.settings.host = os.environ.get("MCP_HOST", "0.0.0.0")
         mcp.settings.port = int(os.environ.get("MCP_PORT", "9810"))
+        mcp.settings.transport_security = _transport_security()
         print("homelab-monitor MCP on http://%s:%s/mcp -> %s"
               % (mcp.settings.host, mcp.settings.port, hc.base_url()), file=sys.stderr)
         mcp.run(transport="streamable-http")
     elif transport == "sse":
         mcp.settings.host = os.environ.get("MCP_HOST", "0.0.0.0")
         mcp.settings.port = int(os.environ.get("MCP_PORT", "9810"))
+        mcp.settings.transport_security = _transport_security()
         mcp.run(transport="sse")
     else:
         mcp.run(transport="stdio")

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.SikamikanikoBG/homelab-monitor",
   "title": "HomeLab Monitor",
   "description": "Self-hosted homelab dashboard with a built-in read-only MCP server (hosts, Docker, GPU, services).",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "websiteUrl": "https://sikamikanikobg.github.io/homelab-monitor/mcp/",
   "repository": {
     "url": "https://github.com/SikamikanikoBG/homelab-monitor",
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/sikamikaniko123/homelab-monitor:0.14.2",
+      "identifier": "docker.io/sikamikaniko123/homelab-monitor:0.14.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What & why

The built-in MCP server over HTTP rejected remote clients with **421 Misdirected Request**. The MCP SDK's DNS-rebinding guard only trusts a `localhost` Host header, so the documented `claude mcp add --transport http homelab http://YOUR-HUB:9810/mcp` failed whenever the hub was reached by name or IP.

## Fix

- HTTP/SSE transport disables the localhost-only Host check by default (safe — every MCP tool is read-only).
- New `MCP_ALLOWED_HOSTS` (+ optional `MCP_ALLOWED_ORIGINS`) env re-enables and scopes it to specific hosts for lock-down.
- stdio transport unaffected.
- Version bump 0.14.2 → 0.14.3 (app.py, server.json, CHANGELOG), docker-compose documents the new env.

## Verification

Tested against the real SDK (mcp 1.27.2) in the running container:
- Default (no env): full `initialize` POST with a remote Host → **200 OK** + session id (was 421). ✓
- Lock-down (`MCP_ALLOWED_HOSTS=localhost:*`): remote Host → **421**, localhost → passes. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)