### PR TITLE
feat(gpu): support multiple GPUs — per-card monitoring (#95)

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,7 @@ LOCK = threading.Lock()
 _DB_MAINTENANCE = False   # True during backup/restore — collector skips DB writes
 _DB_SCHEMA = """
 CREATE TABLE IF NOT EXISTS samples(ts INTEGER PRIMARY KEY, util REAL, mem_used REAL, mem_total REAL, power REAL, temp REAL);
+CREATE TABLE IF NOT EXISTS gpu_samples(ts INTEGER, idx INTEGER, util REAL, mem_used REAL, mem_total REAL, power REAL, temp REAL);
 CREATE TABLE IF NOT EXISTS proc(ts INTEGER, service TEXT, mem REAL);
 CREATE TABLE IF NOT EXISTS models(ts INTEGER, service TEXT, model TEXT, vram REAL);
 CREATE TABLE IF NOT EXISTS edges(ts INTEGER, caller TEXT, server TEXT, conns INTEGER);
@@ -103,6 +104,7 @@ CREATE TABLE IF NOT EXISTS hosts(
   last_check_at INTEGER,
   last_check_json TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_gpus_ts   ON gpu_samples(ts);
 CREATE INDEX IF NOT EXISTS idx_proc_ts   ON proc(ts);
 CREATE INDEX IF NOT EXISTS idx_models_ts ON models(ts);
 CREATE INDEX IF NOT EXISTS idx_edges_ts  ON edges(ts);
@@ -170,7 +172,7 @@ except sqlite3.OperationalError as e:
 _apply_schema_migrations(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
-          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None}
+          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": []}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
@@ -3229,24 +3231,40 @@ def sample_once():
     # a GPU-less host). Now a GPU failure just degrades the GPU panel to "absent"
     # while temperature & friends keep refreshing.
     util = mem_used = mem_total = power = temp = 0.0
+    gpus = []
     procs = {}
     gpu_avail = False
     try:
-        g = smi(["--query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
-                 "--format=csv,noheader,nounits"]).splitlines()[0].split(",")
-        # Parse each field defensively: nvidia-smi emits the literal "[N/A]" /
-        # "[Not Supported]" for power.draw/temperature.gpu on many consumer/laptop
-        # GPUs and inside containers, even with `nounits`. The old all-or-nothing
-        # float() unpack raised ValueError on that, which the except below caught
-        # and reported the (present, working) GPU as ABSENT. Degrade just the bad
-        # field to 0 instead.
-        util, mem_used, mem_total, power, temp = (_gpu_num(x) for x in g)
+        # One CSV row per card (issue #95). Parse each field defensively: nvidia-smi
+        # emits the literal "[N/A]" / "[Not Supported]" for power.draw/temperature
+        # on many consumer/laptop GPUs and inside containers, even with `nounits` —
+        # so degrade just the bad field to 0 rather than dropping the whole card.
+        rows = smi(["--query-gpu=index,name,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu",
+                    "--format=csv,noheader,nounits"]).splitlines()
+        for line in rows:
+            if not line.strip():
+                continue
+            p = [x.strip() for x in line.split(",")]
+            if len(p) < 7:
+                continue
+            u, mu, mt, pw, tp = (_gpu_num(x) for x in p[2:7])
+            gpus.append({"idx": int(_gpu_num(p[0])), "name": p[1] or f"GPU {p[0]}",
+                         "util": u, "mem_used": mu, "mem_total": mt, "power": pw, "temp": tp})
+        if not gpus:
+            raise ValueError("nvidia-smi returned no GPU rows")
+        gpu_avail = True
+        # Aggregate across cards for the existing single-GPU views: VRAM + power are
+        # the pool, utilisation is averaged, temperature is the hottest card.
+        mem_used  = sum(g["mem_used"] for g in gpus)
+        mem_total = sum(g["mem_total"] for g in gpus)
+        power     = sum(g["power"] for g in gpus)
+        util      = round(sum(g["util"] for g in gpus) / len(gpus))
+        temp      = max(g["temp"] for g in gpus)
         for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
             if line.strip():
                 pid, mem = (p.strip() for p in line.split(","))
                 svc = service_for_pid(pid, nm)
                 procs[svc] = procs.get(svc, 0) + _gpu_num(mem)
-        gpu_avail = True
     except Exception as e:
         # Log only on the ok→fail edge so a permanently GPU-less host doesn't spam.
         if LATEST.get("gpu_avail"):
@@ -3296,12 +3314,19 @@ def sample_once():
                 DB.execute("INSERT INTO models VALUES(?,?,?,?)", (ts, svc, mdl, vram))  # lives in LATEST only
         for (caller, server), n in edges.items():
             DB.execute("INSERT INTO edges VALUES(?,?,?,?)", (ts, caller, server, n))
+        # Per-GPU history only when there's more than one card (single-GPU rigs are
+        # already covered by the aggregate `samples` table) — keeps storage lean.
+        if gpu_avail and len(gpus) > 1:
+            for g in gpus:
+                DB.execute("INSERT INTO gpu_samples(ts,idx,util,mem_used,mem_total,power,temp) "
+                           "VALUES(?,?,?,?,?,?,?)",
+                           (ts, g["idx"], g["util"], g["mem_used"], g["mem_total"], g["power"], g["temp"]))
         if ts % 360 < INTERVAL:
-            for t in ("samples", "proc", "models", "edges", "events"):
+            for t in ("samples", "proc", "models", "edges", "events", "gpu_samples"):
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))
         DB.commit()
     LATEST.update(ts=ts, util=util, mem_used=mem_used, mem_total=mem_total, power=power, temp=temp,
-                  gpu_avail=gpu_avail,
+                  gpu_avail=gpu_avail, gpus=gpus,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
@@ -3694,7 +3719,8 @@ def api_health():
     now = {"gpu": {"util": LATEST["util"], "mem_used": LATEST["mem_used"],
                    "mem_total": (LATEST["mem_total"] or 24576) if gpu_avail else 0,
                    "power": LATEST["power"], "temp": LATEST["temp"],
-                   "available": bool(gpu_avail)},
+                   "available": bool(gpu_avail),
+                   "gpus": LATEST.get("gpus") or []},   # per-card detail (issue #95)
            "host": enrich_os_upgrade(LATEST["host"])}
     docker  = HEALTH["docker"]  or {"available": False, "reason": "warming up…",
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -144,6 +144,16 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .logdrawer-status{font-size:11.5px;color:var(--mut);padding:4px 14px;flex:none}
 .logdrawer-body{flex:1;margin:0;padding:10px 14px;overflow:auto;background:#0b0e14;color:#cdd9e5;
   font-family:var(--mono);font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word}
+/* Per-GPU cards (issue #95) */
+.gpucard{border:1px solid var(--bd);border-radius:9px;padding:11px 13px;margin-bottom:10px;background:rgba(127,127,127,.04)}
+.gpucard:last-child{margin-bottom:0}
+.gpucard-h{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:7px;font-size:13.5px}
+.gpucard-stats{margin-left:auto;color:var(--mut);font-size:12px;font-variant-numeric:tabular-nums}
+.gpucard-row{display:flex;align-items:center;gap:9px;margin-top:5px;font-size:12.5px}
+.gpucard-lbl{flex:none;width:42px;color:var(--mut)}
+.gpucard-bar{flex:1;height:8px;border-radius:5px;background:var(--bd);overflow:hidden}
+.gpucard-bar>span{display:block;height:100%;border-radius:5px}
+.gpucard-val{flex:none;min-width:158px;text-align:right;font-variant-numeric:tabular-nums}
 .muted{color:var(--mut)}a{color:#58a6ff}
 /* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
 .ports{display:inline-flex;flex-wrap:wrap;gap:4px}
@@ -661,6 +671,10 @@ a{color:var(--info)}
     <div class="card"><h2>📋 Services on the GPU (selected range)</h2>
       <table><thead><tr><th>Service</th><th>Peak</th><th>Avg</th><th>% time</th></tr></thead><tbody id="sumtbl"></tbody></table>
     </div>
+  </div>
+  <div class="card" id="pergpu-card" hidden><h2>🎮 Per-GPU</h2>
+    <div id="pergpu"></div>
+    <p class="cap">Live per-card utilisation, VRAM, power and temperature. The cards above pool VRAM and power across all GPUs.</p>
   </div>
   <div class="card"><h2>📊 VRAM by service over time</h2>
     <div class="chartbox"><canvas id="vram"></canvas></div>
@@ -1214,6 +1228,7 @@ function renderData(){
     {v:fmtMB(n.mem_used)+' <span style="font-size:13px;color:var(--mut)">/ '+fmtMB(tot)+'</span>',l:'VRAM in use',s:memPct+'% full'},
     {v:Math.round(n.util)+'%',l:'GPU util',s:Math.round(n.power)+' W · '+Math.round(n.temp)+'°C'},
   ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div><div class="s">${t.s||''}</div></div>`).join('');
+  renderPerGpu(n.gpus);
   const bar=document.getElementById('vrambar'); bar.innerHTML='';
   n.procs.forEach(p=>{const s=document.createElement('div');s.style.width=(p.mem/tot*100)+'%';s.style.background=colorFor(p.service);s.title=p.service+': '+fmtMB(p.mem);bar.appendChild(s);});
   document.getElementById('nowtbl').innerHTML = n.procs.length? n.procs.map(p=>
@@ -1252,6 +1267,31 @@ function renderData(){
   if(TAB==='security') renderSecurity();
 
   buildCharts();
+}
+
+// Per-GPU cards (issue #95): one card per physical GPU with live util/VRAM/power/
+// temp. Shown only when there's more than one card — single-GPU rigs already see
+// everything in the "GPU right now" panel, which pools across cards.
+function renderPerGpu(gpus){
+  const card=document.getElementById('pergpu-card'), box=document.getElementById('pergpu');
+  if(!card||!box) return;
+  if(!gpus || gpus.length<2){ card.hidden=true; return; }
+  card.hidden=false;
+  const tint=v=>v>85?'#f85149':v>60?'#d29922':'#3fb950';
+  box.innerHTML = gpus.map(g=>{
+    const memPct = g.mem_total? Math.round(g.mem_used/g.mem_total*100):0;
+    const util = Math.round(g.util||0);
+    return `<div class="gpucard">
+      <div class="gpucard-h"><b>GPU ${g.idx}</b> <span class="muted">${esc(g.name||'')}</span>
+        <span class="gpucard-stats">${util}% util · ${Math.round(g.power||0)} W · ${Math.round(g.temp||0)}°C</span></div>
+      <div class="gpucard-row"><span class="gpucard-lbl">VRAM</span>
+        <span class="gpucard-bar"><span style="width:${memPct}%;background:${tint(memPct)}"></span></span>
+        <span class="gpucard-val">${fmtMB(g.mem_used||0)} / ${fmtMB(g.mem_total||0)} · ${memPct}%</span></div>
+      <div class="gpucard-row"><span class="gpucard-lbl">Util</span>
+        <span class="gpucard-bar"><span style="width:${Math.min(100,util)}%;background:${tint(util)}"></span></span>
+        <span class="gpucard-val">${util}%</span></div>
+    </div>`;
+  }).join('');
 }
 
 // Mini-htop card (issue #32): top processes by CPU% and by RAM, from /api/health

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -1,0 +1,57 @@
+"""Unit tests for multi-GPU sampling (issue #95)."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestMultiGpu(unittest.TestCase):
+    def _sample_with(self, gpu_csv):
+        def fake_smi(args):
+            a = " ".join(args)
+            if "query-gpu" in a:
+                return gpu_csv
+            return ""   # no compute-apps
+        with patch("app.smi", side_effect=fake_smi), \
+             patch("app.containers", return_value=[]), \
+             patch("app.sample_callers", return_value={}), \
+             patch("app.read_host", return_value={"cpu": 0, "ram_used": 0,
+                                                   "ram_total": 0, "load1": 0, "ctemp": 0}):
+            app.sample_once()
+
+    def test_two_gpus_parsed_and_aggregated(self):
+        self._sample_with("0, NVIDIA GeForce RTX 3090, 50, 8000, 24576, 200, 60\n"
+                          "1, NVIDIA GeForce RTX 3090, 10, 2000, 24576, 100, 45")
+        gs = app.LATEST["gpus"]
+        self.assertEqual([g["idx"] for g in gs], [0, 1])
+        self.assertTrue(app.LATEST["gpu_avail"])
+        self.assertEqual(app.LATEST["mem_used"], 10000)    # 8000 + 2000 (pool)
+        self.assertEqual(app.LATEST["mem_total"], 49152)   # 24576 * 2
+        self.assertEqual(app.LATEST["power"], 300)         # 200 + 100
+        self.assertEqual(app.LATEST["util"], 30)           # (50 + 10) / 2
+        self.assertEqual(app.LATEST["temp"], 60)           # hottest card
+        # per-GPU history persisted when there's more than one card
+        with app.LOCK:
+            n = app.DB.execute("SELECT COUNT(DISTINCT idx) FROM gpu_samples").fetchone()[0]
+        self.assertGreaterEqual(n, 2)
+
+    def test_single_gpu_still_works(self):
+        self._sample_with("0, NVIDIA GeForce RTX 3090, 25, 4000, 24576, 150, 55")
+        self.assertEqual(len(app.LATEST["gpus"]), 1)
+        self.assertEqual(app.LATEST["mem_used"], 4000)
+        self.assertEqual(app.LATEST["util"], 25)
+        self.assertTrue(app.LATEST["gpu_avail"])
+
+    def test_not_supported_fields_degrade(self):
+        self._sample_with("0, GPU, [N/A], 1000, 8000, [Not Supported], [Not Supported]")
+        g = app.LATEST["gpus"][0]
+        self.assertEqual(g["mem_used"], 1000)
+        self.assertEqual(g["power"], 0)   # unsupported -> 0, card still present
+        self.assertEqual(g["temp"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #95.

The monitor now understands rigs with **more than one GPU**.

### Backend (`app.py`)
- The GPU sampler enumerates **every card** (one `nvidia-smi` row per GPU) instead of only GPU 0. Each card's util / VRAM / power / temp is kept live in `LATEST["gpus"]` and surfaced on `/api/health` (`now.gpu.gpus`) and `/api/data` (`now.gpus`).
- Per-GPU history is persisted to a new `gpu_samples` table (only when there's >1 card, to stay lean) and pruned with the rest.
- The **existing single-GPU views are unchanged**: they now show **pooled** VRAM and power across cards, **averaged** utilisation, and the **hottest** temperature.

### Frontend (`static/dashboard.html`)
- A new **🎮 Per-GPU** card on the GPU tab: one row per card with live util & VRAM bars (green/amber/red), power and temp. Shown **only when more than one GPU** is present, so single-GPU users see no change.

### Tests
- `tests/test_multigpu.py`: two-GPU parse + aggregation (pool/avg/max) + history persistence, single-GPU unchanged, and `[N/A]`/`[Not Supported]` fields degrading to 0 without dropping the card. Full suite (53 tests) green.

### Note
I don't have a multi-GPU rig to see this render live — verified by unit tests and on the single-GPU hub. I'll ask the reporter to try it on the `next` preview image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)