### PR TITLE
fix(cost): bundle tariffs.json so the country dropdown populates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY probe.py /app/probe.py
 COPY probe.ps1 /app/probe.ps1
 COPY static/dashboard.html /app/static/dashboard.html
 COPY static/favicon.svg    /app/static/favicon.svg
+COPY static/tariffs.json   /app/static/tariffs.json
 
 # Built-in MCP server (read-only): the FastMCP wrapper + its pure-stdlib client,
 # plus the CHANGELOG it serves as a resource, and the process launcher that runs


### PR DESCRIPTION
The Dockerfile copies static assets individually and missed `static/tariffs.json` → `/static/tariffs.json` 404'd in the image → empty country dropdown. One-line COPY fix. Verified the file 404s on `ardi:9801` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)