### PR TITLE
docs(changelog): credit contributors by handle for 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ release notes.
 ## [0.15.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.15.0) — 2026-06-12
 *Polish, safety & sharing.*
 - **Snapshot & Share** — grab the current tab as a PNG, or share a generic link + blurb (no host data) to X, Reddit, Hacker News, LinkedIn, Mastodon, Bluesky, Telegram, WhatsApp and more. Closes #31, #87.
-- **Service ports** — the Services tab shows each service's listening port as a click-through link, now including forking services (Pi-hole FTL, dnsmasq, libvirtd) whose socket lives in a child process — resolved via the unit's cgroup. Closes #83. Thanks @ravvdevv.
-- **Backup & restore** — one-click SQLite export/import so you never lose your history. Closes #86.
-- **MCP status pill** — see at a glance when an AI agent is connected to the built-in MCP server. Closes #84.
-- **Telegram alerting** — a third notification channel alongside Discord and ntfy. Closes #27.
-- **Desktop polish** — the dashboard fills the width and tints nav vs. main for easier scanning. Closes #85.
+- **Service ports** — the Services tab shows each service's listening port as a click-through link, now including forking services (Pi-hole FTL, dnsmasq, libvirtd) whose socket lives in a child process — resolved via the unit's cgroup. Closes #83. Thanks @ravvdevv for the PR, and @vaishnavidesai09 for the scoping.
+- **Backup & restore** — one-click SQLite export/import so you never lose your history. Closes #86. Thanks @mohd-ibadullah.
+- **MCP status pill** — see at a glance when an AI agent is connected to the built-in MCP server. Closes #84. Thanks @mohd-ibadullah.
+- **Telegram alerting** — a third notification channel alongside Discord and ntfy. Closes #27. Thanks @mohd-ibadullah.
+- **Desktop polish** — the dashboard fills the width and tints nav vs. main for easier scanning. Closes #85. Thanks @vikasvardhanv.
 - **What's new** — a one-time welcome modal after an upgrade, rolling up the changelog for every release since the one you last ran (served offline from this file).
+
+Huge thanks to @mohd-ibadullah, @vikasvardhanv and @ravvdevv for the PRs this cycle — and @vaishnavidesai09 for the scoping on #83.
 
 ## [0.14.4](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.4) — 2026-06-10
 - **Fix:** Services tab now refreshes immediately when you switch hosts. The host-switch path in `refreshCurrentTab()` was missing a `services` branch, so Services only re-rendered on tab-change instead of right away. Closes #82. Thanks @mohd-ibadullah for the first-time contribution.


### PR DESCRIPTION
<!-- Thanks for sending a PR! A short description and a ticked checklist are all
we need — the rest is optional. -->

## What this changes

<!-- One or two sentences. Link related issues with "Fixes #123" if any. -->

## Checklist

- [ ] **Base branch is `next`** (the integration branch), not `main`. Change the
      base dropdown above if it still says `main`. *(Hotfixes for the current
      release may target `main` — note that in the description if so.)*
- [ ] Branched off the **latest `next`** (`git pull origin next` before
      branching) — avoids stale-branch merge churn.
- [ ] Tested locally with `docker compose up -d --build` and the dashboard
      behaves as expected.
- [ ] No version bump in this PR — version bumps are handled by the maintainer
      at release time.
- [ ] For a new monitor / probe: followed the **"add a monitor" pattern** in
      `CONTRIBUTING.md` (collector → `health_scan()` → `/api/health` → `TABS`
      entry + section + renderer). *(Skip if not applicable.)*

## Notes for the reviewer

<!-- Anything worth flagging: trade-offs you considered, screenshots of UI
changes, things you're unsure about. -->
