### PR TITLE
Feature/98 clickable logo

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -324,6 +324,9 @@ body{background:var(--canvas)}
 /* visual hierarchy: nav surfaces distinct from content */
 .main{min-width:0;display:flex;flex-direction:column;background:var(--bg)}
 .sbrand{display:flex;align-items:center;flex-wrap:wrap;gap:5px 9px;padding:14px 15px 12px;border-bottom:1px solid var(--bd)}
+.sbrand-link{display:flex;align-items:center;gap:9px;color:inherit;background:none;border:0;padding:0;font:inherit;text-decoration:none;min-width:0;cursor:pointer}
+.sbrand-link:hover .nm{color:var(--accent)}
+.sbrand-link:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:6px}
 .sbrand .logo{font-size:17px;flex:none}.sbrand .nm{font-size:13.5px;font-weight:600;white-space:nowrap}
 .sbrand .ver{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--mut);background:var(--card);border:1px solid var(--bd);border-radius:7px;padding:2px 8px;line-height:1.4}
 .navlist{flex:1 1 auto;overflow:auto;padding:8px}
@@ -992,7 +995,7 @@ function mountShell(){
   const STAR_SVG  = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>';
   const GH_SVG    = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>';
   const ISSUE_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0z"/></svg>';
-  side.innerHTML = '<div class="sbrand"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span></div>'
+  side.innerHTML = '<div class="sbrand"><button type="button" class="sbrand-link" id="homeBrand" aria-label="Go to Overview" title="Go to Overview"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span></button></div>'
     + '<div class="ghbox">'
     +   '<a class="ghstar" id="ghstar" href="'+REPO+'" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub — it genuinely helps the project grow">'
     +     STAR_SVG + '<span id="ghlabel">Star on GitHub</span>'
@@ -1006,6 +1009,7 @@ function mountShell(){
     +   '<div class="star-cta cta-post">Thanks for the star! Got an idea or a bug? <a href="'+REPO+'/issues/new/choose" target="_blank" rel="noopener">Open an issue</a>.</div>'
     + '</div>'
     + '<div class="navlist" id="navlist"></div><div class="foot" id="foot"></div>';
+  const homeBrand = document.getElementById('homeBrand'); if(homeBrand) homeBrand.addEventListener('click', () => showTab('overview'));
   const ver = document.getElementById('ver'); if(ver) document.querySelector('.sbrand').appendChild(ver);
   const tb = document.getElementById('topbar');
   const hb = document.getElementById('hostbar'); if(hb) tb.appendChild(hb);


### PR DESCRIPTION
## What this changes

Makes the homelab title or logo `HomeLab Monitor` in the top header clickable. It now correctly triggers the existing frontend tab-switching to route the user back to the default overview landing page or rather view from any other tab. 

Fixes #98

## Checklist

- [x] **Base branch is `next`** (the integration branch), not `main`. Change the base dropdown above if it still says `main`.
- [x] Branched off the **latest `next`** (`git pull origin next` before branching) — avoids stale-branch merge churn.
- [x] Tested locally with `docker compose up -d --build` and the dashboard behaves as expected.
- [x] No version bump in this PR — version bumps are handled by the maintainer at release time.
- [x] For a new monitor / probe: followed the **"add a monitor" pattern** in `CONTRIBUTING.md`. *(Not applicable)*

## Notes for the reviewer

The implementation wraps the header logo block in a clickable element within `static/dashboard.html` and utilizes the existing `TABS` switching machinery to ensure no architectural regressions. Added an `aria-label="Go to Overview"` and appropriate pointer styling for correct UX and accessibility :)