### PR TITLE
feat(host): power & cost estimator — kWh to money (#25)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2813,6 +2813,8 @@ SETTING_DEFAULTS = {
     "telegram_chat_id":    "",
     "alert_min_level":     "warning",  # "warning" or "critical"
     "disk_alert_pct":      "90",       # disk usage % that trips an alert
+    "kwh_price":           "",         # electricity price per kWh; empty hides the cost card (#25)
+    "currency":            "$",        # symbol shown next to costs
 }
 SETTING_SECRETS = {"discord_webhook_url", "telegram_token"}   # never round-tripped to the UI in full
 
@@ -3365,6 +3367,55 @@ def api_data():
                     "services": services, "other": other, "summary": summary, "model_summary": model_summary,
                     "callers": callers, "events": evs, "insights": insights, "pressure_free_mb": PRESSURE_MB,
                     "mem_total": mem_total, "peak_mem": peak, "now": LATEST})
+
+@app.route("/api/cost")
+def api_cost():
+    """Power → kWh → money (#25). Integrates the GPU `power` samples we already
+    collect over the requested range. Each sample stands for INTERVAL seconds, so
+    energy(kWh) = sum(power_W) * INTERVAL / 3_600_000. Cost = energy * kwh_price.
+    The card stays hidden until a price is set, so `enabled` gates the UI."""
+    s = get_settings()
+    try:
+        price = float(s.get("kwh_price") or 0)
+    except (TypeError, ValueError):
+        price = 0.0
+    currency = s.get("currency") or "$"
+    rng = request.args.get("range", "7d")
+    span = RANGES.get(rng, 604800)
+    now = int(time.time())
+    kwh_per_wsample = INTERVAL / 3_600_000.0   # one power sample -> kWh
+
+    with LOCK:
+        cur = DB.cursor()
+        def avg_w(since):
+            return round(cur.execute("SELECT AVG(power) FROM samples WHERE ts>=?", (since,)).fetchone()[0] or 0)
+        def kwh(since):
+            tot = cur.execute("SELECT SUM(power) FROM samples WHERE ts>=?", (since,)).fetchone()[0] or 0
+            return tot * kwh_per_wsample
+        lt = time.localtime(now)
+        midnight = int(time.mktime((lt.tm_year, lt.tm_mon, lt.tm_mday, 0, 0, 0, 0, 0, -1)))
+        windows = {"today": kwh(midnight), "d7": kwh(now - 604800), "d30": kwh(now - 2592000)}
+
+        # Cumulative-cost series across the selected range (mirrors api_data buckets).
+        since = (cur.execute("SELECT MIN(ts) FROM samples").fetchone()[0] or now) if span is None else now - span
+        bk = max(INTERVAL, round(max(1, now - since) / MAX_POINTS))
+        rows = cur.execute("SELECT (ts/?)*? b, SUM(power) FROM samples WHERE ts>=? GROUP BY b ORDER BY b",
+                           (bk, bk, since)).fetchall()
+    labels, cost_cum, running = [], [], 0.0
+    for b, p in rows:
+        running += (p or 0) * kwh_per_wsample * price
+        labels.append(int(b)); cost_cum.append(round(running, 4))
+
+    fmt = lambda k: round(k * price, 2)
+    return jsonify({
+        "enabled": price > 0, "kwh_price": price, "currency": currency,
+        "range": rng, "bucket_sec": bk,
+        "current_w": round(LATEST.get("power") or 0),
+        "avg_24h_w": avg_w(now - 86400), "avg_7d_w": avg_w(now - 604800),
+        "kwh": {k: round(v, 3) for k, v in windows.items()},
+        "cost": {k: fmt(v) for k, v in windows.items()},
+        "series": {"labels": labels, "cost_cum": cost_cum},
+    })
 
 @app.route("/healthz")
 def healthz():

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -748,6 +748,20 @@ a{color:var(--info)}
         </div>
       </div>
 
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+        <div>
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Electricity price (per kWh)</div>
+          <input type="number" id="al_kwh" min="0" step="0.01" placeholder="e.g. 0.30"
+                 style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+        </div>
+        <div>
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Currency symbol</div>
+          <input type="text" id="al_currency" maxlength="4" placeholder="$"
+                 style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+        </div>
+      </div>
+      <p class="cap" style="margin-top:-4px">Powers the <b>💰 Power &amp; cost</b> card on the Host tab from the GPU power history. Leave the price blank to hide the card.</p>
+
       <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
         <button class="rb on" id="al_save">Save</button>
         <button class="rb"    id="al_test">Send test alert</button>
