### PR TITLE
ci: publish :next image on next pushes + ardi preview compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ name: CI
 #   • Pull requests targeting `next` (the integration branch) or `main`.
 #   • Pushes to `next` — a belt-and-braces check after merges land.
 # Intentionally NOT on every main push (tags/main already gate releases).
+#
+# On a push to `next`, once `smoke` is green, `publish-next` ships a moving
+# `:next` Docker image (the preview channel) so a Watchtower-followed staging
+# instance can auto-redeploy. See deploy/docker-compose.next.yml.
 
 on:
   pull_request:
@@ -48,3 +52,44 @@ jobs:
             sleep 1
           done
           echo "healthz never came up"; docker logs hlm; docker rm -f hlm; exit 1
+
+  # ── preview channel ───────────────────────────────────────────────────────────
+  # After smoke passes on a push to `next`, publish a moving `:next` image (plus an
+  # immutable `:next-<sha>` for pinning / rollback) to Docker Hub. This is the dev
+  # preview channel, kept separate from the released `:latest` / `:x.y.z` tags that
+  # release.yml publishes on `v*` tags. A Watchtower-followed staging instance on
+  # the hub (deploy/docker-compose.next.yml) redeploys whenever `:next` moves.
+  publish-next:
+    needs: smoke
+    if: github.event_name == 'push' && github.ref == 'refs/heads/next'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: sikamikaniko123/homelab-monitor
+          tags: |
+            type=raw,value=next
+            type=sha,prefix=next-,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          # amd64-only keeps the per-merge build fast; the deploy target (ardi) is
+          # x86_64. Add linux/arm64 here (and setup-qemu-action above) if you ever
+          # run `:next` on an arm host.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ release notes.
 ## [0.15.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.15.0) — 2026-06-12
 *Polish, safety & sharing.*
 - **Snapshot & Share** — grab the current tab as a PNG, or share a generic link + blurb (no host data) to X, Reddit, Hacker News, LinkedIn, Mastodon, Bluesky, Telegram, WhatsApp and more. Closes #31, #87.
-- **Service ports** — the Services tab shows each service's listening port as a click-through link, now including forking services (Pi-hole FTL, dnsmasq, libvirtd) whose socket lives in a child process — resolved via the unit's cgroup. Closes #83. Thanks @ravvdevv.
-- **Backup & restore** — one-click SQLite export/import so you never lose your history. Closes #86.
-- **MCP status pill** — see at a glance when an AI agent is connected to the built-in MCP server. Closes #84.
-- **Telegram alerting** — a third notification channel alongside Discord and ntfy. Closes #27.
-- **Desktop polish** — the dashboard fills the width and tints nav vs. main for easier scanning. Closes #85.
+- **Service ports** — the Services tab shows each service's listening port as a click-through link, now including forking services (Pi-hole FTL, dnsmasq, libvirtd) whose socket lives in a child process — resolved via the unit's cgroup. Closes #83. Thanks @ravvdevv for the PR, and @vaishnavidesai09 for the scoping.
+- **Backup & restore** — one-click SQLite export/import so you never lose your history. Closes #86. Thanks @mohd-ibadullah.
+- **MCP status pill** — see at a glance when an AI agent is connected to the built-in MCP server. Closes #84. Thanks @mohd-ibadullah.
+- **Telegram alerting** — a third notification channel alongside Discord and ntfy. Closes #27. Thanks @mohd-ibadullah.
+- **Desktop polish** — the dashboard fills the width and tints nav vs. main for easier scanning. Closes #85. Thanks @vikasvardhanv.
 - **What's new** — a one-time welcome modal after an upgrade, rolling up the changelog for every release since the one you last ran (served offline from this file).
+
+Huge thanks to @mohd-ibadullah, @vikasvardhanv and @ravvdevv for the PRs this cycle — and @vaishnavidesai09 for the scoping on #83.
 
 ## [0.14.4](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.14.4) — 2026-06-10
 - **Fix:** Services tab now refreshes immediately when you switch hosts. The host-switch path in `refreshCurrentTab()` was missing a `services` branch, so Services only re-rendered on tab-change instead of right away. Closes #82. Thanks @mohd-ibadullah for the first-time contribution.

