### PR TITLE
docs: refresh star-history chart (cache-bust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ If HomeLab Monitor saves you a browser tab or two, a ⭐ on GitHub genuinely hel
 
 <a href="https://www.star-history.com/?repos=SikamikanikoBG%2Fhomelab-monitor&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&theme=dark&legend=top-left&cachebust=20260609" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&legend=top-left&cachebust=20260609" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&legend=top-left&cachebust=20260609" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star-history chart in the README is a live image, but GitHub's camo proxy caches it and can freeze it at an old star count. Appends `&cachebust=20260609` to the three `api.star-history.com/chart` image URLs (dark/light `<source>` + `<img>` fallback) so GitHub fetches a fresh render showing the current count (46 ⭐). No visual change otherwise; the star-history.com page link is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)