### PR TITLE
fix(ci): discord-announce workflow failed to parse

### DIFF
--- a/.github/workflows/discord-announce.yml
+++ b/.github/workflows/discord-announce.yml
@@ -77,9 +77,8 @@ jobs:
           # Discord embed description hard limit is 4096 chars; keep headroom
           # and link out to the full notes when we truncate.
           if [ "$(printf '%s' "$desc" | wc -c)" -gt 3500 ]; then
-            desc="$(printf '%s' "$desc" | cut -c1-3500)
-
-… [read the full release notes →]($URL)"
+            head=$(printf '%s' "$desc" | cut -c1-3500)
+            desc=$(printf '%s\n\n… [read the full release notes →](%s)' "$head" "$URL")
           fi
           payload=$(jq -nc \
             --arg name "$NAME" --arg url "$URL" --arg desc "$desc" \


### PR DESCRIPTION
The truncation branch put a continuation line at column 0 inside the `run: |` block scalar, which terminates the block and breaks YAML parsing (startup_failure on push). Rebuilds the truncation string with `printf '%s\n\n…'` so every line stays inside the block. Validated with a YAML parser before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)