### PR TITLE
feat(experiments): training-run detection + GPU activity sessions tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,7 +175,7 @@ _apply_schema_migrations(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
           "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": [], "gpu_extra": {},
-          "model_meta": {}, "serving": []}
+          "model_meta": {}, "serving": [], "training": []}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
@@ -2170,6 +2170,104 @@ def collect_top_processes(top_n=10):
             "by_mem": sorted(rows, key=lambda r: -r["mem_mb"])[:top_n],
             "ncpu": ncpu}
 
+# ── Experiments: training-run detection + GPU activity sessions ────────────────
+# Auto-recognise training / fine-tuning jobs from /proc cmdline, and reconstruct
+# "GPU activity sessions" from the power/util history we already store — so the
+# Experiments tab works with zero config and no agent inside the job.
+TRAIN_LAUNCHERS = ("torchrun", "deepspeed", "torch.distributed.run",
+                   "torch.distributed.launch", "torch.distributed.elastic", "accelerate")
+_TRAIN_SCRIPT_RE = re.compile(r"(train|finetune|fine[_-]?tune|sft|dpo|grpo|ppo|pretrain|lora|qlora)", re.I)
+_ML_FRAMEWORK_RE = re.compile(r"(pytorch_lightning|lightning\.|transformers\.trainer|"
+                              r"axolotl|unsloth|trl|llama[_-]?factory|nanogpt|megatron)", re.I)
+
+def _classify_training(argv):
+    """argv: cmdline tokens. Return a short label if this looks like a training /
+    fine-tuning job, else None. Conservative — must not flag plain inference."""
+    if not argv:
+        return None
+    low = " ".join(argv).lower()
+    for l in TRAIN_LAUNCHERS:
+        if l in low:
+            return l.split(".")[-1]
+    for a in argv:
+        if a.endswith(".py") and _TRAIN_SCRIPT_RE.search(os.path.basename(a)):
+            return os.path.basename(a)
+    if "python" in low and _ML_FRAMEWORK_RE.search(low):
+        return "training"
+    return None
+
+_TRAIN_SEEN = {}   # pid -> first-seen ts (resets on restart; gives a live elapsed clock)
+
+def collect_training(gpu_pids, now=None):
+    """Scan /proc for training-like processes; annotate each with the VRAM its PID
+    holds on the GPU (from nvidia-smi compute-apps) and how long we've seen it.
+    `gpu_pids`: {int pid -> MB}. Returns [] where /proc is unavailable."""
+    now = now or int(time.time())
+    out, alive = [], set()
+    try:
+        pids = [p for p in os.listdir("/proc") if p.isdigit()]
+    except Exception:
+        return out
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as f:
+                raw = f.read()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        argv = [t for t in raw.decode("utf-8", "replace").split("\x00") if t]
+        label = _classify_training(argv)
+        if not label:
+            continue
+        alive.add(pid)
+        first = _TRAIN_SEEN.setdefault(pid, now)
+        vram = gpu_pids.get(int(pid), 0)
+        out.append({"pid": int(pid), "label": label, "cmd": " ".join(argv)[:240],
+                    "elapsed": max(0, now - first), "vram": round(vram), "on_gpu": bool(vram)})
+    for dead in [p for p in _TRAIN_SEEN if p not in alive]:
+        _TRAIN_SEEN.pop(dead, None)
+    return sorted(out, key=lambda r: -r["elapsed"])
+
+_ACTIVE_UTIL = 20    # GPU util % at/above which a sample counts as a "busy" session sample
+
+def _gpu_sessions(rows, interval, active_util=_ACTIVE_UTIL, max_gap=3, min_len=2, price=0.0):
+    """Reconstruct contiguous GPU-busy sessions from sample rows. `rows`: ascending
+    (ts, util, power, mem_used). A session is a run of samples with util>=active_util,
+    tolerating up to `max_gap` idle samples. Returns sessions newest-first with
+    duration, peak util/VRAM, average power, energy (kWh) and money."""
+    kwh_per = interval / 3_600_000.0
+    sessions, cur, gap = [], None, 0
+
+    def close():
+        nonlocal cur
+        if cur and cur["n"] >= min_len:
+            energy = cur["sum_power"] * kwh_per
+            sessions.append({
+                "start": cur["start"], "end": cur["end"],
+                "duration": cur["end"] - cur["start"] + interval,
+                "peak_util": round(cur["peak_util"]), "peak_vram": round(cur["peak_vram"]),
+                "avg_power": round(cur["sum_power"] / cur["n"]),
+                "energy_kwh": round(energy, 4), "cost": round(energy * price, 4)})
+        cur = None
+
+    for ts, util, power, mem in rows:
+        if (util or 0) >= active_util:
+            if cur is None:
+                cur = {"start": ts, "end": ts, "peak_util": 0, "peak_vram": 0, "sum_power": 0.0, "n": 0}
+            cur["end"] = ts
+            cur["peak_util"] = max(cur["peak_util"], util or 0)
+            cur["peak_vram"] = max(cur["peak_vram"], mem or 0)
+            cur["sum_power"] += (power or 0)
+            cur["n"] += 1
+            gap = 0
+        elif cur is not None:
+            gap += 1
+            if gap > max_gap:
+                close(); gap = 0
+    close()
+    return sorted(sessions, key=lambda s: -s["start"])
+
 def health_scan():
     HEALTH["docker"]  = collect_docker()
     HEALTH["systemd"] = collect_systemd()
