### PR TITLE
feat(gpu): telemetry truth — throttle, mem-BW, clocks, power headroom (#95)

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,7 +174,7 @@ except sqlite3.OperationalError as e:
 _apply_schema_migrations(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
-          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": []}
+          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": [], "gpu_extra": {}}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
@@ -3189,6 +3189,89 @@ def _gpu_num(x):
     except ValueError:
         return 0.0
 
+# Extra per-card telemetry the AI/DS crowd actually debugs with: memory-bandwidth
+# utilisation (mem-bound vs compute-bound), core/memory clocks, power limit (for
+# headroom), performance state, memory-junction temp, and the *throttle reasons*
+# that explain a card quietly running below its rated clocks. All best-effort —
+# many consumer GPUs report "[N/A]" for some of these and very old drivers may not
+# know a field name at all — so enrichment runs in its own guard and never blocks
+# the core GPU sample. `clocks_throttle_reasons.active` is a hex bitmask; the
+# field prefix was renamed `clocks_event_reasons` in newer drivers, so we try both.
+_THROTTLE_BITS = [
+    (0x0000000000000004, "Power cap"),    # SW_POWER_CAP — hitting the power limit
+    (0x0000000000000008, "HW slowdown"),  # HW_SLOWDOWN (thermal/power/other, generic)
+    (0x0000000000000020, "SW thermal"),   # SW_THERMAL_SLOWDOWN
+    (0x0000000000000040, "HW thermal"),   # HW_THERMAL_SLOWDOWN — too hot
+    (0x0000000000000080, "Power brake"),  # HW_POWER_BRAKE_SLOWDOWN — external power brake
+]
+
+def _decode_throttle(hexstr):
+    """nvidia-smi throttle bitmask → list of *meaningful* reasons. Idle / app-clocks
+    / sync-boost / display bits are normal and intentionally ignored."""
+    try:
+        mask = int(str(hexstr).strip(), 16)
+    except (TypeError, ValueError):
+        return []
+    return [label for bit, label in _THROTTLE_BITS if mask & bit]
+
+def _enrich_gpus(gpus):
+    """Best-effort: attach mem_util/clocks/power_limit/pstate/temp_mem and throttle
+    reasons to each card dict in `gpus` (matched by index). Mutates in place."""
+    by_idx = {g["idx"]: g for g in gpus}
+    try:
+        rows = smi(["--query-gpu=index,utilization.memory,clocks.current.sm,clocks.current.memory,"
+                    "power.limit,temperature.memory,pstate", "--format=csv,noheader,nounits"]).splitlines()
+        for line in rows:
+            p = [x.strip() for x in line.split(",")]
+            if len(p) < 7:
+                continue
+            g = by_idx.get(int(_gpu_num(p[0])))
+            if not g:
+                continue
+            g["mem_util"]    = _gpu_num(p[1])
+            g["clk_sm"]      = _gpu_num(p[2])
+            g["clk_mem"]     = _gpu_num(p[3])
+            g["power_limit"] = _gpu_num(p[4])
+            g["temp_mem"]    = _gpu_num(p[5])
+            g["pstate"]      = p[6] if (p[6] and not p[6].startswith("[")) else ""
+    except Exception:
+        pass
+    for field in ("clocks_throttle_reasons.active", "clocks_event_reasons.active"):
+        try:
+            rows = smi(["--query-gpu=index," + field, "--format=csv,noheader,nounits"]).splitlines()
+        except Exception:
+            continue
+        ok = False
+        for line in rows:
+            p = [x.strip() for x in line.split(",")]
+            if len(p) < 2 or not p[1] or p[1].startswith("["):
+                continue
+            g = by_idx.get(int(_gpu_num(p[0])))
+            if g is None:
+                continue
+            g["throttle"] = _decode_throttle(p[1])
+            g["throttled"] = bool(g["throttle"])
+            ok = True
+        if ok:
+            break
+
+def _gpu_extra(gpus):
+    """Aggregate the enriched per-card telemetry into one representative dict for the
+    always-visible 'GPU right now' panel (single-GPU rigs never see the per-card cards)."""
+    if not gpus:
+        return {}
+    g0 = gpus[0]
+    return {
+        "mem_util":  round(sum(g.get("mem_util", 0) for g in gpus) / len(gpus)),
+        "clk_sm":    round(g0.get("clk_sm", 0)),
+        "clk_mem":   round(g0.get("clk_mem", 0)),
+        "power_limit": round(sum(g.get("power_limit", 0) for g in gpus)),
+        "pstate":    g0.get("pstate", ""),
+        "temp_mem":  round(max((g.get("temp_mem", 0) for g in gpus), default=0)),
+        "throttled": any(g.get("throttled") for g in gpus),
+        "throttle":  sorted({r for g in gpus for r in g.get("throttle", [])}),
+    }
+
 def service_for_pid(pid, nm):
     try:
         with open(f"/proc/{pid}/cgroup") as f:
@@ -3286,6 +3369,7 @@ def sample_once():
     # while temperature & friends keep refreshing.
     util = mem_used = mem_total = power = temp = 0.0
     gpus = []
+    gpu_extra = {}
     procs = {}
     gpu_avail = False
     try:
@@ -3314,6 +3398,8 @@ def sample_once():
         power     = sum(g["power"] for g in gpus)
         util      = round(sum(g["util"] for g in gpus) / len(gpus))
         temp      = max(g["temp"] for g in gpus)
+        _enrich_gpus(gpus)                 # mem-bw util, clocks, power limit, throttle reasons (best-effort)
+        gpu_extra = _gpu_extra(gpus)
         for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
             if line.strip():
                 pid, mem = (p.strip() for p in line.split(","))
@@ -3382,7 +3468,7 @@ def sample_once():
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))
         DB.commit()
     LATEST.update(ts=ts, util=util, mem_used=mem_used, mem_total=mem_total, power=power, temp=temp,
-                  gpu_avail=gpu_avail, gpus=gpus,
+                  gpu_avail=gpu_avail, gpus=gpus, gpu_extra=gpu_extra,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
@@ -3910,7 +3996,8 @@ def api_health():
                    "mem_total": (LATEST["mem_total"] or 24576) if gpu_avail else 0,
                    "power": LATEST["power"], "temp": LATEST["temp"],
                    "available": bool(gpu_avail),
-                   "gpus": LATEST.get("gpus") or []},   # per-card detail (issue #95)
+                   "gpus": LATEST.get("gpus") or [],    # per-card detail (issue #95)
+                   "extra": LATEST.get("gpu_extra") or {}},  # mem-bw/clocks/throttle (telemetry)
            "host": enrich_os_upgrade(LATEST["host"])}
     docker  = HEALTH["docker"]  or {"available": False, "reason": "warming up…",
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -154,6 +154,12 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .gpucard-bar{flex:1;height:8px;border-radius:5px;background:var(--bd);overflow:hidden}
 .gpucard-bar>span{display:block;height:100%;border-radius:5px}
 .gpucard-val{flex:none;min-width:158px;text-align:right;font-variant-numeric:tabular-nums}
+/* GPU telemetry chips (mem-bw util, clocks, power headroom, p-state, mem temp) */
+.gpu-detail{display:flex;flex-wrap:wrap;gap:7px;margin-top:13px}
+.gpu-chip{display:flex;flex-direction:column;gap:1px;border:1px solid var(--bd);border-radius:8px;padding:6px 10px;background:rgba(127,127,127,.04);min-width:96px}
+.gpu-chip .v{font-size:13.5px;font-weight:600;font-variant-numeric:tabular-nums}
+.gpu-chip .l{font-size:10.5px;color:var(--mut);text-transform:uppercase;letter-spacing:.02em}
+.gpu-chip.bad{border-color:var(--crit)} .gpu-chip.warn{border-color:var(--warn)}
 .muted{color:var(--mut)}a{color:#58a6ff}
 /* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
 .ports{display:inline-flex;flex-wrap:wrap;gap:4px}
@@ -661,9 +667,11 @@ a{color:var(--info)}
 
 <!-- ───────── GPU ───────── -->
 <section data-tab="gpu" hidden>
+  <div id="gpu-throttle" class="ins crit" style="display:none;margin-bottom:14px"></div>
   <div class="cols">
     <div class="card"><h2>🎮 GPU right now</h2>
       <div class="grid" id="gpukpis" style="grid-template-columns:1fr 1fr"></div>
+      <div id="gpu-detail" class="gpu-detail"></div>
       <div style="margin:14px 0 6px" class="muted" >VRAM allocation</div>
       <div class="bar" id="vrambar"></div>
       <table style="margin-top:12px"><tbody id="nowtbl"></tbody></table>
@@ -1276,6 +1284,7 @@ function renderData(){
     {v:fmtMB(n.mem_used)+' <span style="font-size:13px;color:var(--mut)">/ '+fmtMB(tot)+'</span>',l:'VRAM in use',s:memPct+'% full'},
     {v:Math.round(n.util)+'%',l:'GPU util',s:Math.round(n.power)+' W · '+Math.round(n.temp)+'°C'},
   ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div><div class="s">${t.s||''}</div></div>`).join('');
+  renderGpuDetail(n.gpu_extra||{}, n.power);
   renderPerGpu(n.gpus);
   const bar=document.getElementById('vrambar'); bar.innerHTML='';
   n.procs.forEach(p=>{const s=document.createElement('div');s.style.width=(p.mem/tot*100)+'%';s.style.background=colorFor(p.service);s.title=p.service+': '+fmtMB(p.mem);bar.appendChild(s);});
@@ -1319,6 +1328,40 @@ function renderData(){
 
 // Per-GPU cards (issue #95): one card per physical GPU with live util/VRAM/power/
 // temp. Shown only when there's more than one card — single-GPU rigs already see
+// GPU telemetry detail (issue: GPU truth-telling). Throttle banner + a chip row
+// of the things AI/DS engineers actually debug with: memory-bandwidth utilisation
+// (mem-bound vs compute-bound), core/mem clocks, power draw vs limit (headroom),
+// performance state, and memory-junction temp. Chips hide individually when the
+// driver/card reports the field as unsupported, so consumer GPUs degrade cleanly.
+function renderGpuDetail(x, powerNow){
+  const banner=document.getElementById('gpu-throttle');
+  if(banner){
+    if(x.throttled && (x.throttle||[]).length){
+      banner.style.display='flex';
+      banner.innerHTML=`<div class="ic">🔥</div><div><div class="t">GPU is throttling — running below rated clocks</div>`
+        +`<div class="d">Reason: <b>${(x.throttle||[]).map(esc).join(', ')}</b>. `
+        +`Your real throughput is lower than the util % suggests — check cooling or the power limit.</div></div>`;
+    } else { banner.style.display='none'; }
+  }
+  const box=document.getElementById('gpu-detail'); if(!box) return;
+  const chips=[];
+  if(x.mem_util!=null && (x.mem_util>0 || x.clk_sm>0)){
+    const mb = x.mem_util>=70 ? 'warn' : '';
+    chips.push({v:Math.round(x.mem_util)+'%', l:'Mem-BW util', c:mb,
+                t:'Memory-bandwidth utilisation. High here with low GPU util = memory-bound (the usual LLM-inference bottleneck).'});
+  }
+  if(x.clk_sm>0) chips.push({v:Math.round(x.clk_sm)+' MHz', l:'Core clock'});
+  if(x.clk_mem>0) chips.push({v:Math.round(x.clk_mem)+' MHz', l:'Mem clock'});
+  if(x.power_limit>0){
+    const head=Math.round((powerNow||0)/x.power_limit*100);
+    chips.push({v:`${Math.round(powerNow||0)} / ${Math.round(x.power_limit)} W`, l:`Power · ${head}% of cap`,
+                c: head>=98?'bad':head>=90?'warn':'', t:'Draw vs the card power limit. Pinned at ~100% = power-capped.'});
+  }
+  if(x.pstate) chips.push({v:x.pstate, l:'Perf state', t:'P0 = max performance; higher P-numbers = lower clocks.'});
+  if(x.temp_mem>0) chips.push({v:Math.round(x.temp_mem)+'°C', l:'Mem temp', c:x.temp_mem>=95?'bad':x.temp_mem>=85?'warn':''});
+  box.innerHTML = chips.map(c=>`<div class="gpu-chip ${c.c||''}"${c.t?` title="${esc(c.t)}"`:''}><div class="v">${esc(c.v)}</div><div class="l">${esc(c.l)}</div></div>`).join('');
+}
+
 // everything in the "GPU right now" panel, which pools across cards.
 function renderPerGpu(gpus){
   const card=document.getElementById('pergpu-card'), box=document.getElementById('pergpu');
@@ -1329,15 +1372,23 @@ function renderPerGpu(gpus){
   box.innerHTML = gpus.map(g=>{
     const memPct = g.mem_total? Math.round(g.mem_used/g.mem_total*100):0;
     const util = Math.round(g.util||0);
+    const memUtil = Math.round(g.mem_util||0);
+    const thr = (g.throttled && (g.throttle||[]).length)
+      ? `<span class="badge crit" title="Throttling: ${esc((g.throttle||[]).join(', '))}">🔥 throttling</span>` : '';
+    const clk = g.clk_sm>0 ? ` · ${Math.round(g.clk_sm)} MHz` : '';
+    const cap = g.power_limit>0 ? `/${Math.round(g.power_limit)} W cap` : '';
     return `<div class="gpucard">
-      <div class="gpucard-h"><b>GPU ${g.idx}</b> <span class="muted">${esc(g.name||'')}</span>
-        <span class="gpucard-stats">${util}% util · ${Math.round(g.power||0)} W · ${Math.round(g.temp||0)}°C</span></div>
+      <div class="gpucard-h"><b>GPU ${g.idx}</b> <span class="muted">${esc(g.name||'')}</span> ${thr}
+        <span class="gpucard-stats">${util}% util · ${Math.round(g.power||0)} W${cap}${clk} · ${Math.round(g.temp||0)}°C${g.pstate?' · '+esc(g.pstate):''}</span></div>
       <div class="gpucard-row"><span class="gpucard-lbl">VRAM</span>
         <span class="gpucard-bar"><span style="width:${memPct}%;background:${tint(memPct)}"></span></span>
         <span class="gpucard-val">${fmtMB(g.mem_used||0)} / ${fmtMB(g.mem_total||0)} · ${memPct}%</span></div>
       <div class="gpucard-row"><span class="gpucard-lbl">Util</span>
         <span class="gpucard-bar"><span style="width:${Math.min(100,util)}%;background:${tint(util)}"></span></span>
         <span class="gpucard-val">${util}%</span></div>
+      <div class="gpucard-row"><span class="gpucard-lbl" title="Memory-bandwidth utilisation — high here with low Util = memory-bound">Mem-BW</span>
+        <span class="gpucard-bar"><span style="width:${Math.min(100,memUtil)}%;background:${tint(memUtil)}"></span></span>
+        <span class="gpucard-val">${memUtil}%</span></div>
     </div>`;
   }).join('');
 }

--- a/tests/test_gputelemetry.py
+++ b/tests/test_gputelemetry.py
@@ -1,0 +1,98 @@
+"""Unit tests for the enriched GPU telemetry — mem-BW util, clocks, power limit,
+performance state, memory temp, and throttle-reason decoding (GPU truth-telling)."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestThrottleDecode(unittest.TestCase):
+    def test_idle_and_zero_are_not_throttling(self):
+        self.assertEqual(app._decode_throttle("0x0000000000000000"), [])
+        self.assertEqual(app._decode_throttle("0x0000000000000001"), [])  # GPU_IDLE — normal
+
+    def test_power_cap(self):
+        self.assertEqual(app._decode_throttle("0x0000000000000004"), ["Power cap"])
+
+    def test_combined_power_and_hw_thermal(self):
+        # 0x44 = 0x40 (HW thermal) | 0x04 (Power cap)
+        self.assertEqual(app._decode_throttle("0x0000000000000044"), ["Power cap", "HW thermal"])
+
+    def test_unsupported_value(self):
+        self.assertEqual(app._decode_throttle("[N/A]"), [])
+        self.assertEqual(app._decode_throttle(None), [])
+
+
+class TestEnrichGpus(unittest.TestCase):
+    def test_attaches_extra_fields_and_throttle(self):
+        gpus = [{"idx": 0, "util": 50, "power": 100, "mem_used": 8000, "mem_total": 24000, "temp": 70}]
+
+        def fake_smi(args):
+            a = args[0]
+            if "utilization.memory" in a:
+                return "0, 45, 1800, 9500, 250, 78, P2"
+            if "clocks_throttle_reasons.active" in a:
+                return "0, 0x0000000000000004"   # power cap
+            return ""
+        with patch("app.smi", side_effect=fake_smi):
+            app._enrich_gpus(gpus)
+        g = gpus[0]
+        self.assertEqual(g["mem_util"], 45)
+        self.assertEqual(g["clk_sm"], 1800)
+        self.assertEqual(g["clk_mem"], 9500)
+        self.assertEqual(g["power_limit"], 250)
+        self.assertEqual(g["temp_mem"], 78)
+        self.assertEqual(g["pstate"], "P2")
+        self.assertTrue(g["throttled"])
+        self.assertIn("Power cap", g["throttle"])
+
+    def test_field_rename_fallback(self):
+        # Newer drivers renamed clocks_throttle_reasons -> clocks_event_reasons.
+        gpus = [{"idx": 0, "util": 10}]
+
+        def fake_smi(args):
+            a = args[0]
+            if "utilization.memory" in a:
+                return "0, 5, 300, 405, 200, [N/A], P8"
+            if "clocks_throttle_reasons.active" in a:
+                return ""                          # old field unsupported -> empty
+            if "clocks_event_reasons.active" in a:
+                return "0, 0x0000000000000040"     # HW thermal via the new field name
+            return ""
+        with patch("app.smi", side_effect=fake_smi):
+            app._enrich_gpus(gpus)
+        self.assertEqual(gpus[0]["pstate"], "P8")
+        self.assertEqual(gpus[0]["temp_mem"], 0)   # [N/A] tolerated -> 0
+        self.assertEqual(gpus[0]["throttle"], ["HW thermal"])
+
+    def test_enrichment_never_raises_on_bad_smi(self):
+        gpus = [{"idx": 0, "util": 1}]
+        with patch("app.smi", side_effect=RuntimeError("nvidia-smi blew up")):
+            app._enrich_gpus(gpus)                  # must swallow, not propagate
+        self.assertNotIn("mem_util", gpus[0])       # nothing attached, but no crash
+
+
+class TestGpuExtra(unittest.TestCase):
+    def test_aggregate(self):
+        gpus = [
+            {"idx": 0, "mem_util": 40, "clk_sm": 1800, "clk_mem": 9000, "power_limit": 250,
+             "pstate": "P2", "temp_mem": 80, "throttled": True, "throttle": ["Power cap"]},
+            {"idx": 1, "mem_util": 60, "power_limit": 250, "temp_mem": 70, "throttle": []},
+        ]
+        x = app._gpu_extra(gpus)
+        self.assertEqual(x["mem_util"], 50)          # avg(40, 60)
+        self.assertEqual(x["power_limit"], 500)      # sum
+        self.assertEqual(x["temp_mem"], 80)          # max
+        self.assertEqual(x["clk_sm"], 1800)          # representative (card 0)
+        self.assertTrue(x["throttled"])              # any card
+        self.assertEqual(x["throttle"], ["Power cap"])
+
+    def test_empty(self):
+        self.assertEqual(app._gpu_extra([]), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## GPU truth-telling — part of 0.16 "AI Lab Cockpit"

A GPU reporting **100% util** can still be quietly underperforming. This surfaces the signals AI/DS engineers actually debug with — all from the `nvidia-smi` we already call, **no new deps**, all best-effort and degrading cleanly on consumer cards.

- **Throttle banner** (the screenshot feature): decodes `clocks_throttle_reasons.active` and shows a red banner when the card is **power-capped / thermally throttling** — so you know the util % is lying about real throughput. Handles the `clocks_event_reasons` field rename in newer drivers.
- **Memory-bandwidth utilisation**: high mem-BW + low GPU util = **memory-bound** (the usual LLM-inference bottleneck). Chip + per-card bar.
- **Core/mem clocks, power draw vs limit (headroom %), perf state, mem-junction temp**: a chip row in the always-visible "GPU right now" panel and enriched per-card cards.

Exposed on `/api/data` `now.gpu_extra` and `/api/health` `now.gpu.extra`.

### Safety
Enrichment is isolated in its own guards — unsupported fields (`[N/A]`) degrade to 0/hidden, and any nvidia-smi failure leaves the core GPU sample untouched. Verified live on `ardi:9801`.

### Tests
Throttle-bitmask decode, enrichment parsing + driver field-rename fallback + never-raises guard, aggregate. **71 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)