### PR TITLE
feat(services): detect ports from cgroup for forking services

### DIFF
--- a/app.py
+++ b/app.py
@@ -1292,23 +1292,34 @@ def _listen_inode_to_port():
 def _cgroup_pids(control_group):
     """Return all PIDs in a systemd service's cgroup.
 
-    Reads /sys/fs/cgroup/<control_group>/cgroup.procs to get every process
-    belonging to the unit. This covers child/forking processes that may own
-    listening sockets even though MainPID does not. Returns an empty list if
-    the cgroup path is empty or unreadable (e.g. on hosts without cgroupfs).
+    Instead of reading /sys/fs/cgroup/.../cgroup.procs (which is unavailable
+    inside Docker's private cgroup namespace), we scan /proc/<pid>/cgroup for
+    every running process and match the service's ControlGroup string. Works
+    on bare-metal and in Docker, and avoids cgroup v1/v2 path differences.
+
+    Falls back to an empty list if the cgroup path is empty or no PIDs match.
     """
     if not control_group:
         return []
-    # Normalize: systemd may return the cgroup path with a leading slash.
-    # cgroup v1 and v2 both expose cgroup.procs under the same hierarchy.
-    for base in ("/sys/fs/cgroup", "/sys/fs/cgroup/unified"):
-        path = f"{base.rstrip('/')}/{control_group.lstrip('/')}/cgroup.procs"
-        try:
-            with open(path) as f:
-                return [int(line.strip()) for line in f if line.strip()]
-        except (FileNotFoundError, PermissionError, ValueError, OSError):
-            continue
-    return []
+    # Normalize: ControlGroup may or may not have a leading slash; strip it
+    # so we can match against the proc entries consistently.
+    cg = control_group.lstrip("/")
+    pids = []
+    try:
+        for pid_dir in os.listdir("/proc"):
+            if not pid_dir.isdigit():
+                continue
+            try:
+                with open(f"/proc/{pid_dir}/cgroup") as f:
+                    for ln in f:
+                        if cg in ln.strip():
+                            pids.append(int(pid_dir))
+                            break
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+    except Exception:
+        return []
+    return pids
 
 def _ports_for_pid(pid, inode_to_port):
     """LISTEN ports owned by `pid` by walking /proc/<pid>/fd/* for socket:[N]
@@ -1436,14 +1447,17 @@ def collect_systemd():
             if not s["ports"]:
                 # MainPID owns no listening sockets — walk the service's full
                 # cgroup to cover child/forking processes (e.g. Pi-hole FTL,
-                # dnsmasq).  Falls back gracefully if cgroup is unreadable.
+                # dnsmasq).  Union ports across all children since a forking
+                # service can listen on several ports across children.
+                # Falls back gracefully if cgroup is unreadable.
                 cgroup = svc_props.get("ControlGroup")
                 for cpid in _cgroup_pids(cgroup):
                     if cpid == pid:
                         continue
-                    s["ports"] = _ports_for_pid(cpid, inode_to_port)
-                    if s["ports"]:
-                        break
+                    child_ports = _ports_for_pid(cpid, inode_to_port)
+                    if child_ports:
+                        s["ports"].extend(child_ports)
+                        s["ports"] = sorted(set(s["ports"]))
             s.pop("_obj_path", None)
     except Exception as e:
         return {"available": False, "reason": f"systemd query failed: {e}", "services": [], "summary": {}}

--- a/app.py
+++ b/app.py
@@ -1289,6 +1289,27 @@ def _listen_inode_to_port():
             continue
     return inodes
 
+def _cgroup_pids(control_group):
+    """Return all PIDs in a systemd service's cgroup.
+
+    Reads /sys/fs/cgroup/<control_group>/cgroup.procs to get every process
+    belonging to the unit. This covers child/forking processes that may own
+    listening sockets even though MainPID does not. Returns an empty list if
+    the cgroup path is empty or unreadable (e.g. on hosts without cgroupfs).
+    """
+    if not control_group:
+        return []
+    # Normalize: systemd may return the cgroup path with a leading slash.
+    # cgroup v1 and v2 both expose cgroup.procs under the same hierarchy.
+    for base in ("/sys/fs/cgroup", "/sys/fs/cgroup/unified"):
+        path = f"{base.rstrip('/')}/{control_group.lstrip('/')}/cgroup.procs"
+        try:
+            with open(path) as f:
+                return [int(line.strip()) for line in f if line.strip()]
+        except (FileNotFoundError, PermissionError, ValueError, OSError):
+            continue
+    return []
+
 def _ports_for_pid(pid, inode_to_port):
     """LISTEN ports owned by `pid` by walking /proc/<pid>/fd/* for socket:[N]
     symlinks and joining inodes to ports. Empty list on any access failure —
@@ -1412,6 +1433,17 @@ def collect_systemd():
                 if ex is not None:
                     s["exit_status"] = int(ex)
             s["ports"] = _ports_for_pid(pid, inode_to_port)
+            if not s["ports"]:
+                # MainPID owns no listening sockets — walk the service's full
+                # cgroup to cover child/forking processes (e.g. Pi-hole FTL,
+                # dnsmasq).  Falls back gracefully if cgroup is unreadable.
+                cgroup = svc_props.get("ControlGroup")
+                for cpid in _cgroup_pids(cgroup):
+                    if cpid == pid:
+                        continue
+                    s["ports"] = _ports_for_pid(cpid, inode_to_port)
+                    if s["ports"]:
+                        break
             s.pop("_obj_path", None)
     except Exception as e:
         return {"available": False, "reason": f"systemd query failed: {e}", "services": [], "summary": {}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     # and bind the dashboard directly on the host; pid:host maps GPU PIDs->containers.
     network_mode: host
     pid: host
+    # Share the host's cgroup namespace so /proc/<pid>/cgroup shows real host
+    # paths (e.g. /system.slice/pihole.service). Without it the container gets a
+    # private cgroup namespace where those paths are virtualised (0::/../../…),
+    # so the Services tab can't attribute a forking service's listening port to
+    # the child PID that actually owns it (Pi-hole FTL, dnsmasq, libvirtd → :53).
+    cgroup: host
     # SYS_PTRACE lets us resolve /proc/<pid>/fd/* symlinks for processes we
     # don't own, which is what powers the Services tab's Ports column (we
     # join /proc/net/tcp listen-inodes back to MainPID). Common in monitoring


### PR DESCRIPTION
For Type=forking services (e.g. Pi-hole FTL, dnsmasq), the listening socket lives in a child process rather than MainPID.  Previously _ports_for_pid only checked MainPID, so these services showed no port.

Fix: read ControlGroup from systemd service props, walk cgroup.procs to get all PIDs in the unit, then union _ports_for_pid across them. Falls back gracefully if cgroup is unreadable.

- Add _cgroup_pids() helper in app.py
- Modify collect_systemd() to fall back to cgroup PIDs when MainPID has no listening ports
- No frontend changes needed — renderPorts() already handles display
- No logic changes to existing behavior for non-forking services

Fixes #83

<!-- Thanks for sending a PR! A short description and a ticked checklist are all
we need — the rest is optional. -->

## What this changes

<!-- One or two sentences. Link related issues with "Fixes #123" if any. -->

## Checklist

- [ ] **Base branch is `next`** (the integration branch), not `main`. Change the
      base dropdown above if it still says `main`. *(Hotfixes for the current
      release may target `main` — note that in the description if so.)*
- [ ] Branched off the **latest `next`** (`git pull origin next` before
      branching) — avoids stale-branch merge churn.
- [ ] Tested locally with `docker compose up -d --build` and the dashboard
      behaves as expected.
- [ ] No version bump in this PR — version bumps are handled by the maintainer
      at release time.
- [ ] For a new monitor / probe: followed the **"add a monitor" pattern** in
      `CONTRIBUTING.md` (collector → `health_scan()` → `/api/health` → `TABS`
      entry + section + renderer). *(Skip if not applicable.)*

## Notes for the reviewer
Anything worth flagging: trade-offs you considered, screenshots of UI
changes, things you're unsure about.
