### PR TITLE
feat(experiments): notebooks & tools discovery + idle-VRAM squatter

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,7 +175,7 @@ _apply_schema_migrations(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
           "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpus": [], "gpu_extra": {},
-          "model_meta": {}, "serving": [], "training": []}
+          "model_meta": {}, "serving": [], "training": [], "devtools": []}
 # Current state of the "status" monitors (Docker + systemd). The background
 # collector refreshes these; /api/health just serves the cached snapshot.
 HEALTH = {"docker": None, "systemd": None, "update": None, "processes": None, "at": 0}
@@ -2229,6 +2229,63 @@ def collect_training(gpu_pids, now=None):
         _TRAIN_SEEN.pop(dead, None)
     return sorted(out, key=lambda r: -r["elapsed"])
 
+# Data-science tooling that runs as a local web app — discovered from /proc cmdline
+# so the dashboard links straight to your notebooks & experiment trackers, and can
+# flag a notebook kernel quietly squatting on VRAM (the "my GPU is full but nothing
+# is running" culprit). (kind, label, default_port, cmdline regex).
+_DEVTOOLS = [
+    ("jupyter",     "Jupyter",     8888, re.compile(r"jupyter[-_ ]?(lab|notebook|server)|jupyterlab", re.I)),
+    ("tensorboard", "TensorBoard", 6006, re.compile(r"tensorboard", re.I)),
+    ("mlflow",      "MLflow",      5000, re.compile(r"\bmlflow\b", re.I)),
+    ("wandb",       "W&B",         8080, re.compile(r"\bwandb\b", re.I)),
+    ("streamlit",   "Streamlit",   8501, re.compile(r"\bstreamlit\b", re.I)),
+    ("ray",         "Ray",         8265, re.compile(r"raylet|ray\.dashboard|ray start", re.I)),
+]
+_PORT_RE = re.compile(r"^--?port(?:=(\d{2,5}))?$")
+
+def _extract_port(argv):
+    """Pull an explicit --port N / --port=N from a cmdline, else None."""
+    for i, a in enumerate(argv):
+        m = _PORT_RE.match(a)
+        if m:
+            if m.group(1):
+                return int(m.group(1))
+            if i + 1 < len(argv) and argv[i + 1].isdigit():
+                return int(argv[i + 1])
+    return None
+
+def collect_devtools(gpu_pids):
+    """Discover running DS/AI tools (Jupyter, TensorBoard, MLflow, W&B, …) from /proc
+    and tag any that are holding GPU VRAM. Returns [] where /proc is unavailable."""
+    out, seen = [], set()
+    try:
+        pids = [p for p in os.listdir("/proc") if p.isdigit()]
+    except Exception:
+        return out
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as f:
+                raw = f.read()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        argv = [t for t in raw.decode("utf-8", "replace").split("\x00") if t]
+        low = " ".join(argv).lower()
+        for kind, label, dport, rx in _DEVTOOLS:
+            if not rx.search(low):
+                continue
+            port = _extract_port(argv) or dport
+            key = (kind, port)
+            if key in seen:
+                break
+            seen.add(key)
+            vram = gpu_pids.get(int(pid), 0)
+            out.append({"kind": kind, "label": label, "port": port, "pid": int(pid),
+                        "vram": round(vram), "idle_vram": bool(vram)})
+            break
+    return sorted(out, key=lambda r: r["label"])
+
 _ACTIVE_UTIL = 20    # GPU util % at/above which a sample counts as a "busy" session sample
 
 def _gpu_sessions(rows, interval, active_util=_ACTIVE_UTIL, max_gap=3, min_len=2, price=0.0):
@@ -3707,6 +3764,10 @@ def sample_once():
         training = collect_training(gpu_pids)
     except Exception:
         training = []
+    try:
+        devtools = collect_devtools(gpu_pids)
+    except Exception:
+        devtools = []
 
     host = read_host()
     ts = int(time.time())
@@ -3745,7 +3806,7 @@ def sample_once():
                   gpu_avail=gpu_avail, gpus=gpus, gpu_extra=gpu_extra,
                   procs=sorted(({"service": s, "mem": round(m)} for s, m in procs.items()), key=lambda x: -x["mem"]),
                   models=[{"service": s, "model": m, "vram": v} for s, m, v in models],
