### PR TITLE
feat(host): mini-htop — top processes by CPU and RAM (#32)

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,7 +166,7 @@ LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "te
           "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
-HEALTH = {"docker": None, "systemd": None, "update": None, "at": 0}
+HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
 WATCH_SERVICES = [s.strip() for s in os.environ.get("WATCH_SERVICES", "").split(",") if s.strip()]
 SYSTEMD_ADMIN_DIR = "/etc/systemd/system/"   # units here are admin/user-authored (vs vendor)
 _ct_cache = {"list": [], "at": 0}
@@ -1899,10 +1899,70 @@ def local_diagnostics():
         _diag(checks, "host_metrics", "Host metrics", "warn", "/proc not readable — host metrics limited")
     return {"checks": checks, "summary": _summarize(checks)}
 
+# ── Top processes (issue #32): a psutil-free /proc reader for the Host tab's
+# mini-htop. Aggregates by command so N workers of one exe collapse into a single
+# row, and derives CPU% from the jiffy delta between two health scans (~15s
+# apart) against /proc/stat's total. The first scan after boot has no delta, so
+# CPU% reads 0 until the next cycle. Builds on the /proc parsing seeded in #34
+# (thanks @samkelomncwabe63-svg).
+_PROC_PREV = {"total": None, "pids": {}}
+_PROC_PAGE_KB = (os.sysconf("SC_PAGE_SIZE") // 1024) if hasattr(os, "sysconf") else 4
+
+def _total_cpu_jiffies():
+    with open("/proc/stat") as f:
+        parts = f.readline().split()[1:]   # cpu  user nice system idle iowait …
+    return sum(int(x) for x in parts)
+
+def collect_top_processes(top_n=10):
+    """Top-N processes by CPU% and by RAM, aggregated by command. Reads /proc
+    directly (no psutil); returns None where /proc isn't available (e.g. a
+    Windows hub) so the card simply hides rather than erroring."""
+    try:
+        total = _total_cpu_jiffies()
+        pids = [p for p in os.listdir("/proc") if p.isdigit()]
+    except Exception:
+        return None
+    prev_total = _PROC_PREV["total"]
+    prev_pids  = _PROC_PREV["pids"]
+    cur_pids, agg = {}, {}
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/stat") as f:
+                stat = f.read()
+            rp = stat.rfind(")")                 # comm can hold spaces/parens
+            comm = stat[stat.find("(") + 1:rp]
+            rest = stat[rp + 2:].split()         # fields from 'state' onward
+            jiff = int(rest[11]) + int(rest[12]) # utime + stime
+            with open(f"/proc/{pid}/statm") as f:
+                rss_kb = int(f.read().split()[1]) * _PROC_PAGE_KB
+        except (OSError, ValueError, IndexError):
+            continue
+        cur_pids[pid] = jiff
+        a = agg.setdefault(comm, {"mem_kb": 0, "dcpu": 0, "count": 0})
+        a["mem_kb"] += rss_kb
+        a["count"]  += 1
+        if pid in prev_pids:
+            d = jiff - prev_pids[pid]
+            if d > 0:
+                a["dcpu"] += d
+    _PROC_PREV["total"] = total
+    _PROC_PREV["pids"]  = cur_pids
+    ncpu = os.cpu_count() or 1
+    span = (total - prev_total) if prev_total else 0
+    rows = []
+    for comm, a in agg.items():
+        cpu = (100.0 * a["dcpu"] / span * ncpu) if span > 0 else 0.0
+        rows.append({"name": comm, "cpu_pct": round(cpu, 1),
+                     "mem_mb": round(a["mem_kb"] / 1024), "count": a["count"]})
+    return {"by_cpu": sorted(rows, key=lambda r: -r["cpu_pct"])[:top_n],
+            "by_mem": sorted(rows, key=lambda r: -r["mem_mb"])[:top_n],
+            "ncpu": ncpu}
+
 def health_scan():
     HEALTH["docker"]  = collect_docker()
     HEALTH["systemd"] = collect_systemd()
     HEALTH["update"]  = collect_update()
+    HEALTH["processes"] = collect_top_processes()
     collect_os_releases()
     HEALTH["at"]      = int(time.time())
 
@@ -3436,6 +3496,7 @@ def api_health():
     update  = HEALTH["update"]  or {"available": False, "current": VERSION}
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd, "update": update,
+                    "processes": HEALTH["processes"],
                     "os_updates": os_updates_summary(),
                     "diagnostics": local_diagnostics(),
                     "mcp": {"enabled": _mcp_enabled(), "port": _mcp_port()},

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -113,6 +113,18 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .tg{color:var(--mut);font-size:13px;display:flex;align-items:center;gap:6px;cursor:pointer}
 .cols{display:grid;grid-template-columns:1fr 1fr;gap:16px}@media(max-width:760px){.cols{grid-template-columns:1fr}}
 .cap{color:var(--mut);font-size:12px;margin-top:9px}.pill{font-size:11px;color:var(--mut);border:1px solid var(--bd);border-radius:5px;padding:1px 6px}
+/* Top-processes mini-htop (issue #32) */
+.topproc-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+@media(max-width:560px){.topproc-grid{grid-template-columns:1fr}}
+.topproc-col h3{font-size:11px;font-weight:700;color:var(--mut);text-transform:uppercase;letter-spacing:.05em;margin:0 0 6px}
+.topproc-row{display:flex;align-items:center;gap:8px;padding:5px 7px;border-radius:7px;font-size:12.5px}
+.topproc-row:nth-child(odd){background:rgba(127,127,127,.06)}
+.topproc-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:var(--mono)}
+.topproc-badge{flex:none;font-size:10px;color:var(--mut);border:1px solid var(--bd);border-radius:5px;padding:0 5px;line-height:1.5}
+.topproc-bar{flex:none;width:42px;height:6px;border-radius:4px;background:var(--bd);overflow:hidden}
+.topproc-bar>span{display:block;height:100%;border-radius:4px}
+.topproc-val{flex:none;font-variant-numeric:tabular-nums;font-weight:600;min-width:52px;text-align:right}
+.topproc-empty{color:var(--mut);font-size:12.5px;padding:6px 2px}
 .muted{color:var(--mut)}a{color:#58a6ff}
 /* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
 .ports{display:inline-flex;flex-wrap:wrap;gap:4px}
@@ -837,6 +849,10 @@ a{color:var(--info)}
     <div id="disks" style="margin-top:14px"></div>
     <div id="sysinfo" style="margin-top:16px"></div>
   </div>
+  <div class="card" id="topproc-card" hidden><h2>🧠 Top processes</h2>
+    <div class="topproc-grid" id="topproc"></div>
+    <p class="cap" id="topproc_cap"></p>
+  </div>
   <div class="card"><h2>🧠 Memory map — containers &amp; services</h2>
     <div id="ramtree" class="treemap"></div>
     <p class="cap" id="ramtree_cap"></p>
@@ -1169,6 +1185,7 @@ function renderData(){
        <span>💾 ${esc(dk.mount)}</span><span class="muted">${dk.used} / ${dk.total} GB · ${dk.pct}%</span></div>
        <div class="dbar"><div style="width:${dk.pct}%;background:${sev(dk.pct)}"></div></div></div>`).join('');
     renderSysInfo();
+    renderTopProcs();
   }
   // Network/Security read the active host block; re-render them on each data
   // refresh (and on first load) when one of them is the visible tab.
@@ -1176,6 +1193,39 @@ function renderData(){
   if(TAB==='security') renderSecurity();
 
   buildCharts();
+}
+
+// Mini-htop card (issue #32): top processes by CPU% and by RAM, from /api/health
+// (HH.processes), aggregated by command on the hub. Local hub only — /proc is
+// the hub's; remote hosts don't ship process tables yet, so the card hides.
+function renderTopProcs(){
+  const card = document.getElementById('topproc-card');
+  const box  = document.getElementById('topproc');
+  if(!card || !box) return;
+  const p = HH && HH.processes;
+  const cpu = (p && p.by_cpu) || [], mem = (p && p.by_mem) || [];
+  if(CURRENT_HOST !== 'local' || !p || (!cpu.length && !mem.length)){ card.hidden = true; return; }
+  card.hidden = false;
+  const ncpu = p.ncpu || 1;
+  const ramTotal = (HH.now && HH.now.host && HH.now.host.ram_total) || 0;
+  const tint = v => v>70 ? '#f85149' : v>35 ? '#d29922' : '#3fb950';
+  const row = (r, isCpu) => {
+    const pct   = isCpu ? Math.min(100, (r.cpu_pct||0)/ncpu)
+                        : (ramTotal ? Math.min(100, (r.mem_mb||0)*100/ramTotal) : 0);
+    const label = isCpu ? ((r.cpu_pct>=10?Math.round(r.cpu_pct):(r.cpu_pct||0).toFixed(1))+'%')
+                        : fmtMB(r.mem_mb||0);
+    const badge = r.count>1 ? `<span class="topproc-badge" title="${r.count} processes">×${r.count}</span>` : '';
+    return `<div class="topproc-row"><span class="topproc-name" title="${esc(r.name)}">${esc(r.name)}</span>${badge}`
+         + `<span class="topproc-bar"><span style="width:${pct}%;background:${tint(pct)}"></span></span>`
+         + `<span class="topproc-val">${label}</span></div>`;
+  };
+  const col = (title, arr, isCpu) =>
+    `<div class="topproc-col"><h3>${title}</h3>`
+    + (arr.length ? arr.map(r=>row(r,isCpu)).join('') : '<div class="topproc-empty">No data yet.</div>')
+    + '</div>';
+  box.innerHTML = col('By CPU', cpu, true) + col('By RAM', mem, false);
+  const cap = document.getElementById('topproc_cap');
+  if(cap) cap.textContent = `Grouped by command across ${ncpu} cores · CPU% is per-core · refreshes every 15s`;
 }
 
 // ── AI Models: expandable rows + per-model VRAM timeline ──────────────────────
@@ -1252,6 +1302,7 @@ function modelSpark(service,tot){
 function renderHealth(){
   if(!HH) return;
   document.getElementById('ver').textContent='v'+HH.version;
+  renderTopProcs();   // mini-htop card refreshes on every health poll (issue #32)
 
   // Update-available badge — only visible when GitHub releases shows a newer tag.
   const up = HH.update || {};

--- a/tests/test_topproc.py
+++ b/tests/test_topproc.py
@@ -1,0 +1,68 @@
+"""Unit tests for the Top-processes /proc reader (issue #32)."""
+import os
+import re
+import sys
+import unittest
+from unittest.mock import patch, mock_open
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+def _stat_blob(pid, comm, utime, stime=0):
+    # /proc/<pid>/stat: pid (comm) state ppid ... then at field 14/15 utime/stime.
+    # After the comm, fields start at 'state'; index 11 = utime, 12 = stime.
+    return f"{pid} ({comm}) S 1 1 1 0 -1 0 0 0 0 0 {utime} {stime} 0 0 20 0 1 0 100\n"
+
+
+class TestTopProcesses(unittest.TestCase):
+    def setUp(self):
+        app._PROC_PREV = {"total": None, "pids": {}}
+
+    def _run(self, total, procs):
+        """procs: {pid: (comm, jiffies, rss_pages)} -> collect_top_processes()."""
+        def fake_open(path, *a, **k):
+            if path == "/proc/stat":
+                return mock_open(read_data=f"cpu {total} 0 0 0 0 0 0 0\n")()
+            m = re.match(r"/proc/(\d+)/stat$", path)
+            if m:
+                comm, jiff, _ = procs[m.group(1)]
+                return mock_open(read_data=_stat_blob(m.group(1), comm, jiff))()
+            m = re.match(r"/proc/(\d+)/statm$", path)
+            if m:
+                pages = procs[m.group(1)][2]
+                return mock_open(read_data=f"9999 {pages} 0 0 0 0 0\n")()
+            raise FileNotFoundError(path)
+        with patch("app.os.listdir", return_value=list(procs.keys())), \
+             patch("app.os.cpu_count", return_value=4), \
+             patch("builtins.open", side_effect=fake_open):
+            return app.collect_top_processes()
+
+    def test_aggregates_workers_by_command(self):
+        procs = {"10": ("python", 100, 256), "11": ("python", 100, 256),
+                 "20": ("ollama", 50, 1024)}
+        r = self._run(1000, procs)
+        self.assertIsNotNone(r)
+        py = next(x for x in r["by_mem"] if x["name"] == "python")
+        self.assertEqual(py["count"], 2)                       # 2 workers collapsed
+        self.assertEqual(py["mem_mb"], round(2 * 256 * 4 / 1024))   # 2 MB
+        # ollama (1024 pages = 4 MB) tops the RAM column over python (2 MB)
+        self.assertEqual(r["by_mem"][0]["name"], "ollama")
+
+    def test_first_scan_has_zero_cpu(self):
+        r = self._run(1000, {"10": ("x", 500, 100)})
+        self.assertEqual(r["by_cpu"][0]["cpu_pct"], 0.0)       # no prev delta yet
+
+    def test_cpu_percent_from_jiffy_delta(self):
+        self._run(1000, {"10": ("stress", 0, 100)})           # seed prev
+        r = self._run(1400, {"10": ("stress", 100, 100)})     # +100 of +400 total
+        st = next(x for x in r["by_cpu"] if x["name"] == "stress")
+        self.assertAlmostEqual(st["cpu_pct"], 100.0, delta=0.1)  # *ncpu(4) per-core
+
+    def test_returns_none_without_proc(self):
+        with patch("app.os.listdir", side_effect=FileNotFoundError):
+            self.assertIsNone(app.collect_top_processes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #32.

A compact **🧠 Top processes** card on the Host tab — top-10 **By CPU** and top-10 **By RAM**, side by side.

### Backend (`app.py`)
- `collect_top_processes()` reads `/proc/<pid>/stat` + `/proc/<pid>/statm` directly — **no psutil**.
- **Aggregates by command** so 20 `python` workers collapse into one row (with an `×count` badge).
- **CPU%** derived from the jiffy delta between health scans (~15s) vs `/proc/stat` total, normalised per-core (`top`-style). First scan after boot reads 0% until the next cycle.
- Wired into `health_scan()` (same 15s cadence as the other host KPIs) and surfaced on `/api/health`.
- Returns `None` where `/proc` isn't available (Windows hub / remote) → the card simply hides.

### Frontend (`static/dashboard.html`)
- Two-column card with per-row mini usage bars (green/amber/red), tabular-aligned values, `×count` badges, theme-safe, responsive (stacks on narrow screens). Local-hub only for now.

### Tests
- `tests/test_topproc.py` (4 cases): command aggregation, RAM sort, zero-CPU first scan, CPU% from jiffy delta, and `None` without `/proc`. `py_compile` clean.

### Credit
Builds on the `/proc` parsing seeded in #34 — thanks @samkelomncwabe63-svg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)