### PR TITLE
feat(models): model intelligence — metadata + live serving telemetry

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,7 +174,8 @@ except sqlite3.OperationalError as e:
 _apply_schema_migrations(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
-          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": [], "gpu_extra": {}}
+          "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": [], "gpu_extra": {},
+          "model_meta": {}, "serving": []}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
@@ -447,6 +448,160 @@ def probe_models(ct):
     if len(idle) > CATALOG_MAX:
         idle = [(f"{len(idle)} models available", None)]
     return loaded + idle
+
+# ── Model intelligence: per-model metadata + live serving telemetry ───────────
+# Two passive, no-dep enrichments that make the AI Models tab authoritative:
+#   1. Ollama /api/show — param size, quantization, context length, capabilities
+#      (immutable per tag, so cached; only fetched for currently-loaded models).
+#   2. vLLM / TGI /metrics — running/waiting requests, KV-cache fill, tokens/sec
+#      (Prometheus text, parsed with stdlib regex; tok/s from a counter delta).
+def _http_post_json(ip, port, path, payload, timeout=2):
+    c = http.client.HTTPConnection(ip, port, timeout=timeout)
+    try:
+        body = json.dumps(payload).encode()
+        c.request("POST", path, body=body, headers={"Content-Type": "application/json"})
+        r = c.getresponse(); data = r.read(); status = r.status
+    finally:
+        c.close()
+    return json.loads(data) if status < 400 else None
+
+def _http_text(ip, port, path, timeout=2):
+    c = http.client.HTTPConnection(ip, port, timeout=timeout)
+    try:
+        c.request("GET", path); r = c.getresponse(); data = r.read(); status = r.status
+    finally:
+        c.close()
+    return data.decode("utf-8", "replace") if status < 400 else None
+
+_OLLAMA_META = {}   # model name -> {param_size, quant, ctx, caps}; immutable per tag, cached
+
+def _ollama_meta(ip, model):
+    """POST /api/show once per model and cache. Passive — triggers no inference."""
+    if model in _OLLAMA_META:
+        return _OLLAMA_META[model]
+    meta = {}
+    try:
+        d = _http_post_json(ip, 11434, "/api/show", {"model": model}) or {}
+        det = d.get("details") or {}
+        meta["param_size"] = det.get("parameter_size") or ""
+        meta["quant"] = det.get("quantization_level") or ""
+        ctx = ""
+        for k, v in (d.get("model_info") or {}).items():
+            if k.endswith(".context_length"):
+                ctx = int(v) if str(v).isdigit() else v; break
+        meta["ctx"] = ctx
+        meta["caps"] = [c for c in (d.get("capabilities") or []) if c != "completion"]
+    except Exception:
+        meta = {}
+    if any(meta.get(k) for k in ("param_size", "quant", "ctx", "caps")):
+        _OLLAMA_META[model] = meta
+    return meta
+
+def collect_model_meta(ai, models):
+    """{model_name: meta} for Ollama models. Cached metadata is returned for free;
+    a fresh /api/show is only paid for a currently-loaded model we haven't seen."""
+    ip_of = {ct["name"]: (ct.get("ip") or "127.0.0.1") for ct in ai}
+    is_ollama = {ct["name"] for ct in ai
+                 if "ollama" in (ct.get("name", "") + " " + ct.get("image", "")).lower()}
+    out = {}
+    for svc, mdl, vram in models:
+        if svc not in is_ollama or not mdl:
+            continue
+        if mdl in _OLLAMA_META:
+            out[mdl] = _OLLAMA_META[mdl]
+        elif vram is not None:                      # only pay /api/show for loaded models
+            meta = _ollama_meta(ip_of.get(svc, "127.0.0.1"), mdl)
+            if meta:
+                out[mdl] = meta
+    return out
+
+_PROM_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([0-9.eEnaN+-]+)\s*$")
+
+def _parse_prom(text):
+    """Prometheus exposition text -> {metric_name: value summed across label sets}.
+    Comments and non-finite values are skipped."""
+    out = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+        m = _PROM_RE.match(line)
+        if not m:
+            continue
+        try:
+            v = float(m.group(3))
+        except ValueError:
+            continue
+        if v != v or v in (float("inf"), float("-inf")):   # NaN / inf
+            continue
+        out[m.group(1)] = out.get(m.group(1), 0.0) + v
+    return out
+
+def _first_metric(metrics, *names):
+    for n in names:
+        if n in metrics:
+            return metrics[n]
+    return None
+
+def _serving_extract(metrics):
+    """Pull the serving KPIs out of a parsed /metrics dict (vLLM + TGI aliases).
+    Returns raw fields incl. the generation-tokens counter for rate calc upstream."""
+    out = {}
+    running = _first_metric(metrics, "vllm:num_requests_running", "tgi_batch_current_size")
+    waiting = _first_metric(metrics, "vllm:num_requests_waiting", "tgi_queue_size")
+    kv = _first_metric(metrics, "vllm:kv_cache_usage_perc", "vllm:gpu_cache_usage_perc")
+    gen = _first_metric(metrics, "vllm:generation_tokens_total", "tgi_request_generated_tokens_sum")
+    ts_sum = _first_metric(metrics, "vllm:time_to_first_token_seconds_sum")
+    ts_cnt = _first_metric(metrics, "vllm:time_to_first_token_seconds_count")
+    if running is not None: out["running"] = int(running)
+    if waiting is not None: out["waiting"] = int(waiting)
+    if kv is not None:      out["kv_cache_pct"] = round(kv * 100, 1) if kv <= 1.5 else round(kv, 1)
+    if gen is not None:     out["gen_tokens_total"] = gen
+    if ts_sum is not None and ts_cnt:
+        out["ttft_avg_s"] = round(ts_sum / ts_cnt, 3)
+    return out
+
+_METRICS_HINTS = ("vllm", "text-generation-inference", "tgi", "sglang", "aphrodite",
+                  "lorax", "mistral", "text-embeddings-inference", "infinity")
+_SERVE_PREV = {}    # svc -> (gen_tokens_total, ts), for tokens/sec from the counter delta
+
+def collect_serving(ai):
+    """Scrape /metrics from Prometheus-exposing inference servers and return a list of
+    live serving stats (running/waiting/KV-cache/tok-s/TTFT). Bounded: only hint-matched
+    containers, a few candidate ports at a short timeout, first hit wins."""
+    out, nowt = [], time.time()
+    for ct in ai:
+        name = ct.get("name", "")
+        if not any(h in (name + " " + ct.get("image", "")).lower() for h in _METRICS_HINTS):
+            continue
+        ip = ct.get("ip") or "127.0.0.1"
+        ports = []
+        for p in (list(ct.get("ports") or []) + [8000]):
+            if p and p not in ports:
+                ports.append(p)
+        text = None
+        for p in ports[:4]:
+            try:
+                t = _http_text(ip, p, "/metrics", timeout=1.0)
+            except Exception:
+                t = None
+            if t and ("vllm:" in t or "tgi_" in t):
+                text = t; break
+        if not text:
+            continue
+        st = _serving_extract(_parse_prom(text))
+        gen = st.pop("gen_tokens_total", None)
+        if gen is not None:
+            prev = _SERVE_PREV.get(name)
+            if prev and nowt > prev[1]:
+                rate = (gen - prev[0]) / (nowt - prev[1])
+                if rate >= 0:
+                    st["tok_per_s"] = round(rate, 1)
+            _SERVE_PREV[name] = (gen, nowt)
+        if st:
+            st["service"] = name
+            out.append(st)
+    return out
 
 # ── Host metrics (read from /proc, /sys, statvfs — host values via shared kernel)
 def _cpu_pct():