-                  model_meta=model_meta, serving=serving, training=training,
+                  model_meta=model_meta, serving=serving, training=training, devtools=devtools,
                   callers=sorted(({"caller": c, "server": s, "conns": n} for (c, s), n in edges.items()),
                                  key=lambda x: -x["conns"]), host=host)
 
@@ -4044,6 +4105,7 @@ def api_sessions():
                    "cost": round(tot_energy * price, 2),
                    "active_hours": round(sum(x["duration"] for x in sessions) / 3600.0, 1)},
         "training": LATEST.get("training") or [],
+        "devtools": LATEST.get("devtools") or [],
     })
 
 # ── Container logs over SSE (issue #28) ───────────────────────────────────────

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -166,6 +166,11 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .mchip.cap{border-color:#58a6ff66;color:#58a6ff}
 .serving-row{display:flex;flex-wrap:wrap;gap:7px;align-items:center;margin:10px 0 2px}
 .serving-tag{font-size:10.5px;color:var(--ok);border:1px solid var(--ok);border-radius:9px;padding:2px 8px;opacity:.8}
+/* Notebooks & tools tiles on the Experiments tab */
+.tool-grid{display:flex;flex-wrap:wrap;gap:10px}
+.tool-tile{display:flex;align-items:center;gap:8px;border:1px solid var(--bd);border-radius:10px;padding:9px 13px;background:rgba(127,127,127,.04);text-decoration:none;color:var(--tx)}
+.tool-tile:hover{border-color:#58a6ff}
+.tool-ic{font-size:17px}.tool-nm{font-weight:600;font-size:13px}.tool-pt{color:var(--mut);font-size:12px;font-variant-numeric:tabular-nums}
 .muted{color:var(--mut)}a{color:#58a6ff}
 /* clickable port chips on the Containers/Services tabs — opens the host:port in a new tab */
 .ports{display:inline-flex;flex-wrap:wrap;gap:4px}
@@ -713,6 +718,11 @@ a{color:var(--info)}
   <div class="card" id="train-card">
     <h2>🔬 Training runs <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— detected on the hub right now</span></h2>
     <div id="train-body"></div>
+  </div>
+  <div class="card" id="devtools-card" hidden>
+    <h2>🧰 Notebooks &amp; tools</h2>
+    <div id="devtools-body"></div>
+    <p class="cap">Auto-discovered DS/AI web tools running on the hub. A 🟡 VRAM tag means a kernel/process is holding GPU memory — often a forgotten notebook squatting on VRAM.</p>
   </div>
   <div class="card">
     <h2>📈 GPU activity sessions</h2>
@@ -2653,6 +2663,24 @@ async function renderExperiments(force){
             <span class="gpucard-stats">${fmtDur(t.elapsed)} elapsed${t.vram?' · '+fmtMB(t.vram)+' VRAM':''}</span></div>
           <div class="cap" style="margin-top:6px;word-break:break-all">${esc(t.cmd)}</div></div>`;
       }).join('');
+    }
+  }
+  // Notebooks & tools (auto-discovered DS/AI web apps)
+  const dv=j.devtools||[], dc=document.getElementById('devtools-card'), db=document.getElementById('devtools-body');
+  if(dc&&db){
+    if(!dv.length){ dc.hidden=true; }
+    else{
+      dc.hidden=false;
+      const ICONS={jupyter:'📓',tensorboard:'📊',mlflow:'🧪',wandb:'🐝',streamlit:'🎈',ray:'⚡'};
+      db.innerHTML='<div class="tool-grid">'+dv.map(d=>{
+        const href=`//${location.hostname}:${d.port}`;
+        return `<a class="tool-tile" href="${href}" target="_blank" rel="noopener" title="Open ${esc(d.label)} on port ${d.port}">
+          <span class="tool-ic">${ICONS[d.kind]||'🔗'}</span>
+          <span class="tool-nm">${esc(d.label)}</span>
+          <span class="tool-pt">:${d.port}</span>
+          ${d.idle_vram?`<span class="badge warn" title="Holding ${fmtMB(d.vram)} of GPU VRAM">🟡 ${fmtMB(d.vram)}</span>`:''}
+        </a>`;
+      }).join('')+'</div>';
     }
   }
   // GPU activity sessions

