### PR TITLE
fix(network): keep host throughput to real NICs, not per-container veths (#30)

### DIFF
--- a/app.py
+++ b/app.py
@@ -584,11 +584,19 @@ def _read_net_dev(path):
         pass
     return out
 
+# Per-container veth pairs and the dynamic docker-network bridges are internal
+# plumbing — on a busy host there are dozens, and their traffic is already shown
+# per-container in the Top-talkers table. Keep the host throughput view to real
+# uplinks (eth*, en*, wl*, bond*, docker0, tailscale*, wg* …).
+_HOST_NIC_SKIP = re.compile(r"^(veth|br-)")
+
 def _net_rows(ts, nm):
     """Rows for net_samples this tick: host NICs from /proc/net/dev plus one row
     per container (its netns totals, read via a representative PID) tagged '@name'."""
     rows = []
     for iface, (rx, tx) in _read_net_dev("/proc/net/dev").items():
+        if _HOST_NIC_SKIP.match(iface):
+            continue
         rows.append((ts, iface, rx, tx))
     try:
         for name, pid in container_pids(nm).items():
@@ -3671,7 +3679,7 @@ def api_network():
             s = aout.setdefault(b, [0, 0]); s[0] += do / dt; s[1] += 1
         return ain, aout
 
-    host_ifaces = sorted(i for i in series if not i.startswith("@"))
+    host_ifaces = sorted(i for i in series if not i.startswith("@") and not _HOST_NIC_SKIP.match(i))
     labels = sorted({(t // bk) * bk for i in host_ifaces for t, _, _ in series[i]})
     ifaces_out = []
     for iface in host_ifaces:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -32,6 +32,23 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(oll["bytes_in"], 5000)
         self.assertEqual(oll["total"], 6000)
 
+    def test_veth_and_bridges_excluded_from_host_nics(self):
+        now = int(time.time())
+        t0, t1 = now - 40, now - 30
+        with app.LOCK:
+            app.DB.execute("DELETE FROM net_samples")
+            app.DB.executemany(
+                "INSERT INTO net_samples(ts,iface,bytes_in,bytes_out) VALUES(?,?,?,?)",
+                [(t0, "eth0", 0, 0), (t1, "eth0", 1000, 500),
+                 (t0, "veth1234", 0, 0), (t1, "veth1234", 9000, 9000),
+                 (t0, "br-abcdef", 0, 0), (t1, "br-abcdef", 9000, 9000)])
+            app.DB.commit()
+        j = app.app.test_client().get("/api/network?range=1h").get_json()
+        names = [x["iface"] for x in j["ifaces"]]
+        self.assertIn("eth0", names)
+        self.assertNotIn("veth1234", names)   # per-container plumbing filtered out
+        self.assertNotIn("br-abcdef", names)
+
     def test_counter_reset_is_ignored(self):
         now = int(time.time())
         with app.LOCK:


### PR DESCRIPTION
Follow-up polish to #30. The live hub returned **31 NICs** for the throughput chart — every container's `veth*` pair and the dynamic `br-<id>` docker bridges. Those are internal plumbing (already covered per-container by the Top-talkers table), so the chart was unusably noisy.

Now filtered both at sample time and on read, keeping the host view to real uplinks (`eth*`, `en*`, `docker0`, `tailscale*`, …). Adds a test asserting veth/bridge exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)