@@ -3434,6 +3589,18 @@ def sample_once():
     # Attribute model-server traffic to its callers (who is driving Ollama, etc.).
     edges = sample_callers(conts, {c["name"] for c in ai})
 
+    # Model intelligence: per-model metadata (Ollama /api/show, cached) + live serving
+    # telemetry (vLLM/TGI /metrics). Both best-effort — a slow/absent endpoint must
+    # never wedge the sample, so each is isolated.
+    try:
+        model_meta = collect_model_meta(ai, models)
+    except Exception:
+        model_meta = {}
+    try:
+        serving = collect_serving(ai)
+    except Exception:
+        serving = []
+
     host = read_host()
     ts = int(time.time())
     if _DB_MAINTENANCE:
@@ -3471,6 +3638,7 @@ def sample_once():
                   gpu_avail=gpu_avail, gpus=gpus, gpu_extra=gpu_extra,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
+                  model_meta=model_meta, serving=serving,
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
                                  key=lambda x: -x["conns"]), host=host)
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -160,6 +160,12 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .gpu-chip .v{font-size:13.5px;font-weight:600;font-variant-numeric:tabular-nums}
 .gpu-chip .l{font-size:10.5px;color:var(--mut);text-transform:uppercase;letter-spacing:.02em}
 .gpu-chip.bad{border-color:var(--crit)} .gpu-chip.warn{border-color:var(--warn)}