@@ -3526,6 +3624,7 @@ def sample_once():
     gpus = []
     gpu_extra = {}
     procs = {}
+    gpu_pids = {}
     gpu_avail = False
     try:
         # One CSV row per card (issue #95). Parse each field defensively: nvidia-smi
@@ -3560,6 +3659,10 @@ def sample_once():
                 pid, mem = (p.strip() for p in line.split(","))
                 svc = service_for_pid(pid, nm)
                 procs[svc] = procs.get(svc, 0) + _gpu_num(mem)
+                try:
+                    gpu_pids[int(pid)] = gpu_pids.get(int(pid), 0) + _gpu_num(mem)
+                except ValueError:
+                    pass
     except Exception as e:
         # Log only on the ok→fail edge so a permanently GPU-less host doesn't spam.
         if LATEST.get("gpu_avail"):
@@ -3600,6 +3703,10 @@ def sample_once():
         serving = collect_serving(ai)
     except Exception:
         serving = []
+    try:
+        training = collect_training(gpu_pids)
+    except Exception:
+        training = []
 
     host = read_host()
     ts = int(time.time())
@@ -3638,7 +3745,7 @@ def sample_once():
                   gpu_avail=gpu_avail, gpus=gpus, gpu_extra=gpu_extra,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
-                  model_meta=model_meta, serving=serving,
+                  model_meta=model_meta, serving=serving, training=training,
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
                                  key=lambda x: -x["conns"]), host=host)
 
@@ -3907,6 +4014,36 @@ def api_cost():
                    "night_start": s.get("night_start", "22:00"),
                    "night_end": s.get("night_end", "06:00")},
         "series": {"labels": labels, "cost_cum": cost_cum},
+    })
+
+@app.route("/api/sessions")
+def api_sessions():
+    """GPU activity sessions over the range — contiguous GPU-busy periods rebuilt
+    from the power/util history. Plus the live training processes detected on the
+    hub right now (LATEST['training']). Powers the Experiments tab."""
+    s = get_settings()
+    try:
+        price = float(s.get("kwh_price") or 0)
+    except (TypeError, ValueError):
+        price = 0.0
+    rng = request.args.get("range", "7d")
+    span = RANGES.get(rng, 604800)
+    now = int(time.time())
+    with LOCK:
+        cur = DB.cursor()
+        since = (cur.execute("SELECT MIN(ts) FROM samples").fetchone()[0] or now) if span is None else now - span
+        rows = cur.execute("SELECT ts,util,power,mem_used FROM samples WHERE ts>=? ORDER BY ts", (since,)).fetchall()
+    sessions = _gpu_sessions(rows, INTERVAL, price=price)[:50]
+    tot_energy = round(sum(x["energy_kwh"] for x in sessions), 3)
+    return jsonify({
+        "range": rng, "currency": s.get("currency") or "$",
+        "price": price, "kwh_price": price,
+        "active_pct": _ACTIVE_UTIL,
+        "sessions": sessions,
+        "totals": {"count": len(sessions), "energy_kwh": tot_energy,
+                   "cost": round(tot_energy * price, 2),
+                   "active_hours": round(sum(x["duration"] for x in sessions) / 3600.0, 1)},
+        "training": LATEST.get("training") or [],
     })
 
 # ── Container logs over SSE (issue #28) ───────────────────────────────────────

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -708,6 +708,22 @@ a{color:var(--info)}
   <p class="cap">One panel per model <b>server</b>: its VRAM timeline (shared by the models it hosts) plus each model's own peak &amp; average. A server is shown even while <b>Idle</b> (model unloaded / between requests), so nothing vanishes when VRAM is released. Recognised: Ollama, vLLM, SGLang, llama.cpp, LocalAI, HF TGI/TEI, LoRAX, mistral.rs, Aphrodite, koboldcpp, tabbyAPI, text-generation-webui, LM Studio, xinference, OpenLLM, LiteLLM, GPUStack, Cortex/Jan, Ramalama, Nexa, Triton, Infinity, faster-whisper/Speaches, Whisper ASR webservice/WhisperX, Wyoming (HA voice), OpenedAI-Speech, Stable Diffusion (A1111/Forge/SD.Next), InvokeAI, ComfyUI.</p>
 </section>
 
