### PR TITLE
Add MCP status pill for active agent visibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /app/static \
       -o /app/static/chart.min.js
 
 COPY app.py /app/app.py
+COPY mcp_status.py /app/mcp_status.py
 COPY probe.py /app/probe.py
 # probe.ps1 is the Windows-host probe: the hub pipes it over SSH to Windows
 # remotes (PowerShell, no install) and gets back the same JSON probe.py emits.

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ except ImportError:
 
 VERSION      = "0.14.3"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
+MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
 RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
 DOCKER_SOCK  = os.environ.get("DOCKER_SOCK", "/var/run/docker.sock")
@@ -3186,6 +3187,56 @@ def favicon():
     open without rendering HTML). Serve the SVG we ship in static/."""
     return app.send_static_file("favicon.svg")
 
+def _mcp_enabled():
+    return os.environ.get("ENABLE_MCP", "1").strip().lower() not in ("0", "false", "no")
+
+def _mcp_port():
+    try:
+        return int(os.environ.get("MCP_PORT", "9810") or 9810)
+    except ValueError:
+        return 9810
+
+def _mcp_probe(port, timeout=0.5):
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+def build_mcp_status():
+    """MCP liveness + recent-activity signal for the dashboard status pill."""
+    if not _mcp_enabled():
+        return {"enabled": False, "state": "off"}
+    import mcp_status as ms
+    port = _mcp_port()
+    up = _mcp_probe(port)
+    raw = ms.read_status()
+    in_flight = int(raw.get("in_flight") or 0)
+    last_ts = raw.get("last_activity_ts")
+    age_s = None
+    if last_ts is not None:
+        try:
+            age_s = max(0, int(time.time() - float(last_ts)))
+        except (TypeError, ValueError):
+            age_s = None
+    if not up:
+        state = "down"
+    elif in_flight > 0 or (age_s is not None and age_s <= MCP_IDLE_SEC):
+        state = "active"
+    else:
+        state = "idle"
+    out = {"enabled": True, "up": up, "state": state, "port": port,
+           "active_requests": in_flight}
+    if last_ts is not None:
+        out["last_activity_ts"] = last_ts
+    if age_s is not None:
+        out["last_activity_age_s"] = age_s
+    return out
+
+@app.route("/api/mcp-status")
+def api_mcp_status():
+    return jsonify(build_mcp_status())
+
 @app.route("/api/health")
 def api_health():
     """Current state of the status monitors (Docker + systemd) plus a light GPU/host
@@ -3201,16 +3252,11 @@ def api_health():
     systemd = HEALTH["systemd"] or {"available": False, "reason": "warming up…",
                                     "services": [], "summary": {}}
     update  = HEALTH["update"]  or {"available": False, "current": VERSION}
-    mcp_enabled = os.environ.get("ENABLE_MCP", "1").strip().lower() not in ("0", "false", "no")
-    try:
-        mcp_port = int(os.environ.get("MCP_PORT", "9810") or 9810)
-    except ValueError:
-        mcp_port = 9810
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd, "update": update,
                     "os_updates": os_updates_summary(),
                     "diagnostics": local_diagnostics(),
-                    "mcp": {"enabled": mcp_enabled, "port": mcp_port},
+                    "mcp": {"enabled": _mcp_enabled(), "port": _mcp_port()},
                     "overview": build_overview(now, docker, systemd)})
 
 @app.route("/metrics")

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -32,14 +32,19 @@ Guardrails: **read-only**. There are no write tools. Any future write capability
 labelled destructive, and gated behind explicit config — per issue #70.
 """
 
+import functools
 import json
 import os
 import sys
 
-# Make `import homelab_client` work regardless of the caller's cwd.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Make `import homelab_client` / `mcp_status` work regardless of the caller's cwd.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _p in (_here, os.path.dirname(_here)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 import homelab_client as hc  # noqa: E402
+import mcp_status as ms  # noqa: E402
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 from mcp.server.transport_security import TransportSecuritySettings  # noqa: E402
 
@@ -59,9 +64,22 @@ INSTRUCTIONS = (
 mcp = FastMCP("homelab-monitor", instructions=INSTRUCTIONS)
 
 
+def _track(fn):
+    """Bump the shared MCP activity file on every tool/resource invocation."""
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        ms.record_activity()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            ms.clear_activity()
+    return wrapper
+
+
 # ── tools (read-only) ─────────────────────────────────────────────────────────
 
 @mcp.tool()
+@_track
 def list_hosts() -> dict:
     """List every host in the fleet with headline vitals (hub listed first).
 
@@ -72,6 +90,7 @@ def list_hosts() -> dict:
 
 
 @mcp.tool()