@@ -852,6 +866,16 @@ a{color:var(--info)}
   <div class="card" id="topproc-card" hidden><h2>🧠 Top processes</h2>
     <div class="topproc-grid" id="topproc"></div>
     <p class="cap" id="topproc_cap"></p>
+  </div>
+  <div class="card" id="cost-card" hidden><h2>💰 Power &amp; cost</h2>
+    <div id="cost-disabled" class="topproc-empty" hidden>
+      Set a price per kWh in <a href="#alerts" id="cost-settings-link">Settings</a> to see what your GPU costs to run.
+    </div>
+    <div id="cost-body" hidden>
+      <div class="grid" id="cost-kpis"></div>
+      <div class="chartbox short" style="margin-top:12px"><canvas id="costchart"></canvas></div>
+      <p class="cap" id="cost_cap"></p>
+    </div>
   </div>
   <div class="card"><h2>🧠 Memory map — containers &amp; services</h2>
     <div id="ramtree" class="treemap"></div>
@@ -1186,6 +1210,7 @@ function renderData(){
        <div class="dbar"><div style="width:${dk.pct}%;background:${sev(dk.pct)}"></div></div></div>`).join('');
     renderSysInfo();
     renderTopProcs();
+    renderCost();
   }
   // Network/Security read the active host block; re-render them on each data
   // refresh (and on first load) when one of them is the visible tab.
@@ -1226,6 +1251,47 @@ function renderTopProcs(){
   box.innerHTML = col('By CPU', cpu, true) + col('By RAM', mem, false);
   const cap = document.getElementById('topproc_cap');
   if(cap) cap.textContent = `Grouped by command across ${ncpu} cores · CPU% is per-core · refreshes every 15s`;
+}
+
+// Power & cost card (issue #25): turns the GPU power history into kWh -> money.
+// Fetches /api/cost for the active range; hidden until a kWh price is set, and a
+// thin cumulative-cost line tracks spend across the selected range. Local only.
+async function renderCost(){
+  const card = document.getElementById('cost-card');
+  if(!card) return;
+  if(CURRENT_HOST !== 'local'){ card.hidden = true; return; }
+  let j; try{ j = await (await fetch('/api/cost?range=' + encodeURIComponent(R))).json(); }
+  catch(e){ card.hidden = true; return; }
+  card.hidden = false;
+  const dis = document.getElementById('cost-disabled'), body = document.getElementById('cost-body');
+  if(!j.enabled){
+    dis.hidden = false; body.hidden = true;
+    if(charts['costchart']){ charts['costchart'].destroy(); delete charts['costchart']; }
+    const lk = document.getElementById('cost-settings-link');
+    if(lk) lk.onclick = e => { e.preventDefault(); showTab('alerts'); };
+    return;
+  }
+  dis.hidden = true; body.hidden = false;
+  const cur = j.currency || '$';
+  const money = v => cur + (v || 0).toFixed(2);
+  document.getElementById('cost-kpis').innerHTML = [
+    {v: j.current_w + ' W', l: 'Current draw'},
+    {v: j.avg_24h_w + ' W', l: '24h average'},
+    {v: j.avg_7d_w + ' W',  l: '7d average'},
+    {v: money(j.cost.today), l: 'Cost today',   s: (j.kwh.today||0).toFixed(2) + ' kWh'},
+    {v: money(j.cost.d7),    l: 'Last 7 days',   s: (j.kwh.d7||0).toFixed(1) + ' kWh'},
+    {v: money(j.cost.d30),   l: 'Last 30 days',  s: (j.kwh.d30||0).toFixed(1) + ' kWh'},
+  ].map(t => `<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div><div class="s">${t.s||''}</div></div>`).join('');
+  const labels = fmtLabels(j.series.labels);
+  mk('costchart', {type:'line', data:{labels, datasets:[
+    {label:'Cumulative cost ('+cur+')', data:j.series.cost_cum, borderColor:'#3fb950',
+     backgroundColor:'#3fb95033', fill:true, pointRadius:0, tension:.25}]},
+    options:{responsive:true, maintainAspectRatio:false, interaction:{mode:'index',intersect:false},
+      scales:{x:{grid:{color:cv('--free')}, ticks:{color:cv('--mut'), maxTicksLimit:10, autoSkip:true}},
+       y:{min:0, grid:{color:cv('--free')}, ticks:{color:cv('--mut'), callback:v=>cur+(+v).toFixed(2)}}},
+      plugins:{legend:{labels:{color:cv('--tx'), boxWidth:12}}}}, plugins:[areaBg]});
+  const cap = document.getElementById('cost_cap');
+  if(cap) cap.textContent = `At ${cur}${j.kwh_price}/kWh · integrated from GPU power samples · ${j.range} range`;
 }
 
 // ── AI Models: expandable rows + per-model VRAM timeline ──────────────────────
@@ -1629,6 +1695,8 @@ async function loadAlerts(){
   document.getElementById('al_telegram_chat_id').value = s.telegram_chat_id||'';
   document.getElementById('al_minlevel').value    = s.alert_min_level||'warning';
   document.getElementById('al_disk').value        = s.disk_alert_pct||'90';
+  document.getElementById('al_kwh').value         = s.kwh_price||'';
+  document.getElementById('al_currency').value    = s.currency||'$';
   // The webhook is a secret — server only returns whether one is set.
   const inp=document.getElementById('al_discord');
   if(!ALERTS_LOADED){ inp.value=''; inp.placeholder = s.discord_webhook_url_set
@@ -1659,6 +1727,8 @@ async function saveAlerts(){
     telegram_chat_id: document.getElementById('al_telegram_chat_id').value.trim(),
     alert_min_level:  document.getElementById('al_minlevel').value,
     disk_alert_pct:   String(parseInt(document.getElementById('al_disk').value||'90',10)||90),
+    kwh_price:        document.getElementById('al_kwh').value.trim(),
+    currency:         document.getElementById('al_currency').value.trim()||'$',
   };
   // Only send the webhook field if the user actually typed in it — empty means
   // "no change" when one is already saved (matching the placeholder hint),

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,46 @@
+"""Unit tests for the power & cost estimator endpoint (issue #25)."""
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestCost(unittest.TestCase):
+    def _seed_hour_at(self, watts):
+        """Fill the last hour with `watts` power samples, one per INTERVAL."""
+        now = int(time.time())
+        with app.LOCK:
+            app.DB.execute("DELETE FROM samples")
+            n = 3600 // app.INTERVAL
+            for i in range(n):
+                ts = now - 3600 + i * app.INTERVAL
+                app.DB.execute("INSERT OR REPLACE INTO samples(ts,util,mem_used,mem_total,power,temp) "
+                               "VALUES(?,?,?,?,?,?)", (ts, 0, 0, 0, watts, 0))
+            app.DB.commit()
+
+    def test_disabled_without_price(self):
+        app.save_settings({"kwh_price": "", "currency": "$"})
+        j = app.app.test_client().get("/api/cost?range=30d").get_json()
+        self.assertFalse(j["enabled"])
+
+    def test_250w_for_an_hour_at_0_30(self):
+        # 250 W for 1 h = 0.25 kWh -> 0.075 at 0.30/kWh (issue acceptance criterion).
+        self._seed_hour_at(250)
+        app.save_settings({"kwh_price": "0.30", "currency": "€"})
+        j = app.app.test_client().get("/api/cost?range=30d").get_json()
+        self.assertTrue(j["enabled"])
+        self.assertEqual(j["currency"], "€")
+        self.assertEqual(j["avg_24h_w"], 250)
+        self.assertAlmostEqual(j["kwh"]["d30"], 0.25, delta=0.01)
+        self.assertAlmostEqual(j["cost"]["d30"], 0.075, delta=0.01)
+        self.assertTrue(len(j["series"]["cost_cum"]) > 0)
+        # cumulative series is monotonic non-decreasing and ends near the total
+        cc = j["series"]["cost_cum"]
+        self.assertTrue(all(cc[i] <= cc[i + 1] + 1e-9 for i in range(len(cc) - 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #25.

Turns the GPU **power** samples we already collect into running cost.

### Backend (`app.py`)
- `GET /api/cost?range=…` integrates `samples.power` over the range (each sample = `INTERVAL` s) → kWh → currency. Returns current/24h/7d draw, cost for **today / last 7d / last 30d**, and a **cumulative-cost** series for the selected range.
- Two new settings — `kwh_price` (float) and `currency` (symbol) — round-trip next to the alert settings. `enabled` is false until a price is set.

### Frontend (`static/dashboard.html`)
- **💰 Power & cost** card on the Host tab: current/24h/7d draw, three cost rows with kWh subtitles, and a thin cumulative-cost line over the active range.
- Hidden until a price is set — replaced by a one-line *"set a price per kWh in Settings"* deep-link.
- Two Settings fields (price + currency) with a note pointing back to the card.

### Tests
- `tests/test_cost.py`: the issue's acceptance case (250 W for 1 h at 0.30 ≈ 0.075), disabled-without-price, and a monotonic cumulative series. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)