+<!-- ───────── Experiments / Training ───────── -->
+<section data-tab="experiments" hidden>
+  <div class="card" id="train-card">
+    <h2>🔬 Training runs <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— detected on the hub right now</span></h2>
+    <div id="train-body"></div>
+  </div>
+  <div class="card">
+    <h2>📈 GPU activity sessions</h2>
+    <div class="grid" id="sess-kpis"></div>
+    <table style="margin-top:12px"><thead><tr>
+      <th>Started</th><th>Duration</th><th>Peak util</th><th>Peak VRAM</th><th>Avg power</th><th>Energy</th><th>Cost</th>
+    </tr></thead><tbody id="sess-tbl"></tbody></table>
+    <p class="cap" id="sess-cap">Contiguous GPU-busy periods reconstructed from power &amp; utilisation history — each is a training run, batch job or inference burst. Energy is integrated from GPU power; cost uses your kWh price.</p>
+  </div>
+</section>
+
 <!-- ───────── Containers ───────── -->
 <section data-tab="containers" hidden>
   <div class="card"><h2>📦 Docker containers</h2>
@@ -1089,6 +1105,7 @@ const TABS = [
   {id:'overview',   label:'Overview',   charts:false},
   {id:'gpu',        label:'GPU',        charts:true},
   {id:'models',     label:'AI Models',  charts:false},
+  {id:'experiments',label:'Experiments', charts:false},
   {id:'containers', label:'Containers', charts:false},
   {id:'services',   label:'Services',   charts:false},
   {id:'host',       label:'System',     charts:true},
@@ -1120,6 +1137,7 @@ let HOST_DATA = null; // current host's /api/host_data response when remote
 const SC = {crit:'var(--crit)',warn:'var(--warn)',ok:'var(--ok)',info:'var(--mut)'};
 const fmtMB = v => v>=1024 ? (v/1024).toFixed(1)+' GB' : Math.round(v)+' MB';
 const fmtUp = s => {const d=s/86400|0,h=s%86400/3600|0,m=s%3600/60|0; return d?`${d}d ${h}h`:h?`${h}h ${m}m`:`${m}m`;};
+const fmtDur = s => {s=Math.max(0,Math.round(s)); if(s<60)return s+'s'; const m=s/60|0; if(m<60)return m+'m '+(s%60)+'s'; const h=m/60|0; if(h<24)return h+'h '+(m%60)+'m'; const d=h/24|0; return d+'d '+(h%24)+'h';};
 const sev = p => p>=90?'var(--crit)':p>=75?'var(--warn)':'var(--ok)';
 const esc = s => (s==null?'':String(s)).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
 const ICON={critical:'⛔',warning:'⚠️',ok:'✅',info:'ℹ️'};
@@ -1233,6 +1251,7 @@ function showTab(id){
     else renderLocalOnlyNotice(id);
   }
   if(id==='overview'){ renderFleet(); renderAiBand(); }
+  if(id==='experiments') renderExperiments(true);
   if(id==='host')     renderHostTab();
   if(id==='disks')    renderDisksTab();
   if(id==='network')  renderNetwork();
@@ -1596,6 +1615,7 @@ function renderHealth(){
   document.getElementById('ver').textContent='v'+HH.version;
   renderTopProcs();   // mini-htop card refreshes on every health poll (issue #32)
   renderAiBand();     // overview AI band uses fresh GPU/throttle data from /api/health
+  if(TAB==='experiments') renderExperiments(false);   // throttled live refresh of training cards
 
   // Update-available badge — only visible when GitHub releases shows a newer tag.
   const up = HH.update || {};
@@ -2458,7 +2478,7 @@ async function deleteHost(name){
 
 // ── Fleet + per-host (Issue #35 slice 2) ─────────────────────────────────────
 const HOST_SCOPED_TABS = new Set(['host','services']); // tabs that render from any host
-const LOCAL_ONLY_TABS  = new Set(['gpu','models','containers']);  // tabs not yet probed per-host
+const LOCAL_ONLY_TABS  = new Set(['gpu','models','experiments','containers']);  // tabs not yet probed per-host
 
 function fmtMBshort(v){
   if(v==null) return '—';
@@ -2602,6 +2622,55 @@ function paintAiBand(g,x,loaded,serving){
   if(cap) cap.textContent = g.available
     ? 'Live snapshot of this hub’s GPU + model servers. Tokens/sec and efficiency come from vLLM/TGI /metrics when present.'
     : 'No GPU detected on the hub — showing model servers only.';
+}
+
+// ── Experiments / Training tab ───────────────────────────────────────────────
+// Live training-run cards (auto-detected from /proc on the hub) + a table of GPU
+// activity sessions reconstructed from power/util history, with energy and cost.
+let EXP_AT=0;
+async function renderExperiments(force){
+  if(CURRENT_HOST!=='local'){ renderLocalOnlyNotice('experiments'); return; }
+  clearLocalOnlyNotice('experiments');
+  if(!force && Date.now()-EXP_AT < 15000) return;   // throttle the live refresh
+  EXP_AT=Date.now();
+  let j; try{ j=await(await fetch('/api/sessions?range='+encodeURIComponent(R))).json(); }catch(e){ return; }
+  const cur=j.currency||'$';
+  // Training runs detected right now
+  const tr=j.training||[], tb=document.getElementById('train-body');
+  if(tb){
+    if(!tr.length){
+      tb.innerHTML='<div class="muted">No training or fine-tuning process detected on the hub. Launch one '
+        +'(<code>torchrun</code>, <code>accelerate</code>, <code>deepspeed</code>, a <code>train.py</code> / SFT / LoRA script…) '
+        +'and it appears here automatically — no agent inside the job.</div>';
+    } else {
+      const gutil=(HH&&HH.now&&HH.now.gpu&&HH.now.gpu.util)||0;
+      tb.innerHTML=tr.map(t=>{
+        const stall=t.on_gpu && gutil<8;
+        return `<div class="gpucard">
+          <div class="gpucard-h"><b>${esc(t.label)}</b> <span class="muted">pid ${t.pid}</span>
+            ${t.on_gpu?'<span class="badge ok">on GPU</span>':'<span class="badge info">no GPU yet</span>'}
+            ${stall?'<span class="badge crit" title="Holds VRAM but GPU util ~0 — possible stall (dead dataloader / checkpoint / deadlock)">⚠ possible stall</span>':''}
+            <span class="gpucard-stats">${fmtDur(t.elapsed)} elapsed${t.vram?' · '+fmtMB(t.vram)+' VRAM':''}</span></div>
+          <div class="cap" style="margin-top:6px;word-break:break-all">${esc(t.cmd)}</div></div>`;
+      }).join('');
+    }
+  }
+  // GPU activity sessions
+  const T=j.totals||{};
+  const k=document.getElementById('sess-kpis');
+  if(k) k.innerHTML=[
+    {v:String(T.count||0),l:'Sessions'},
+    {v:(T.active_hours||0)+' h',l:'GPU-active time'},
+    {v:(T.energy_kwh||0).toFixed(2)+' kWh',l:'Energy'},
+    {v:j.price>0?cur+(T.cost||0).toFixed(2):'—',l:'Cost'},
+  ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div></div>`).join('');
+  const fmtTs=ts=>new Date(ts*1000).toLocaleString([], {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+  const rows=j.sessions||[], st=document.getElementById('sess-tbl');
+  if(st) st.innerHTML = rows.length? rows.map(s=>
+    `<tr><td>${fmtTs(s.start)}</td><td>${fmtDur(s.duration)}</td><td>${s.peak_util}%</td>
+      <td>${fmtMB(s.peak_vram)}</td><td>${s.avg_power} W</td><td>${s.energy_kwh.toFixed(3)} kWh</td>
+      <td>${j.price>0?cur+s.cost.toFixed(2):'—'}</td></tr>`).join('')
+    : `<tr><td class="muted" colspan="7">No GPU activity above ${j.active_pct||20}% util in this range yet.</td></tr>`;
 }
 
 function renderFleet(){
@@ -3289,7 +3358,8 @@ mountShell();
 buildNav();
 initTheme();
 document.querySelectorAll('.rb').forEach(b=>b.onclick=()=>{R=b.dataset.r;localStorage.setItem('hl_range',R);
-  document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));loadData();});
+  document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));loadData();
+  if(TAB==='experiments') renderExperiments(true);});
 document.querySelector(`.rb[data-r="${R}"]`)?.classList.add('on');
 
 /* ════════ Snapshot + Share (#31 / #87) ════════

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,132 @@
+"""Unit tests for the Experiments tab: training-run detection (/proc cmdline) and
+GPU activity-session reconstruction from power/util history."""
+import os
+import re
+import sys
+import time
+import unittest
+from io import BytesIO
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestClassifyTraining(unittest.TestCase):
+    def test_launchers(self):
+        self.assertEqual(app._classify_training(["torchrun", "--nproc", "2", "train.py"]), "torchrun")
+        self.assertEqual(app._classify_training(["accelerate", "launch", "run.py"]), "accelerate")
+        self.assertEqual(app._classify_training(["deepspeed", "x.py"]), "deepspeed")
+
+    def test_train_scripts(self):
+        self.assertEqual(app._classify_training(["python", "train.py"]), "train.py")
+        self.assertEqual(app._classify_training(["python", "/work/finetune_lora.py", "--lr", "1e-4"]),
+                         "finetune_lora.py")
+
+    def test_ml_framework_module(self):
+        self.assertEqual(app._classify_training(["python", "-m", "axolotl.cli.train"]), "training")
+
+    def test_not_training(self):
+        self.assertIsNone(app._classify_training(["python", "serve_api.py"]))
+        self.assertIsNone(app._classify_training(["ollama", "serve"]))
+        self.assertIsNone(app._classify_training([]))
+
+
+class TestCollectTraining(unittest.TestCase):
+    def _run(self, procs, gpu_pids, now):
+        def fake_open(path, *a, **k):
+            m = re.match(r"/proc/(\d+)/cmdline$", path)
+            if m and m.group(1) in procs:
+                return BytesIO(procs[m.group(1)])
+            raise FileNotFoundError(path)
+        with patch("app.os.listdir", return_value=list(procs.keys())), \
+             patch("builtins.open", side_effect=fake_open):
+            return app.collect_training(gpu_pids, now=now)
+
+    def test_detects_and_annotates_vram(self):
+        app._TRAIN_SEEN.clear()
+        procs = {"100": b"torchrun\x00--nproc_per_node\x002\x00sft.py\x00",
+                 "200": b"python\x00serve_api.py\x00",            # inference, not training
+                 "300": b"python\x00finetune_lora.py\x00"}
+        out = self._run(procs, {100: 5000}, now=1000)
+        pids = {r["pid"] for r in out}
+        self.assertIn(100, pids)
+        self.assertIn(300, pids)
+        self.assertNotIn(200, pids)                              # plain inference excluded
+        t100 = next(r for r in out if r["pid"] == 100)
+        self.assertEqual(t100["vram"], 5000)
+        self.assertTrue(t100["on_gpu"])
+        t300 = next(r for r in out if r["pid"] == 300)
+        self.assertFalse(t300["on_gpu"])                        # not on the GPU
+
+    def test_elapsed_from_first_seen(self):
+        app._TRAIN_SEEN.clear()
+        procs = {"100": b"torchrun\x00train.py\x00"}
+        o1 = self._run(procs, {}, now=1000)
+        o2 = self._run(procs, {}, now=1050)
+        self.assertEqual(o1[0]["elapsed"], 0)
+        self.assertEqual(o2[0]["elapsed"], 50)
+
+    def test_dead_pid_forgotten(self):
+        app._TRAIN_SEEN.clear()
+        self._run({"100": b"torchrun\x00train.py\x00"}, {}, now=1000)
+        self.assertIn("100", app._TRAIN_SEEN)
+        self._run({"200": b"deepspeed\x00x.py\x00"}, {}, now=1100)   # 100 gone
+        self.assertNotIn("100", app._TRAIN_SEEN)
+
+
+class TestGpuSessions(unittest.TestCase):
+    def test_single_session_metrics(self):
+        rows = [(100, 50, 200, 8000), (110, 60, 210, 8100), (120, 55, 205, 8050),
+                (130, 5, 50, 100), (140, 3, 40, 90)]
+        s = app._gpu_sessions(rows, 10, active_util=20, max_gap=1, min_len=2, price=0.5)
+        self.assertEqual(len(s), 1)
+        sess = s[0]
+        self.assertEqual(sess["start"], 100)
+        self.assertEqual(sess["end"], 120)
+        self.assertEqual(sess["duration"], 30)                 # end-start+interval
+        self.assertEqual(sess["peak_util"], 60)
+        self.assertEqual(sess["peak_vram"], 8100)
+        expect_kwh = (200 + 210 + 205) * 10 / 3_600_000.0
+        self.assertAlmostEqual(sess["energy_kwh"], round(expect_kwh, 4), places=6)
+        self.assertAlmostEqual(sess["cost"], round(expect_kwh * 0.5, 4), places=6)
+
+    def test_gap_splits_sessions(self):
+        # two bursts separated by 2 idle samples; max_gap=1 -> two sessions
+        rows = [(100, 50, 100, 1), (110, 50, 100, 1),
+                (120, 0, 0, 0), (130, 0, 0, 0),
+                (140, 50, 100, 1), (150, 50, 100, 1)]
+        s = app._gpu_sessions(rows, 10, active_util=20, max_gap=1, min_len=2)
+        self.assertEqual(len(s), 2)
+
+    def test_gap_within_tolerance_merges(self):
+        rows = [(100, 50, 100, 1), (110, 50, 100, 1),
+                (120, 0, 0, 0),
+                (130, 50, 100, 1), (140, 50, 100, 1)]
+        s = app._gpu_sessions(rows, 10, active_util=20, max_gap=2, min_len=2)
+        self.assertEqual(len(s), 1)                            # single idle tolerated
+
+    def test_min_len_drops_blips(self):
+        rows = [(100, 90, 300, 9000), (110, 1, 0, 0)]
+        s = app._gpu_sessions(rows, 10, active_util=20, max_gap=1, min_len=2)
+        self.assertEqual(s, [])                                # one-sample blip ignored
+
+
+class TestApiSessions(unittest.TestCase):
+    def test_endpoint(self):
+        now = int(time.time())
+        with app.LOCK:
+            app.DB.execute("DELETE FROM samples")
+            for i in range(6):
+                app.DB.execute("INSERT OR REPLACE INTO samples(ts,util,mem_used,mem_total,power,temp) "
+                               "VALUES(?,?,?,?,?,?)", (now - 100 + i * 10, 50, 8000, 24000, 200, 60))
+            app.DB.commit()
+        app.save_settings({"kwh_price": "0.30", "currency": "$", "tariff_mode": "single"})
+        j = app.app.test_client().get("/api/sessions?range=1h").get_json()
+        self.assertGreaterEqual(j["totals"]["count"], 1)
+        self.assertIn("training", j)
+        self.assertTrue(j["sessions"][0]["energy_kwh"] > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Experiments / Training tab — part of 0.16 "AI Lab Cockpit"

The feature that turns the dashboard into an **ML cockpit**. A new **Experiments** tab, zero-config, no agent inside the job.

### Training-run auto-detection 🏆
Scans `/proc` cmdline for training/fine-tuning **launchers** (torchrun, accelerate, deepspeed, torch.distributed) and **train-ish scripts** (train/finetune/sft/dpo/lora…) and **ML frameworks** (trl, axolotl, unsloth, llama-factory, lightning…). Conservative — won't flag plain inference. Each run shows launcher, pid, **elapsed time**, and the **VRAM its PID holds** (nvidia-smi compute-apps). A **"possible stall"** badge when it holds VRAM but GPU util has collapsed — *catch a dead 2 a.m. run before you lose the night.*

### GPU activity sessions
`/api/sessions` reconstructs contiguous **GPU-busy periods** from the power/util history we already store (no new storage) — each with duration, peak util/VRAM, avg power, integrated **energy (kWh)** and **cost**. Tolerates short idle gaps; drops one-sample blips.

Both best-effort and isolated; `LATEST['training']` feeds the live cards; tab is local-hub scoped.

### Tests
cmdline classifier (launchers/scripts/frameworks/not-training), collect_training (vram annotation, elapsed-from-first-seen, dead-pid cleanup), session reconstruction (metrics, gap split/merge, min-length), `/api/sessions`. **90 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)