+@_track
 def get_host(name: str) -> dict:
     """Full System / Network / Security inventory for a single host.
 
@@ -81,6 +100,7 @@ def get_host(name: str) -> dict:
 
 
 @mcp.tool()
+@_track
 def get_snapshot() -> dict:
     """Current live vitals across the hub: GPU, host RAM/CPU, Docker and systemd
     health summaries (with any problem containers / failed units), pending OS
@@ -90,6 +110,7 @@ def get_snapshot() -> dict:
 
 
 @mcp.tool()
+@_track
 def get_containers() -> dict:
     """Full Docker container list (Containers tab): per container name, image, state,
     health, exposed ports, RAM (`mem_bytes`), VRAM (`vram_bytes`), image disk and
@@ -99,6 +120,7 @@ def get_containers() -> dict:
 
 
 @mcp.tool()
+@_track
 def get_services() -> dict:
     """Full systemd unit list (Services tab): per unit active/sub state, description,
     listening ports, RAM, uptime, admin/watched flags and status verdict — plus the
@@ -108,6 +130,7 @@ def get_services() -> dict:
 
 
 @mcp.tool()
+@_track
 def get_memory(range: str = "6h") -> dict:
     """RAM breakdown behind the memory treemap: per-service peak/avg/present RAM over
     `range`, the current RAM per process right now, kernel (non-reclaimable) memory,
@@ -117,6 +140,7 @@ def get_memory(range: str = "6h") -> dict:
 
 
 @mcp.tool()
+@_track
 def get_gpu(range: str = "6h") -> dict:
     """GPU detail: current utilisation, VRAM used/total, power and temperature, plus
     per-model VRAM use and the caller→server attribution over `range`. Answers "why
@@ -126,6 +150,7 @@ def get_gpu(range: str = "6h") -> dict:
 
 
 @mcp.tool()
+@_track
 def get_history(range: str = "6h") -> dict:
     """Charted time-series the dashboard graphs over `range`: timestamps + aligned
     arrays for GPU util/VRAM/power/temp and host CPU/RAM/load/temp. Use for trends.
@@ -134,6 +159,7 @@ def get_history(range: str = "6h") -> dict:
 
 
 @mcp.tool()
+@_track
 def scan_disk(path: str = "/", rescan: bool = False) -> dict:
     """WizTree-style nested folder-size treemap for a host path (Disks tab). Wraps the
     monitor's on-demand scan and polls until done. `path` is an absolute host path
@@ -144,6 +170,7 @@ def scan_disk(path: str = "/", rescan: bool = False) -> dict:
 
 
 @mcp.tool()
+@_track
 def get_ai_models(range: str = "6h") -> dict:
     """AI model servers: which models are loaded, their VRAM use, and who is driving
     them (caller→server connection-seconds attribution over `range`, e.g. "6h",
@@ -153,6 +180,7 @@ def get_ai_models(range: str = "6h") -> dict:
 
 
 @mcp.tool()
+@_track
 def get_events(range: str = "6h") -> dict:
     """Recent edge-triggered events over `range` (OOM kills, threshold crossings),
     each with a blame line where one can be attributed, plus derived insights.
@@ -161,6 +189,7 @@ def get_events(range: str = "6h") -> dict:
 
 
 @mcp.tool()
+@_track
 def get_alerts(range: str = "6h") -> dict:
     """Alias for `get_events` — the monitor's alerts are its edge-triggered events."""
     return hc.get_alerts(range)
@@ -169,12 +198,14 @@ def get_alerts(range: str = "6h") -> dict:
 # ── resources ────────────────────────────────────────────────────────────────
 
 @mcp.resource("homelab://metrics", mime_type="text/plain")
+@_track
 def metrics_resource() -> str:
     """Prometheus exposition text from the monitor's /metrics endpoint."""
     return hc.get_metrics()
 
 
 @mcp.resource("homelab://health", mime_type="application/json")
+@_track
 def health_resource() -> str:
     """Monitor liveness + running version (from /healthz)."""
     return json.dumps(hc.get_version(), indent=2)
@@ -194,6 +225,7 @@ def _changelog_path():
 
 
 @mcp.resource("homelab://changelog", mime_type="text/markdown")
+@_track
 def changelog_resource() -> str:
     """The monitor's CHANGELOG, bundled into the image, for version context."""
     path = _changelog_path()

