### PR TITLE
harden: du `--` guard, ssh-target dash guard, webhook URL validation (#96)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1957,6 +1957,12 @@ def _parse_ssh_target(t):
     port = int(g["port"]) if g["port"] else 22
     if not (1 <= port <= 65535):
         return None
+    # Defence-in-depth: a user/host beginning with '-' could be read as an ssh
+    # option (e.g. "-oProxyCommand=…") if it ever reached argv unguarded. The
+    # ssh calls below also pass the destination after "--", so this is the belt
+    # to that suspenders.
+    if g["user"].startswith("-") or g["host"].startswith("-"):
+        return None
     return g["user"], g["host"], port
 
 def list_hosts():
@@ -2300,7 +2306,7 @@ def _ssh(user, host, port, cmd, timeout=8):
     t0 = time.time()
     try:
         p = subprocess.run([
-            "ssh", *_SSH_BASE_ARGS, "-p", str(port), f"{user}@{host}", cmd,
+            "ssh", *_SSH_BASE_ARGS, "-p", str(port), "--", f"{user}@{host}", cmd,
         ], capture_output=True, timeout=timeout)
         ms = int((time.time() - t0) * 1000)
         return (p.returncode,
@@ -2319,7 +2325,7 @@ def _ssh_with_stdin(user, host, port, cmd, stdin_bytes, timeout=60):
     t0 = time.time()
     try:
         p = subprocess.run([
-            "ssh", *_SSH_BASE_ARGS, "-p", str(port), f"{user}@{host}", cmd,
+            "ssh", *_SSH_BASE_ARGS, "-p", str(port), "--", f"{user}@{host}", cmd,
         ], input=stdin_bytes, capture_output=True, timeout=timeout)
         ms = int((time.time() - t0) * 1000)
         return (p.returncode,
@@ -2762,6 +2768,30 @@ def get_settings():
     except Exception as e:
         print("settings read error:", e, flush=True)
     return out
+
+# Settings that hold a URL the server itself will later POST to (the alert
+# webhooks). The dashboard API is intentionally unauthenticated on a trusted
+# LAN, so validating the scheme/host on save keeps someone who can reach the
+# dashboard from pointing these at a non-HTTP scheme or an empty host — a small
+# SSRF-surface tightening, not a change to the trusted-LAN model.
+_URL_SETTING_KEYS = {"discord_webhook_url", "ntfy_server"}
+
+def _validate_url_settings(updates):
+    """Return an error string if any URL-valued setting is malformed, else None.
+    An empty value is allowed (it clears the setting)."""
+    for key in _URL_SETTING_KEYS:
+        if key not in updates:
+            continue
+        val = (updates[key] or "").strip()
+        if not val:
+            continue
+        try:
+            u = urllib.parse.urlparse(val)
+        except Exception:
+            return f"{key} is not a valid URL."
+        if u.scheme not in ("http", "https") or not u.netloc:
+            return f"{key} must be an http(s) URL with a host."
+    return None
 
 def save_settings(updates):
     """Persist any subset of known setting keys. Unknown keys are ignored."""
@@ -3562,7 +3592,9 @@ def _disk_scan_worker(path, real):
         # --max-depth=2 gives two levels at once (folder + its sub-folders) for a
         # nested treemap. du recurses fully regardless of --max-depth, so this is
         # no costlier than depth 1 — it only prints more.
-        r = subprocess.run(["du", "-b", "--max-depth=2", "--one-file-system", real],
+        # `--` ends option parsing so a path can never be read as a du flag.
+        # `real` always starts with "/" already, so this is belt-and-suspenders.
+        r = subprocess.run(["du", "-b", "--max-depth=2", "--one-file-system", "--", real],
                            capture_output=True, text=True, timeout=600)
         sizes = {}
         for ln in (r.stdout or "").splitlines():
@@ -3778,6 +3810,9 @@ def api_settings():
         # Secrets pass through the "_set: false" sentinel from the UI as a way
         # to clear without revealing the current value.
         updates = {k: body[k] for k in body if k in SETTING_DEFAULTS}
+        err = _validate_url_settings(updates)
+        if err:
+            return jsonify({"ok": False, "error": err}), 400
         save_settings(updates)
     return jsonify({"version": VERSION, "settings": _public_settings()})
 

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,75 @@
+"""Unit tests for the defence-in-depth hardening follow-ups (issue #96):
+du `--` argv guard, ssh-target dash guard, and webhook URL validation."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestSshTargetDashGuard(unittest.TestCase):
+    def test_normal_targets_parse(self):
+        self.assertEqual(app._parse_ssh_target("anakin@cloudy"), ("anakin", "cloudy", 22))
+        self.assertEqual(app._parse_ssh_target("ardi@192.168.1.12:2222"),
+                         ("ardi", "192.168.1.12", 2222))
+
+    def test_user_starting_with_dash_rejected(self):
+        self.assertIsNone(app._parse_ssh_target("-oProxyCommand@host"))
+
+    def test_host_starting_with_dash_rejected(self):
+        self.assertIsNone(app._parse_ssh_target("user@-evil"))
+
+    def test_ssh_argv_passes_destination_after_double_dash(self):
+        fake = MagicMock(returncode=0, stdout=b"ok", stderr=b"")
+        with patch("app.subprocess.run", return_value=fake) as run:
+            app._ssh("user", "host", 22, "echo ok")
+        argv = run.call_args[0][0]
+        self.assertIn("--", argv)
+        # "--" must immediately precede the user@host destination.
+        self.assertEqual(argv[argv.index("--") + 1], "user@host")
+
+
+class TestDuArgvGuard(unittest.TestCase):
+    def test_du_path_passed_after_double_dash(self):
+        fake = MagicMock(stdout="", returncode=0)
+        # statvfs() in the worker is already wrapped in try/except, so a missing
+        # free-space figure is harmless and we don't need to stub it here.
+        with patch("app.subprocess.run", return_value=fake) as run:
+            app._disk_scan_worker("/", "/rootfs/some/dir")
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0], "du")
+        self.assertIn("--", argv)
+        # The scanned path must come straight after "--" so it can't be a flag.
+        self.assertEqual(argv[argv.index("--") + 1], "/rootfs/some/dir")
+
+
+class TestWebhookUrlValidation(unittest.TestCase):
+    def test_empty_value_allowed(self):
+        self.assertIsNone(app._validate_url_settings({"discord_webhook_url": ""}))
+        self.assertIsNone(app._validate_url_settings({"ntfy_server": "   "}))
+
+    def test_missing_key_allowed(self):
+        self.assertIsNone(app._validate_url_settings({"alerts_enabled": "1"}))
+
+    def test_valid_http_and_https_accepted(self):
+        self.assertIsNone(app._validate_url_settings(
+            {"discord_webhook_url": "https://discord.com/api/webhooks/1/abc"}))
+        self.assertIsNone(app._validate_url_settings(
+            {"ntfy_server": "http://ntfy.lan:8080"}))
+
+    def test_non_http_scheme_rejected(self):
+        err = app._validate_url_settings({"discord_webhook_url": "file:///etc/passwd"})
+        self.assertIsNotNone(err)
+        self.assertIn("discord_webhook_url", err)
+
+    def test_missing_host_rejected(self):
+        self.assertIsNotNone(app._validate_url_settings({"ntfy_server": "https://"}))
+
+    def test_garbage_rejected(self):
+        self.assertIsNotNone(app._validate_url_settings({"ntfy_server": "not a url"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #96.

Three low-severity, defence-in-depth follow-ups from a pass over the codebase. None are exploitable on the dashboard's trusted-LAN model — they're cheap hygiene.

1. **`du` argv guard** — `_disk_scan_worker` now passes the scanned path after `--`, so it can never be read as a `du` option (`real` already always starts with `/`; belt-and-suspenders).
2. **SSH-target dash guard** — `_parse_ssh_target` rejects a `user`/`host` beginning with `-`, and both `_ssh` / `_ssh_with_stdin` pass the destination after `--`, so a crafted target can't be parsed as an ssh option.
3. **Webhook URL validation** — `discord_webhook_url` / `ntfy_server` are validated as `http(s)` URLs with a host on save (small SSRF-surface tightening); bad input returns 400, empty still clears.

**Tests:** `tests/test_hardening.py` (11 cases) covers all three. `python -m py_compile app.py probe.py` passes (matches CI smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)