--- a/tests/test_devtools.py
+++ b/tests/test_devtools.py
@@ -1,0 +1,61 @@
+"""Unit tests for DS/AI tool discovery (Jupyter, TensorBoard, MLflow, W&B, …)."""
+import os
+import re
+import sys
+import unittest
+from io import BytesIO
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestExtractPort(unittest.TestCase):
+    def test_equals_and_spaced(self):
+        self.assertEqual(app._extract_port(["jupyter-lab", "--port=8890"]), 8890)
+        self.assertEqual(app._extract_port(["tensorboard", "--port", "6007"]), 6007)
+        self.assertIsNone(app._extract_port(["jupyter-lab", "--no-browser"]))
+
+
+class TestCollectDevtools(unittest.TestCase):
+    def _run(self, procs, gpu_pids):
+        def fake_open(path, *a, **k):
+            m = re.match(r"/proc/(\d+)/cmdline$", path)
+            if m and m.group(1) in procs:
+                return BytesIO(procs[m.group(1)])
+            raise FileNotFoundError(path)
+        with patch("app.os.listdir", return_value=list(procs.keys())), \
+             patch("builtins.open", side_effect=fake_open):
+            return app.collect_devtools(gpu_pids)
+
+    def test_discovers_tools_and_ports(self):
+        procs = {
+            "10": b"/usr/bin/python\x00/opt/conda/bin/jupyter-lab\x00--port=8890\x00--no-browser\x00",
+            "20": b"python\x00-m\x00tensorboard\x00--logdir\x00runs\x00--port\x006007\x00",
+            "30": b"mlflow\x00server\x00--host\x000.0.0.0\x00",
+            "40": b"python\x00serve.py\x00",                  # not a tool
+        }
+        out = self._run(procs, {10: 9000})
+        by = {d["kind"]: d for d in out}
+        self.assertEqual(by["jupyter"]["port"], 8890)
+        self.assertEqual(by["tensorboard"]["port"], 6007)
+        self.assertEqual(by["mlflow"]["port"], 5000)         # default when no --port
+        self.assertNotIn("serve", by)
+
+    def test_idle_vram_flag(self):
+        procs = {"10": b"jupyter-lab\x00"}
+        out = self._run(procs, {10: 9216})
+        self.assertTrue(out[0]["idle_vram"])                 # holding VRAM -> squatter
+        self.assertEqual(out[0]["vram"], 9216)
+        out2 = self._run({"11": b"jupyter-lab\x00"}, {})     # no VRAM
+        self.assertFalse(out2[0]["idle_vram"])
+
+    def test_dedup_same_kind_and_port(self):
+        procs = {"10": b"jupyter-lab\x00--port=8888\x00",
+                 "11": b"jupyter-lab\x00--port=8888\x00"}     # worker fork, same port
+        out = self._run(procs, {})
+        self.assertEqual(len([d for d in out if d["kind"] == "jupyter"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Notebooks & Tools — part of 0.16 "AI Lab Cockpit"

Auto-discovers the DS/AI **web tools** running on the hub — **Jupyter, TensorBoard, MLflow, Weights & Biases, Streamlit, Ray** — from `/proc` cmdline, parses out the real `--port`, and shows them as **clickable tiles** on the Experiments tab. Your whole experiment stack, one click away.

### Idle-VRAM squatter 🟡
Any tool whose process is **holding GPU VRAM** gets a VRAM tag — the classic *"my GPU is full but nothing's running"* culprit: a forgotten notebook kernel squatting on memory.

Bounded + isolated like the other collectors, deduped per (kind, port). Exposed via `LATEST['devtools']` and `/api/sessions`; the card hides when nothing is found.

### Tests
`--port` extraction (=, spaced, absent), discovery + default ports, idle-VRAM flag, dedup of worker forks. **94 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)