### PR TITLE
docs(0.16): changelog + morning report + launch copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [Unreleased] — `next` branch · **"The AI Lab Cockpit"**
+*Staged on `next` for preview (deployable via the `:next` Docker image). Not yet on `main`.*
+
+The release that turns HomeLab Monitor from a great sysadmin dashboard into **the** at-a-glance cockpit for people who **train models and serve LLMs** at home. No new dependencies — still pure Python + Flask, reading `nvidia-smi`, `/proc`, the Docker socket and your model servers directly.
+
+- **Cost — day & night tariffs.** Electricity is commonly billed at split day/night rates (UK Economy 7, France Heures Creuses, Spain PVPC, German HT/NT…). The cost card now supports dual tariffs with a configurable night window (may cross midnight, evaluated in server-local time). Don't know your rates? **Pick your country** to prefill a typical, sourced estimate from a bundled 38-country dataset — always editable. Single-average mode is unchanged and the default. (#113)
+- **GPU truth-telling.** A GPU at "100% util" can still be underperforming. New from the same `nvidia-smi` call: **throttle-reason decoding** (a red banner when the card is power-capped or thermally throttling), **memory-bandwidth utilisation** (mem-bound vs compute-bound), core/mem clocks, **power draw vs limit (headroom)**, performance state, and memory-junction temp. (#114)
+- **Model intelligence.** Ollama models show **parameter size, quantization, context length** and capability badges (vision/tools/embedding) via `/api/show`. vLLM/TGI servers get a **live serving** strip — **tokens/sec**, requests running/queued, **KV-cache fill**, and average TTFT — scraped from their Prometheus `/metrics`. (#115)
+- **AI workload band.** The Overview now leads with an at-a-glance hero: models loaded + VRAM committed, GPU util + mem-bandwidth, live throughput, **tokens-per-Joule efficiency**, today's GPU cost, and a throttle banner. (#116)
+- **Experiments tab.** Auto-detects **training / fine-tuning runs** (torchrun, accelerate, deepspeed, train/SFT/LoRA scripts, trl/axolotl/unsloth…) with elapsed time, VRAM held, and a **"possible stall"** alert when a run holds VRAM but GPU util collapses — catch a dead 2 a.m. job. Plus **GPU activity sessions** reconstructed from power/util history, each with energy (kWh) and cost. (#117)
+- **Notebooks & tools.** Auto-discovers **Jupyter, TensorBoard, MLflow, Weights & Biases, Streamlit, Ray** from `/proc` and links straight to them — with an **idle-VRAM-squatter** flag for the forgotten notebook kernel hogging your GPU. (#118)
+
+94 unit tests; every change shipped through CI → `:next` → preview. Research, design and the per-tab gap analysis live under `design/ai-cockpit/`.
+
 ## [0.15.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.15.0) — 2026-06-12
 *Polish, safety & sharing.*
 - **Snapshot & Share** — grab the current tab as a PNG, or share a generic link + blurb (no host data) to X, Reddit, Hacker News, LinkedIn, Mastodon, Bluesky, Telegram, WhatsApp and more. Closes #31, #87.

--- a/design/ai-cockpit/MORNING-REPORT.md
+++ b/design/ai-cockpit/MORNING-REPORT.md
@@ -1,0 +1,65 @@
+# Good morning ☀️ — 0.16 "AI Lab Cockpit" is built
+
+You went out and asked for a revamp of cost monitoring plus an AI/Data-Science
+rethink of the whole dashboard, worked out with specialist agents, shipped one
+by one, on `next` only. Here's what landed while you slept.
+
+## TL;DR
+**6 features, 6 merged PRs, 94 unit tests, 0 changes to `main`.** Everything is on
+`next` and deployable via the `:next` Docker image (Watchtower-redeployed on
+`ardi:9801`). No new dependencies — still pure Python + Flask.
+
+## How the night went (research → debate → build)
+1. **Researched** with three specialist agents in parallel: an AI/DS feature
+   catalog, a per-tab gap audit from a data-scientist's POV, and a dual-tariff
+   cost design with a real 38-country dataset. Artifacts: `research-A/B/C` +
+   `tariffs.json` in this folder.
+2. **Synthesised** into `PLAN.md` — the "AI Lab Cockpit" thesis and a 6-PR roadmap.
+3. **Built** each PR off `origin/next`: implement → local unit tests → PR → CI
+   `smoke` → merge → `:next` publish → Watchtower redeploy → verify.
+
+## What shipped
+
+| PR | Feature | The headline bit |
+|----|---------|------------------|
+| #113 | **Cost: day & night tariffs** | Pick your country → prefilled day/night rates (38-country sourced dataset). Single-average still the default. |
+| #114 | **GPU truth-telling** | Red banner when the GPU is **throttling** (power-capped/thermal); memory-bandwidth %, clocks, power headroom, p-state. ✅ *verified on your real RTX.* |
+| #115 | **Model intelligence** | Ollama param-size/quant/context badges + **live vLLM/TGI tokens/sec, queue, KV-cache, TTFT**. |
+| #116 | **AI workload band** | Overview hero: models loaded, VRAM, **tokens-per-Joule**, today's GPU cost, throttle. |
+| #117 | **Experiments tab** | Auto-detected **training runs** + **stall alert**; **GPU activity sessions** with energy & cost. |
+| #118 | **Notebooks & tools** | Auto-discovered Jupyter/TensorBoard/MLflow/W&B/Streamlit/Ray tiles + **idle-VRAM squatter** flag. |
+
+## The release headline (for the post)
+> **Your GPU says 100% util. This free dashboard tells you the truth — throttled,
+> memory-bandwidth-bound, or a Jupyter kernel squatting on 9 GB of VRAM. Plus live
+> tokens/sec, cost-per-run, and it pings you when a 2 a.m. training run stalls.**
+
+Full launch copy (Reddit / HN / Towards Data Science / X) in `RELEASE-DRAFT.md`.
+
+## How to see it
+- Preview: **http://ardi:9801** — open the new **Experiments** tab, the enriched
+  **GPU** and **AI Models** tabs, and the **Overview** AI band. Settings → Alerts
+  has the new day/night tariff + country picker.
+- The throttle banner only appears when the card actually throttles; the serving
+  strip appears when a vLLM/TGI server is up; training cards appear when a job runs.
+
+## Verification notes (honest status)
+- **#114 GPU telemetry is verified on your real hardware** — `/api/health` returned
+  the correct RTX fields (350 W limit, P8 idle, mem-BW %, clocks).
+- The other PRs passed CI `smoke` + full local unit tests. The GPU-/Docker-dependent
+  UIs can't be exercised on the Windows dev box, so they're best-effort + isolated
+  (any nvidia-smi / endpoint failure degrades that panel and never wedges the
+  sampler). When you read this, Watchtower should have pulled the final `:next`;
+  if `ardi:9801` shows an older build, it's just the 5-minute poll catching up.
+
+## Suggested next steps (your call — I didn't touch these)
+1. **Merge `next` → `main` and cut v0.16** when you've eyeballed the preview. The
+   CHANGELOG `Unreleased` section and `RELEASE-DRAFT.md` are ready.
+2. **README hero update** for the storefront — draft in `RELEASE-DRAFT.md` (§README).
+3. **Star-growth post** using the headline + a screenshot of the throttle banner or
+   the AI band.
+4. A couple of stretch ideas I scoped but didn't build (kept the night focused):
+   per-PID GPU *utilisation* (needs `nvidia-smi pmon`), an opt-in Ollama tok/s
+   benchmark, and a persistent run-history journal. Notes in `research-A`.
+
+Nothing is broken on `main`. Hope this puts a smile on your face. 🛰️

--- a/design/ai-cockpit/PLAN.md
+++ b/design/ai-cockpit/PLAN.md
@@ -47,10 +47,12 @@ Must-haves if the night runs short: **A (requested), B, C.** D–F are high-valu
 - GPU-dependent behavior verified live on `ardi:9801` after Watchtower redeploys (~210–315 s).
 - Issues stay open until shipped to `main` (maintainer convention).
 
-## Status log
-- [ ] A  Cost dual-tariff
-- [ ] B  GPU telemetry
-- [ ] C  Model intelligence
-- [ ] D  Overview AI band + efficiency
-- [ ] E  Experiments/Training tab
-- [ ] F  Notebooks/Endpoints tab
+## Status log — ALL SHIPPED to `next` ✅
+- [x] A  Cost dual-tariff + country prefill — PR #113
+- [x] B  GPU telemetry (throttle/mem-BW/clocks/headroom) — PR #114 *(verified live on real GPU)*
+- [x] C  Model intelligence (Ollama meta + vLLM/TGI serving) — PR #115
+- [x] D  Overview AI band + tokens-per-Joule — PR #116
+- [x] E  Experiments/Training tab (runs + sessions + stall) — PR #117
+- [x] F  Notebooks/Tools discovery + idle-VRAM squatter — PR #118
+
+94 unit tests green. See `MORNING-REPORT.md` for the full account and `RELEASE-DRAFT.md` for the launch copy.

--- a/design/ai-cockpit/RELEASE-DRAFT.md
+++ b/design/ai-cockpit/RELEASE-DRAFT.md
@@ -1,0 +1,53 @@
+# 0.16 "The AI Lab Cockpit" — launch copy
+
+Ready-to-post copy for the release. Tune voice to taste before posting.
+
+## Headline (pick one)
+1. **Your GPU says 100% util. This free dashboard tells you the truth — throttled, memory-bandwidth-bound, or a Jupyter kernel squatting on 9 GB of VRAM.** Plus live tokens/sec, cost-per-run, and it pings you when a 2 a.m. training run stalls.
+2. **Tokens per Joule:** an open-source dashboard that measures how efficiently your home GPU serves LLMs — and what your idle models cost you in electricity.
+3. **I built a free cockpit for my AI home lab** — live tokens/sec, GPU throttling truth, training-run stall alerts, and day/night electricity cost. Pure Python, no agents, no cloud.
+
+## GitHub release notes (v0.16.0)
+
+> ### 🧠 The AI Lab Cockpit
+> HomeLab Monitor is now the at-a-glance dashboard for people who **train models and serve LLMs** at home — without adding a single dependency. It already knew your GPU and containers; now it understands your *AI work*.
+>
+> **🔥 GPU truth-telling.** A red banner when your card is **throttling** (power-capped or thermal), plus memory-bandwidth utilisation (mem-bound vs compute-bound), clocks, power-vs-limit headroom and performance state — all from the `nvidia-smi` it already calls. "100% util" stops lying.
+>
+> **⚡ Live serving telemetry.** vLLM/TGI servers show real **tokens/sec**, requests running/queued, **KV-cache fill** and TTFT, scraped from their Prometheus `/metrics`. Ollama models show **parameter size, quantization, context length** and capability badges.
+>
+> **🔬 Experiments tab.** Your training and fine-tuning runs (torchrun, accelerate, deepspeed, SFT/LoRA scripts, trl/axolotl/unsloth) are **auto-detected** with elapsed time and VRAM held — and a **"possible stall"** alert when a run holds VRAM but GPU util collapses. Plus **GPU activity sessions** with energy and cost per run.
+>
+> **🧰 Notebooks & tools.** Auto-discovers Jupyter, TensorBoard, MLflow, W&B, Streamlit and Ray and links straight to them — and flags the **idle notebook kernel squatting on your VRAM**.
+>
+> **🧠 AI workload band.** The Overview leads with models loaded, VRAM committed, GPU util, **tokens-per-Joule efficiency**, and today's GPU cost.
+>
+> **💰 Day & night electricity tariffs.** Bill your GPU energy at split day/night rates with a configurable night window — or **pick your country** to prefill a typical, sourced estimate (38-country dataset). Don't know your rates? The flat average still works.
+>
+> Still pure Python + Flask. No agents, no Prometheus/Grafana, no cloud. `docker compose up -d` and open the page.
+
+## Reddit (r/LocalLLaMA, r/homelab, r/selfhosted)
+**Title:** Your GPU says 100% util — but is it throttling, memory-bound, or is a notebook squatting on your VRAM? I added "GPU truth-telling" + live tokens/sec to my open-source homelab dashboard.
+
+**Body:** I run models at home and got tired of `watch nvidia-smi` + tailing vLLM logs in three terminals. So my self-hosted dashboard (no agents, no Prometheus, pure Python) now:
+- decodes nvidia-smi **throttle reasons** → red banner when you're power-capped/thermal,
+- shows **memory-bandwidth util** so you can see when you're memory-bound (LLM decode usually is),
+- scrapes vLLM/TGI `/metrics` for **live tokens/sec, KV-cache, queue depth, TTFT**,
+- **auto-detects training runs** and warns when one **stalls** (VRAM held, util at 0 — the dead-dataloader-at-2am scenario),
+- reconstructs **GPU activity sessions** with energy + cost, and shows **tokens-per-Joule**,
+- finds your **Jupyter/TensorBoard/MLflow/W&B** and flags an **idle kernel hogging VRAM**.
+`docker compose up -d`. Feedback and stars welcome — repo in comments.
+
+## Hacker News (Show HN)
+**Show HN: Open-source AI homelab dashboard — GPU throttle truth, live tokens/sec, stall alerts (pure Python)**
+
+## X / Bluesky
+🛰️ New in HomeLab Monitor: it tells you the **truth** about your GPU.
+🔥 throttling? 🧠 memory-bound? 💤 a notebook squatting on 9GB VRAM?
++ live tok/s, tokens-per-Joule, training-run **stall alerts**, and day/night power cost.
+Pure Python, self-hosted, no agents. `docker compose up -d`.
+
+## README hero (§README — drop-in replacement for the intro tagline)
+> **One page for your whole home lab & AI rig — GPU truth (throttling, mem-bandwidth, tokens/sec), training-run stall alerts, model VRAM & cost. No agents, no Prometheus/Grafana, no cloud.**
+>
+> Your GPU is "always busy" — but is it *working*, or throttled, memory-bound, or holding VRAM for a dead notebook? HomeLab Monitor answers the questions an AI home lab actually has: which model holds the GPU, how many tokens/sec you're serving, what a training run cost in kWh, and whether that 2 a.m. fine-tune stalled — across every box over SSH.


### PR DESCRIPTION
Release housekeeping for the 0.16 "AI Lab Cockpit" line (all on `next`): CHANGELOG Unreleased section, a morning report, and ready-to-post launch copy. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)