### PR TITLE
revert: drop the parallel #98 logo-home impl in favour of #101 (DevCrox)

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -324,10 +324,6 @@ body{background:var(--canvas)}
 /* visual hierarchy: nav surfaces distinct from content */
 .main{min-width:0;display:flex;flex-direction:column;background:var(--bg)}
 .sbrand{display:flex;align-items:center;flex-wrap:wrap;gap:5px 9px;padding:14px 15px 12px;border-bottom:1px solid var(--bd)}
-.sbrand[role=button]{cursor:pointer}
-.sbrand[role=button] .nm{transition:color .12s}
-.sbrand[role=button]:hover .nm,.sbrand[role=button]:focus-visible .nm{color:var(--accent)}
-.sbrand[role=button]:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:6px}
 .sbrand .logo{font-size:17px;flex:none}.sbrand .nm{font-size:13.5px;font-weight:600;white-space:nowrap}
 .sbrand .ver{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--mut);background:var(--card);border:1px solid var(--bd);border-radius:7px;padding:2px 8px;line-height:1.4}
 .navlist{flex:1 1 auto;overflow:auto;padding:8px}
@@ -996,7 +992,7 @@ function mountShell(){
   const STAR_SVG  = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>';
   const GH_SVG    = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>';
   const ISSUE_SVG = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0z"/></svg>';
-  side.innerHTML = '<div class="sbrand" id="brandhome" role="button" tabindex="0" aria-label="Go to Overview" title="Go to Overview"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span></div>'
+  side.innerHTML = '<div class="sbrand"><span class="logo">🛰️</span><span class="nm">HomeLab Monitor</span></div>'
     + '<div class="ghbox">'
     +   '<a class="ghstar" id="ghstar" href="'+REPO+'" target="_blank" rel="noopener" title="Star HomeLab Monitor on GitHub — it genuinely helps the project grow">'
     +     STAR_SVG + '<span id="ghlabel">Star on GitHub</span>'
@@ -1011,16 +1007,6 @@ function mountShell(){
     + '</div>'
     + '<div class="navlist" id="navlist"></div><div class="foot" id="foot"></div>';
   const ver = document.getElementById('ver'); if(ver) document.querySelector('.sbrand').appendChild(ver);
-  // Click the logo/title to go home (Overview), like a site logo. Keyboard-
-  // activatable since it's a role=button.
-  const brand = document.getElementById('brandhome');
-  if(brand){
-    const goHome = () => showTab('overview');
-    brand.addEventListener('click', goHome);
-    brand.addEventListener('keydown', e => {
-      if(e.key === 'Enter' || e.key === ' '){ e.preventDefault(); goHome(); }
-    });
-  }
   const tb = document.getElementById('topbar');
   const hb = document.getElementById('hostbar'); if(hb) tb.appendChild(hb);
   const ctr = document.getElementById('controls'); if(ctr) tb.appendChild(ctr);


### PR DESCRIPTION
Reverts the logo-home implementation from #103. A contributor (@DevCrox) had an open PR for the same issue (#98) first — #101, with a cleaner native `<button>`. This revert clears my parallel version so #101 lands clean (no duplicate `side.innerHTML` / dead handler) and their implementation is the one that actually ships.

Merge order: this first, then #101.