--- a/mcp_status.py
+++ b/mcp_status.py
@@ -1,0 +1,70 @@
+"""Shared MCP activity status — read by Flask, written by the MCP server process.
+
+A tiny JSON file under /data (or MCP_STATUS_PATH) is the IPC between the two
+processes launched by launch.py. No background jobs; writers bump on each tool/
+resource call, readers load on demand when /api/mcp-status is hit.
+"""
+
+import json
+import os
+import tempfile
+import threading
+import time
+
+_DEFAULT_DIR = os.path.dirname(os.environ.get("DB_PATH", "/data/gpu.db"))
+STATUS_PATH = os.environ.get("MCP_STATUS_PATH") or os.path.join(_DEFAULT_DIR, "mcp_status.json")
+
+_LOCK = threading.Lock()
+_IN_FLIGHT = 0
+
+
+def _read_raw():
+    try:
+        with open(STATUS_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _write_raw(data):
+    directory = os.path.dirname(STATUS_PATH) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".mcp_status_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, STATUS_PATH)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def record_activity():
+    """Mark an MCP tool/resource invocation (thread-safe, in-process in_flight)."""
+    global _IN_FLIGHT
+    now = time.time()
+    with _LOCK:
+        _IN_FLIGHT += 1
+        data = _read_raw()
+        data["last_activity_ts"] = now
+        data["total_requests"] = int(data.get("total_requests") or 0) + 1
+        data["in_flight"] = _IN_FLIGHT
+        _write_raw(data)
+
+
+def clear_activity():
+    """Decrement in-flight counter after a tool/resource finishes."""
+    global _IN_FLIGHT
+    with _LOCK:
+        _IN_FLIGHT = max(0, _IN_FLIGHT - 1)
+        data = _read_raw()
+        data["in_flight"] = _IN_FLIGHT
+        _write_raw(data)
+
+
+def read_status():
+    """Return the persisted status dict (empty when the file is missing)."""
+    return _read_raw()

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -50,6 +50,11 @@ h1{font-size:22px;margin:0}.ver{color:var(--mut);font-size:12px;border:1px solid
 .spark.go{animation:sparkfly .62s ease-out forwards}
 @keyframes sparkfly{0%{opacity:1;transform:translate(0,0) scale(1)}100%{opacity:0;transform:translate(var(--dx),var(--dy)) scale(.2)}}
 .live{display:flex;align-items:center;gap:6px;color:var(--mut);font-size:13px;margin-left:auto}
+.mcp-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:2px 8px;border-radius:999px;border:1px solid var(--bd);background:var(--inset);color:var(--mut);cursor:default;white-space:nowrap;line-height:1.3}
+.mcp-pill::before{content:'';width:6px;height:6px;border-radius:50%;background:currentColor;flex-shrink:0}
+.mcp-pill.active{color:var(--ok);border-color:var(--ok);background:var(--okbg)}
+.mcp-pill.idle{color:var(--mut)}
+.mcp-pill.down{color:var(--crit);border-color:var(--crit);background:var(--critbg)}
 .pulse{width:9px;height:9px;border-radius:50%;background:var(--ok);animation:p 2s infinite}
 @keyframes p{0%{box-shadow:0 0 0 0 #3fb95066}70%{box-shadow:0 0 0 8px #3fb95000}100%{box-shadow:0 0 0 0 #3fb95000}}
 .sub{color:var(--mut);margin:4px 0 14px;font-size:13.5px}
@@ -399,6 +404,7 @@ th{font-size:10px;text-transform:uppercase;letter-spacing:.05em}
   /* keep the header/live stamp from being clipped at the right edge */
   header{gap:8px}
   .live{font-size:11px}
+  .mcp-pill{font-size:10px;padding:2px 6px;gap:4px}
   /* tighter gutters reclaim width for content on small screens */
   .content{padding-left:13px;padding-right:13px}
   .card{padding:13px 13px}
@@ -451,7 +457,7 @@ a{color:var(--info)}
 <header><h1>🛰️ HomeLab Monitor</h1><span class="ver" id="ver">v…</span>
 <button type="button" class="upd" id="updbadge" title="A newer release is available — click for details">⬆ <span id="updlatest">v…</span> available</button>
 <button type="button" class="upd osupd" id="osupdbadge" title="One or more machines have OS/kernel updates pending — click for details">⬆ <span id="osupdtext">updates</span></button>
-<span class="live"><span class="pulse"></span><span id="lastup">connecting…</span></span></header>
+<span class="live"><span id="mcppill" class="mcp-pill" hidden>MCP</span><span class="pulse"></span><span id="lastup">connecting…</span></span></header>
 <p class="sub">One small container for your home lab — GPU &amp; local-AI, Docker containers, systemd services and host health, all on one page. Everything is discovered automatically; nothing is hardcoded.</p>
 
 <div class="topnav">
@@ -922,9 +928,31 @@ async function loadData(){
   renderData();
   if(TAB==='disks') renderDisksTab();   // populate/refresh disk cards (sig-guarded; won't wipe a scan)
 }
+function fmtMcpAge(sec){
+  if(sec < 60) return sec + 's ago';
+  if(sec < 3600) return Math.floor(sec / 60) + 'm ago';
+  return Math.floor(sec / 3600) + 'h ago';
+}
+function renderMcpPill(s){
+  const el = document.getElementById('mcppill');
+  if(!el) return;
+  if(!s || !s.enabled || s.state === 'off'){ el.hidden = true; return; }
+  el.hidden = false;
+  const labels = {active: 'MCP active', idle: 'MCP idle', down: 'MCP down'};
+  el.textContent = labels[s.state] || 'MCP';
+  el.className = 'mcp-pill ' + (s.state || 'idle');
+  const tip = [];
+  if(s.last_activity_age_s != null) tip.push('Last activity: ' + fmtMcpAge(s.last_activity_age_s));
+  else tip.push('Last activity: never');
+  if(s.active_requests > 0) tip.push('Active requests: ' + s.active_requests);
+  if(s.port) tip.push('Port ' + s.port);
+  el.title = tip.join(' · ');
+}
 async function loadHealth(){
   try{ HH = await(await fetch('/api/health')).json(); }catch(e){ return; }
   renderHealth();
+  try{ renderMcpPill(await(await fetch('/api/mcp-status')).json()); }
+  catch(e){ /* leave the pill unchanged on a transient fetch error */ }
 }
 
 // ── Renderers (history-backed tabs) ───────────────────────────────────────────

--- a/tests/test_mcp_status.py
+++ b/tests/test_mcp_status.py
@@ -1,0 +1,105 @@
+"""Unit tests for MCP status pill backend (issue #84)."""
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+import mcp_status as ms
+
+
+class TestMcpStatusFile(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._prev = ms.STATUS_PATH
+        ms.STATUS_PATH = os.path.join(self._tmpdir.name, "mcp_status.json")
+        ms._IN_FLIGHT = 0
+
+    def tearDown(self):
+        ms.STATUS_PATH = self._prev
+        ms._IN_FLIGHT = 0
+        self._tmpdir.cleanup()
+
+    def test_record_and_read_activity(self):
+        ms.record_activity()
+        ms.clear_activity()
+        raw = ms.read_status()
+        self.assertIn("last_activity_ts", raw)
+        self.assertEqual(raw["total_requests"], 1)
+        self.assertEqual(raw["in_flight"], 0)
+
+    def test_in_flight_tracks_concurrent_calls(self):
+        ms.record_activity()
+        raw = ms.read_status()
+        self.assertEqual(raw["in_flight"], 1)
+        ms.clear_activity()
+        self.assertEqual(ms.read_status()["in_flight"], 0)
+
+    def test_read_missing_file_returns_empty(self):
+        self.assertEqual(ms.read_status(), {})
+
+
+class TestBuildMcpStatus(unittest.TestCase):
+    def test_disabled_returns_off(self):
+        with patch.object(app, "_mcp_enabled", return_value=False):
+            out = app.build_mcp_status()
+        self.assertEqual(out, {"enabled": False, "state": "off"})
+
+    @patch.object(app, "_mcp_probe", return_value=False)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={})
+    def test_unreachable_is_down(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "down")
+        self.assertFalse(out["up"])
+
+    @patch.object(app, "_mcp_probe", return_value=True)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={"in_flight": 2, "last_activity_ts": time.time()})
+    def test_in_flight_is_active(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "active")
+        self.assertEqual(out["active_requests"], 2)
+
+    @patch.object(app, "_mcp_probe", return_value=True)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={"last_activity_ts": time.time() - 10})
+    def test_recent_activity_is_active(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "active")
+        self.assertLessEqual(out["last_activity_age_s"], 45)
+
+    @patch.object(app, "_mcp_probe", return_value=True)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={"last_activity_ts": time.time() - 120})
+    def test_stale_activity_is_idle(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "idle")
+
+    @patch.object(app, "_mcp_probe", return_value=True)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={})
+    def test_no_activity_up_is_idle(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "idle")
+
+    @patch.object(app, "_mcp_probe", return_value=True)
+    @patch.object(app, "_mcp_enabled", return_value=True)
+    @patch.object(app, "_mcp_port", return_value=9810)
+    @patch.object(ms, "read_status", return_value={})
+    def test_missing_status_file_is_idle_not_error(self, *_mocks):
+        out = app.build_mcp_status()
+        self.assertEqual(out["state"], "idle")
+        self.assertTrue(out["up"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #84

## What this changes
- Adds an MCP status pill beside the updated clock
- Shows MCP active, idle, and down states
- Adds a dedicated `/api/mcp-status` endpoint
- Tracks recent MCP activity across tool/resource calls
- Adds backend tests for MCP status state transitions

## Notes
- Pill is hidden when MCP is disabled
- Uses a 45-second idle timeout before returning to idle state
- Existing dashboard behavior remains unchanged