--- a/deploy/docker-compose.next.yml
+++ b/deploy/docker-compose.next.yml
@@ -1,0 +1,77 @@
+# Preview / staging deployment of the `next` channel on the hub (ardi).
+#
+# Runs the moving `sikamikaniko123/homelab-monitor:next` image — published by
+# .github/workflows/ci.yml on every push to the `next` branch — as a SECOND
+# instance alongside the released prod one, on its own ports + data dir so the
+# two never collide:
+#
+#   prod : dashboard :9800  · MCP :9810  · ./data        (docker-compose.yml)
+#   next : dashboard :9801  · MCP :9811  · ./data-next    (this file)
+#
+# Watchtower (scoped to opted-in containers via the enable label) polls Docker
+# Hub and redeploys this container whenever the `:next` digest changes — so the
+# loop is: merge to `next` → CI publishes `:next` → Watchtower auto-redeploys
+# here. Hands-off.
+#
+# Bring it up on ardi:
+#   docker compose -f docker-compose.next.yml up -d
+# Then open http://ardi:9801 (MCP at http://ardi:9811/mcp).
+#
+# Rollback / pin: set the image to an immutable tag, e.g.
+#   image: sikamikaniko123/homelab-monitor:next-<shortsha>
+# and remove the watchtower enable label so it stops auto-updating.
+#
+# If ardi ALREADY runs a global Watchtower, delete the `watchtower` service
+# below and just keep the enable label on homelab-monitor-next.
+
+services:
+  homelab-monitor-next:
+    image: sikamikaniko123/homelab-monitor:next
+    container_name: homelab-monitor-next
+    pull_policy: always          # `up -d` always grabs the freshest :next
+    restart: unless-stopped
+    # Same host-privileged shape as the prod compose so the preview behaves
+    # identically (host networking, GPU PID->container mapping, ptrace ports).
+    network_mode: host
+    pid: host
+    cgroup: host
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor=unconfined
+    labels:
+      # Opt THIS container in to the label-scoped Watchtower below. Prod and
+      # everything else on ardi stay untouched because they lack this label.
+      com.centurylinklabs.watchtower.enable: "true"
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: utility
+      PORT: "9801"               # preview dashboard  -> http://ardi:9801
+      MCP_PORT: "9811"           # preview MCP server -> http://ardi:9811/mcp
+      SAMPLE_INTERVAL: "10"
+      RETENTION_DAYS: "180"
+      PRESSURE_FREE_MB: "2048"
+      HOST_ROOT: "/rootfs"
+      DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/run/dbus/system_bus_socket"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro   # container health, names & model APIs
+      - /:/rootfs:ro                                    # read-only host fs for disk usage
+      - ./data-next:/data                               # separate history DB — never touches prod's ./data
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
+
+  # Label-scoped Watchtower: only manages containers carrying the enable label
+  # above, so it redeploys the preview instance and nothing else. Drop this
+  # service if ardi already has a global Watchtower.
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower-next
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: >-
+      --label-enable
+      --cleanup
+      --interval 60
+    # --label-enable : only touch containers with com.centurylinklabs.watchtower.enable=true
+    # --cleanup      : delete the superseded image after a successful pull
+    # --interval 60  : poll Docker Hub every 60s


### PR DESCRIPTION
## What
Adds a **preview Docker channel** for the `next` branch.

- **`.github/workflows/ci.yml`** — new `publish-next` job (`needs: smoke`, gated to `push` on `next`). Once the existing `smoke` check is green, it builds **amd64** and pushes to Docker Hub:
  - `sikamikaniko123/homelab-monitor:next` — moving tag (Watchtower follows this)
  - `sikamikaniko123/homelab-monitor:next-<sha>` — immutable, for pinning / rollback

  Reuses the existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets. Separate from `release.yml`, which still owns `:latest` / `:x.y.z` on `v*` tags.

- **`deploy/docker-compose.next.yml`** — runs `:next` as a **second instance** on the hub, alongside prod, with no collisions:

  | | Dashboard | MCP | Data dir | Tag |
  |---|---|---|---|---|
  | prod (existing) | `:9800` | `:9810` | `./data` | `:latest` |
  | next (this) | `:9801` | `:9811` | `./data-next` | `:next` |

  Includes a **label-scoped Watchtower** (`--label-enable`, 60s poll) that only manages the opted-in `:next` container — prod and everything else on the host are untouched.

## Flow
merge to `next` → `smoke` passes → `publish-next` pushes `:next` → Watchtower on the hub redeploys the 9801 instance. Hands-off.

## Notes
- amd64-only keeps per-merge builds fast (deploy target is x86_64); arm64 is a one-line add if ever needed.
- If the hub already runs a global Watchtower, drop the `watchtower` service from the compose and keep just the enable label.
- Merging this PR is itself the first push to `next` that publishes `:next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)