+.gpu-chip.live{border-color:var(--ok)}
+/* model metadata badges + live-serving row on the AI Models tab */
+.mchip{display:inline-block;font-size:10.5px;padding:1px 6px;margin-left:4px;border:1px solid var(--bd);border-radius:9px;color:var(--mut);vertical-align:middle;font-variant-numeric:tabular-nums}
+.mchip.cap{border-color:#58a6ff66;color:#58a6ff}
+.serving-row{display:flex;flex-wrap:wrap;gap:7px;align-items:center;margin:10px 0 2px}
+.serving-tag{font-size:10.5px;color:var(--ok);border:1px solid var(--ok);border-radius:9px;padding:2px 8px;opacity:.8}
 .muted{color:var(--mut)}a{color:#58a6ff}
 /* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
 .ports{display:inline-flex;flex-wrap:wrap;gap:4px}
@@ -1503,7 +1509,7 @@ function renderModels(){
     const models=bySvc[svc].slice().sort((a,b)=>(b.peak||0)-(a.peak||0));
     const rows=models.map(m=>{
       const pW=m.peak!=null?Math.max(2,m.peak/maxV*100):0, aW=m.avg!=null?Math.max(2,m.avg/maxV*100):0;
-      return `<tr><td><span class="dot" style="background:${c}"></span>${esc(m.model)}</td>
+      return `<tr><td><span class="dot" style="background:${c}"></span>${esc(m.model)}${modelMetaChips(m.model)}</td>
         <td>${m.vram!=null?'<span class="badge ok">Loaded</span>':'<span class="badge info">Idle</span>'}</td>
         <td>${m.vram!=null?fmtMB(m.vram):'—'}</td>
         <td>${m.peak!=null?fmtMB(m.peak):'—'}</td>
@@ -1515,11 +1521,41 @@ function renderModels(){
       <h2 style="display:flex;align-items:center;gap:8px;text-transform:none;font-size:13px;color:var(--tx)">
         <span class="dot" style="background:${c}"></span>${esc(svc)}
         <span class="pill" style="margin-left:auto;text-transform:none">resident ${ss.present!=null?ss.present+'%':'—'} · server peak ${ss.peak!=null?fmtMB(ss.peak):'—'}</span></h2>
+      ${servingFor(svc)}
       ${modelSpark(svc,tot)}
       ${callersFor(svc)}
       <table style="margin-top:12px"><thead><tr><th>Model</th><th>Status</th><th>Now</th><th>Peak</th><th>Avg</th><th>Peak·Avg</th></tr></thead><tbody>${rows}</tbody></table>
     </div>`;
   }).join('');
+}
+// Model metadata badges (Ollama /api/show): param size, quantization, context
+// length, capabilities. From D.now.model_meta, keyed by model name. Cheap polish
+// that makes the panel feel authoritative — hidden when metadata isn't available.
+function fmtCtx(n){ n=+n||0; return n>=1000 ? (n%1000?(n/1000).toFixed(1):n/1000)+'K' : (n||''); }
+function modelMetaChips(model){
+  const m=((D.now&&D.now.model_meta)||{})[model]; if(!m) return '';
+  const out=[];
+  if(m.param_size) out.push(`<span class="mchip" title="Parameters">${esc(m.param_size)}</span>`);
+  if(m.quant)      out.push(`<span class="mchip" title="Quantization">${esc(m.quant)}</span>`);
+  if(m.ctx)        out.push(`<span class="mchip" title="Context length">${esc(fmtCtx(m.ctx))} ctx</span>`);
+  (m.caps||[]).forEach(c=>{ if(c==='vision'||c==='tools'||c==='embedding')
+    out.push(`<span class="mchip cap" title="Capability">${c==='vision'?'👁 vision':c==='tools'?'🛠 tools':'🔢 embed'}</span>`); });
+  return out.length ? ' '+out.join('') : '';
+}
+// Live serving telemetry (vLLM / TGI /metrics): requests running/waiting, KV-cache
+// fill, tokens/sec, TTFT. From D.now.serving. Only shown for servers that expose it.
+function servingFor(svc){
+  const s=((D.now&&D.now.serving)||[]).find(x=>x.service===svc); if(!s) return '';
+  const chips=[];
+  if(s.tok_per_s!=null)   chips.push({v:s.tok_per_s+' tok/s', l:'Throughput', hot:s.tok_per_s>0});
+  if(s.running!=null)     chips.push({v:s.running, l:'Running', hot:s.running>0});
+  if(s.waiting!=null)     chips.push({v:s.waiting, l:'Queued', warn:s.waiting>0});
+  if(s.kv_cache_pct!=null)chips.push({v:s.kv_cache_pct+'%', l:'KV-cache', warn:s.kv_cache_pct>=90});
+  if(s.ttft_avg_s!=null)  chips.push({v:(s.ttft_avg_s*1000).toFixed(0)+' ms', l:'Avg TTFT'});
+  if(!chips.length) return '';
+  return `<div class="serving-row">${chips.map(c=>
+    `<div class="gpu-chip ${c.warn?'warn':''}${c.hot?' live':''}"><div class="v">${esc(String(c.v))}</div><div class="l">${esc(c.l)}</div></div>`
+  ).join('')}<span class="serving-tag" title="Scraped live from the server's Prometheus /metrics endpoint">live serving</span></div>`;
 }
 // Caller attribution — "who is driving this server", from connection-seconds (D.callers).
 function callersFor(svc){

--- a/tests/test_modelintel.py
+++ b/tests/test_modelintel.py
@@ -1,0 +1,98 @@
+"""Unit tests for model intelligence: Ollama /api/show metadata + vLLM/TGI
+/metrics live serving telemetry."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestParseProm(unittest.TestCase):
+    def test_parse_sums_labels_and_skips_junk(self):
+        text = (
+            "# HELP foo bar\n"
+            "# TYPE foo gauge\n"
+            'vllm:num_requests_running{model="x"} 3\n'
+            'vllm:num_requests_running{model="y"} 2\n'
+            "vllm:kv_cache_usage_perc 0.42\n"
+            "not a metric line\n"
+            "nan_metric NaN\n"
+        )
+        d = app._parse_prom(text)
+        self.assertEqual(d["vllm:num_requests_running"], 5.0)     # summed across label sets
+        self.assertAlmostEqual(d["vllm:kv_cache_usage_perc"], 0.42)
+        self.assertNotIn("nan_metric", d)                         # NaN dropped
+
+
+class TestServingExtract(unittest.TestCase):
+    def test_vllm(self):
+        metrics = {"vllm:num_requests_running": 2, "vllm:num_requests_waiting": 5,
+                   "vllm:kv_cache_usage_perc": 0.73, "vllm:generation_tokens_total": 12345,
+                   "vllm:time_to_first_token_seconds_sum": 4.0,
+                   "vllm:time_to_first_token_seconds_count": 20}
+        o = app._serving_extract(metrics)
+        self.assertEqual(o["running"], 2)
+        self.assertEqual(o["waiting"], 5)
+        self.assertEqual(o["kv_cache_pct"], 73.0)                 # fraction -> percent
+        self.assertEqual(o["gen_tokens_total"], 12345)
+        self.assertAlmostEqual(o["ttft_avg_s"], 0.2)             # 4.0s / 20
+
+    def test_tgi_aliases(self):
+        o = app._serving_extract({"tgi_batch_current_size": 3, "tgi_queue_size": 1})
+        self.assertEqual(o["running"], 3)
+        self.assertEqual(o["waiting"], 1)
+
+
+class TestCollectServing(unittest.TestCase):
+    def test_tokens_per_sec_from_counter_delta(self):
+        ct = {"name": "vllm", "image": "vllm/vllm-openai", "ip": "1.2.3.4", "ports": [8000]}
+        app._SERVE_PREV.clear()
+        seq = iter([1000.0, 1010.0])     # two ticks, 10 s apart
+        with patch("app.time.time", side_effect=lambda: next(seq)):
+            with patch("app._http_text", return_value="vllm:generation_tokens_total 100\nvllm:num_requests_running 1\n"):
+                r1 = app.collect_serving([ct])
+            with patch("app._http_text", return_value="vllm:generation_tokens_total 600\nvllm:num_requests_running 2\n"):
+                r2 = app.collect_serving([ct])
+        self.assertNotIn("tok_per_s", r1[0])                     # first tick: no previous counter
+        self.assertAlmostEqual(r2[0]["tok_per_s"], 50.0, delta=0.1)   # (600-100)/10s
+        self.assertEqual(r2[0]["service"], "vllm")
+
+    def test_non_metrics_server_skipped(self):
+        ct = {"name": "ollama", "image": "ollama/ollama", "ip": "1.2.3.4", "ports": [11434]}
+        with patch("app._http_text", return_value="should not be called"):
+            self.assertEqual(app.collect_serving([ct]), [])      # ollama isn't a /metrics hint
+
+
+class TestOllamaMeta(unittest.TestCase):
+    def test_parses_and_caches(self):
+        app._OLLAMA_META.clear()
+        resp = {"details": {"parameter_size": "8.0B", "quantization_level": "Q4_K_M"},
+                "model_info": {"llama.context_length": 8192},
+                "capabilities": ["completion", "tools", "vision"]}
+        with patch("app._http_post_json", return_value=resp) as pj:
+            m1 = app._ollama_meta("1.2.3.4", "llama3")
+            m2 = app._ollama_meta("1.2.3.4", "llama3")
+        self.assertEqual(m1["param_size"], "8.0B")
+        self.assertEqual(m1["quant"], "Q4_K_M")
+        self.assertEqual(m1["ctx"], 8192)
+        self.assertEqual(set(m1["caps"]), {"tools", "vision"})   # "completion" dropped
+        self.assertEqual(pj.call_count, 1)                       # second call served from cache
+        self.assertEqual(m1, m2)
+
+    def test_collect_only_fetches_loaded(self):
+        app._OLLAMA_META.clear()
+        ai = [{"name": "ollama", "image": "ollama/ollama", "ip": "1.2.3.4"}]
+        models = [("ollama", "loaded-model", 1234), ("ollama", "idle-model", None)]
+        resp = {"details": {"parameter_size": "7B", "quantization_level": "Q8_0"},
+                "model_info": {}, "capabilities": []}
+        with patch("app._http_post_json", return_value=resp) as pj:
+            out = app.collect_model_meta(ai, models)
+        self.assertIn("loaded-model", out)
+        self.assertNotIn("idle-model", out)                     # idle catalogue not paid for
+        self.assertEqual(pj.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Model intelligence — part of 0.16 "AI Lab Cockpit"

Two passive, no-dep enrichments that make the **AI Models** tab feel like it actually understands your inference stack.

### 1. Ollama model metadata (`/api/show`)
Inline badges on each model row: **parameter size**, **quantization** (Q4_K_M…), **context length**, and capability chips (👁 vision / 🛠 tools / 🔢 embed). Cached (immutable per tag) and only fetched for currently-loaded models, so it's one POST per new model — no inference triggered.

### 2. vLLM / TGI live serving telemetry (`/metrics`) 🏆
A **"live serving"** chip row per server: **tokens/sec** (from the generation-tokens counter delta), **requests running / queued**, **KV-cache fill %**, **avg TTFT** — the numbers you currently only get by tailing logs. Prometheus text parsed with stdlib regex; metric-name drift handled via alias sets.

### Safety / bounds
Metadata is cached; serving only scrapes hint-matched containers (vllm/tgi/sglang/aphrodite/…) on a few candidate ports at a 1s timeout, first hit wins. Both are wrapped so a slow/absent endpoint never wedges the sampler. Exposed on `/api/data` `now.model_meta` + `now.serving`.

### Tests
Prometheus parse (label-sum, NaN-skip), serving extract (vLLM + TGI aliases, KV fraction→percent, TTFT), tokens/sec from counter delta, non-metrics server skipped, Ollama metadata parse + cache + loaded-only. **78 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)