### PR TITLE
feat(integrations): push/pull Runs API + client SDK + MLflow sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY probe.ps1 /app/probe.ps1
 COPY static/dashboard.html /app/static/dashboard.html
 COPY static/favicon.svg    /app/static/favicon.svg
 COPY static/tariffs.json   /app/static/tariffs.json
+COPY static/homelab_run.py /app/static/homelab_run.py
 
 # Built-in MCP server (read-only): the FastMCP wrapper + its pure-stdlib client,
 # plus the CHANGELOG it serves as a resource, and the process launcher that runs

--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ Adding a new monitor (it's meant to be easy):
   2. Populate it from `health_scan()` so the background thread keeps it fresh.
   3. Expose it via `/api/health` and add a matching tab/panel in dashboard.html.
 """
-import os, re, glob, time, json, socket, sqlite3, threading, subprocess, http.client, urllib.parse, urllib.request, ipaddress, shlex, struct, shutil, tempfile
+import os, re, glob, time, json, socket, sqlite3, threading, subprocess, http.client, urllib.parse, urllib.request, ipaddress, shlex, struct, shutil, tempfile, secrets, hmac, uuid
+from functools import wraps
 try:
     import fcntl                       # Linux-only; used for per-iface IPv4 (SIOCGIFADDR)
 except ImportError:
@@ -111,8 +112,17 @@ CREATE INDEX IF NOT EXISTS idx_net_ts    ON net_samples(ts);
 CREATE INDEX IF NOT EXISTS idx_proc_ts   ON proc(ts);
 CREATE INDEX IF NOT EXISTS idx_models_ts ON models(ts);
 CREATE INDEX IF NOT EXISTS idx_edges_ts  ON edges(ts);
+CREATE TABLE IF NOT EXISTS runs(
+  id TEXT PRIMARY KEY, name TEXT NOT NULL, source TEXT NOT NULL, status TEXT NOT NULL,
+  started_at INTEGER NOT NULL, ended_at INTEGER, host TEXT, params TEXT, tags TEXT,
+  notes TEXT, heartbeat_at INTEGER, ext_id TEXT, created_at INTEGER NOT NULL);
+CREATE TABLE IF NOT EXISTS run_metrics(run_id TEXT NOT NULL, ts INTEGER NOT NULL,
+  step INTEGER DEFAULT 0, key TEXT NOT NULL, value REAL NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_powerproc_ts   ON power_proc(ts);
 CREATE INDEX IF NOT EXISTS idx_powerproc_name ON power_proc(name, ts);
+CREATE INDEX IF NOT EXISTS idx_runs_started   ON runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_runmetrics_rid ON run_metrics(run_id, key, ts);
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_runs_ext ON runs(source, ext_id);
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_event ON events(ts, service, kind);
 """
 # cpu_power/dram_power: measured CPU package / DRAM watts via RAPL (#costs). NULL when unavailable.
@@ -3368,8 +3378,12 @@ SETTING_DEFAULTS = {
     "night_end":           "06:00",    # local time-of-day "HH:MM"
     "country":             "",         # ISO-3166 alpha-2 — UI prefill memo only; backend never resolves it
     "system_idle_watts":   "",         # optional operator baseline (mainboard/fans/PSU/disks); blank => "other" omitted, never a guessed wall figure
+    # ── Integrations / experiment-tracking API (push/pull) ────────────────────
+    "api_key":             "",         # Bearer/X-API-Key for run ingest; empty => not generated (ingest fail-closed)
+    "mlflow_uri":          "",         # MLflow tracking server base (blank = off)
+    "mlflow_token":        "",         # optional bearer for a secured MLflow
 }
-SETTING_SECRETS = {"discord_webhook_url", "telegram_token"}   # never round-tripped to the UI in full
+SETTING_SECRETS = {"discord_webhook_url", "telegram_token", "api_key", "mlflow_token"}   # never round-tripped to the UI in full
 
 def get_settings():
     """Return the full settings dict (defaults + persisted overrides)."""
@@ -3925,7 +3939,17 @@ def sample_once():
         if ts % 360 < INTERVAL:
             for t in ("samples", "proc", "models", "edges", "events", "gpu_samples", "net_samples", "power_proc"):
                 DB.execute(f"DELETE FROM {t} WHERE ts<?", (ts - RETENTION,))
+        if ts % 60 < INTERVAL:   # stale-run janitor: a crashed/disconnected push run -> killed
+            DB.execute("UPDATE runs SET status='killed', ended_at=COALESCE(ended_at,heartbeat_at,?) "
+                       "WHERE status='running' AND heartbeat_at IS NOT NULL AND heartbeat_at < ?",
+                       (ts, ts - 180))
         DB.commit()
+    # MLflow pull (network; outside the lock) every ~5 min when configured.
+    if get_settings().get("mlflow_uri") and ts % 300 < INTERVAL:
+        try:
+            sync_mlflow()
+        except Exception as e:
+            print("mlflow sync error:", e, flush=True)
     LATEST.update(ts=ts, util=util, mem_used=mem_used, mem_total=mem_total, power=power, temp=temp,
                   cpu_power=cpu_power, dram_power=dram_power, rapl=rapl.get("domains"),
                   gpu_avail=gpu_avail, gpus=gpus, gpu_extra=gpu_extra,
@@ -4384,6 +4408,334 @@ def api_sessions():
         "training": LATEST.get("training") or [],
         "devtools": LATEST.get("devtools") or [],
     })
+
+# ── Integrations: experiment/run tracking API (push/pull) + MLflow sync ────────
+# Pivot from /proc auto-detection to a key-authenticated ingest API a notebook can
+# push to (Jupyter/Colab/Kaggle via homelab_run.py), pulled back with the run's real
+# GPU energy/cost attached by overlapping its [start,end] window with `samples`.
+MAX_RUN_FIELD, MAX_RUN_JSON, MAX_METRICS_REQ = 4096, 64 * 1024, 1000
+RUN_SOURCES = {"jupyter", "colab", "kaggle", "mlflow", "api", "cli"}
+RUN_STATUS  = {"running", "finished", "failed", "killed"}
+
+def _get_api_key():
+    return get_settings().get("api_key") or ""
+
+def _gen_api_key():
+    key = "hlm_" + secrets.token_urlsafe(32)
+    save_settings({"api_key": key})
+    return key
+
+def _key_ok(presented):
+    real = _get_api_key()
+    if not real or not presented:
+        return False                       # fail-closed: no key set => ingest disabled
+    return hmac.compare_digest(presented, real)
+
+def _presented_key():
+    auth = request.headers.get("Authorization", "")
+    if auth[:7].lower() == "bearer ":
+        return auth[7:].strip()
+    return request.headers.get("X-API-Key", "").strip()
+
+def require_api_key(fn):
+    @wraps(fn)
+    def wrapper(*a, **kw):
+        if not _key_ok(_presented_key()):
+            return jsonify({"ok": False, "error": "missing or invalid API key"}), 401
+        return fn(*a, **kw)
+    return wrapper
+
+def _clip(v, n):
+    return ("" if v is None else str(v))[:n]
+
+def _json_field(v, n):
+    if v is None:
+        return None
+    txt = v if isinstance(v, str) else json.dumps(v, separators=(",", ":"))
+    if len(txt.encode("utf-8")) > n:
+        raise ValueError("payload too large")
+    return txt
+
+def _safe_json(txt):
+    try:
+        return json.loads(txt) if txt else None
+    except Exception:
+        return None
+
+def _run_cost_window(cur, started, ended, ctx):
+    """Integrate samples.power over [started, ended] -> (energy_kwh, cost, avg_w,
+    peak_util), priced exactly like the cost card (dual-tariff aware)."""
+    end = ended or int(time.time())
+    kwh_per = INTERVAL / 3_600_000.0
+    e_kwh = cost = sum_p = 0.0
+    n = 0
+    peak_u = 0.0
+    for ts, util, power in cur.execute(
+            "SELECT ts,util,power FROM samples WHERE ts>=? AND ts<=? AND power IS NOT NULL",
+            (started, end)):
+        p = power or 0.0
+        sum_p += p; n += 1; peak_u = max(peak_u, util or 0)
+        e_kwh += p * kwh_per
+        cost += p * kwh_per * (_price_at(ctx, ts) or 0.0)
+    return round(e_kwh, 4), round(cost, 4), (round(sum_p / n) if n else 0), round(peak_u)
+
+@app.route("/api/integration/key", methods=["GET", "POST"])
+def api_integration_key():
+    """GET -> {has_key, key_masked}. POST {regenerate:true} -> {key} (revealed once)."""
+    if request.method == "POST":
+        if (request.get_json(silent=True) or {}).get("regenerate"):
+            return jsonify({"ok": True, "key": _gen_api_key()})
+        return jsonify({"ok": False, "error": "nothing to do"}), 400
+    k = _get_api_key()
+    return jsonify({"has_key": bool(k), "key_masked": (k[:8] + "…" + k[-4:]) if k else ""})
+
+@app.route("/api/runs", methods=["POST"])
+@require_api_key
+def api_runs_create():
+    body = request.get_json(silent=True) or {}
+    source = (body.get("source") or "api").lower()
+    if source not in RUN_SOURCES:
+        source = "api"
+    now = int(time.time())
+    rid = (body.get("id") or uuid.uuid4().hex)[:64]
+    try:
+        params = _json_field(body.get("params"), MAX_RUN_JSON)
+        tags = _json_field(body.get("tags"), MAX_RUN_JSON)
+    except ValueError as e:
+        return jsonify({"ok": False, "error": str(e)}), 413
+    with LOCK:
+        DB.execute("INSERT INTO runs(id,name,source,status,started_at,ended_at,host,params,tags,notes,"
+                   "heartbeat_at,ext_id,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) "
+                   "ON CONFLICT(id) DO NOTHING",
+                   (rid, _clip(body.get("name") or "run", MAX_RUN_FIELD), source, "running",
+                    int(body.get("started_at") or now), None, _clip(body.get("host"), 256),
+                    params, tags, _clip(body.get("notes"), MAX_RUN_FIELD), now, None, now))
+        DB.commit()
+    return jsonify({"ok": True, "id": rid})
+
+@app.route("/api/runs/<rid>", methods=["PATCH"])
+@require_api_key
+def api_runs_update(rid):
+    body = request.get_json(silent=True) or {}
+    sets, args = ["heartbeat_at=?"], [int(time.time())]
+    if body.get("status") in RUN_STATUS:
+        sets.append("status=?"); args.append(body["status"])
+    if body.get("ended_at"):
+        sets.append("ended_at=?"); args.append(int(body["ended_at"]))
+    for f, n in (("name", MAX_RUN_FIELD), ("notes", MAX_RUN_FIELD)):
+        if f in body:
+            sets.append(f"{f}=?"); args.append(_clip(body[f], n))
+    try:
+        for f in ("params", "tags"):
+            if f in body:
+                sets.append(f"{f}=?"); args.append(_json_field(body[f], MAX_RUN_JSON))
+    except ValueError as e:
+        return jsonify({"ok": False, "error": str(e)}), 413
+    args.append(rid)
+    with LOCK:
+        cur = DB.execute(f"UPDATE runs SET {','.join(sets)} WHERE id=?", args)
+        DB.commit()
+    return (jsonify({"ok": True}) if cur.rowcount else (jsonify({"ok": False, "error": "unknown run"}), 404))
+
+@app.route("/api/runs/<rid>/metrics", methods=["POST"])
+@require_api_key
+def api_runs_metrics(rid):
+    body = request.get_json(silent=True) or {}
+    pts = body.get("metrics")
+    if pts is None and "key" in body:
+        pts = [body]
+    pts = pts or []
+    if len(pts) > MAX_METRICS_REQ:
+        return jsonify({"ok": False, "error": f"max {MAX_METRICS_REQ} points/request"}), 413
+    now = int(time.time())
+    rows = []
+    for p in pts:
+        try:
+            rows.append((rid, int(p.get("ts") or now), int(p.get("step") or 0),
+                         _clip(p["key"], 128), float(p["value"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    with LOCK:
+        if not DB.execute("SELECT 1 FROM runs WHERE id=?", (rid,)).fetchone():
+            return jsonify({"ok": False, "error": "unknown run"}), 404
+        if rows:
+            DB.executemany("INSERT INTO run_metrics(run_id,ts,step,key,value) VALUES(?,?,?,?,?)", rows)
+            DB.execute("UPDATE runs SET heartbeat_at=? WHERE id=?", (now, rid))
+            DB.commit()
+    return jsonify({"ok": True, "logged": len(rows)})
+
+@app.route("/api/runs/<rid>/finish", methods=["POST"])
+@require_api_key
+def api_runs_finish(rid):
+    body = request.get_json(silent=True) or {}
+    status = body.get("status") if body.get("status") in RUN_STATUS else "finished"
+    if status == "running":
+        status = "finished"
+    ended = int(body.get("ended_at") or time.time())
+    with LOCK:
+        cur = DB.execute("UPDATE runs SET status=?, ended_at=?, heartbeat_at=? WHERE id=?",
+                         (status, ended, ended, rid))
+        DB.commit()
+    return (jsonify({"ok": True, "id": rid, "status": status}) if cur.rowcount
+            else (jsonify({"ok": False, "error": "unknown run"}), 404))
+
+@app.route("/api/runs")
+def api_runs_list():
+    ctx = _cost_ctx()
+    rng = request.args.get("range", "7d"); span = RANGES.get(rng, 604800)
+    status = request.args.get("status")
+    now = int(time.time()); since = 0 if span is None else now - span
+    q = ("SELECT id,name,source,status,started_at,ended_at,host,params,tags,notes "
+         "FROM runs WHERE (ended_at IS NULL OR ended_at>=?) AND started_at<=? ")
+    args = [since, now]
+    if status in RUN_STATUS:
+        q += "AND status=? "; args.append(status)
+    q += "ORDER BY started_at DESC LIMIT 500"
+    out = []
+    with LOCK:
+        cur = DB.cursor()
+        for (rid, name, source, st, started, ended, host, params, tags, notes) in cur.execute(q, args).fetchall():
+            e_kwh, cost, avg_w, peak_u = _run_cost_window(cur, started, ended, ctx)
+            kv = {}
+            # latest value per key = the last-logged row (max rowid), robust even when
+            # several points share a timestamp.
+            for k, v in cur.execute(
+                    "SELECT key, value FROM run_metrics WHERE run_id=? AND rowid IN "
+                    "(SELECT MAX(rowid) FROM run_metrics WHERE run_id=? GROUP BY key)", (rid, rid)):
+                kv[k] = v
+            out.append({"id": rid, "name": name, "source": source, "status": st,
+                        "started_at": started, "ended_at": ended, "duration": (ended or now) - started,
+                        "host": host, "params": _safe_json(params), "tags": _safe_json(tags), "notes": notes,
+                        "metrics_latest": kv, "energy_kwh": e_kwh, "cost": cost, "avg_w": avg_w, "peak_util": peak_u})
+    return jsonify({"range": rng, "currency": ctx["currency"], "tariff_mode": ctx["mode"], "runs": out})
+
+@app.route("/api/runs/<rid>")
+def api_runs_get(rid):
+    ctx = _cost_ctx()
+    now = int(time.time())
+    with LOCK:
+        cur = DB.cursor()
+        r = cur.execute("SELECT id,name,source,status,started_at,ended_at,host,params,tags,notes "
+                        "FROM runs WHERE id=?", (rid,)).fetchone()
+        if not r:
+            return jsonify({"error": "unknown run"}), 404
+        (rid, name, source, st, started, ended, host, params, tags, notes) = r
+        end = ended or now
+        metrics = {}
+        for k, ts, step, v in cur.execute(
+                "SELECT key,ts,step,value FROM run_metrics WHERE run_id=? ORDER BY key,ts,step", (rid,)):
+            d = metrics.setdefault(k, {"steps": [], "ts": [], "values": []})
+            d["steps"].append(step); d["ts"].append(ts); d["values"].append(v)
+        bk = max(INTERVAL, round(max(1, end - started) / MAX_POINTS))
+        labels, power_w, util_pct = [], [], []
+        for b, ap, au in cur.execute("SELECT (ts/?)*? b, AVG(power), AVG(util) FROM samples "
+                                     "WHERE ts>=? AND ts<=? GROUP BY b ORDER BY b", (bk, bk, started, end)):
+            labels.append(int(b)); power_w.append(round(ap or 0)); util_pct.append(round(au or 0))
+        e_kwh, cost, avg_w, peak_u = _run_cost_window(cur, started, end, ctx)
+    return jsonify({"id": rid, "name": name, "source": source, "status": st,
+                    "started_at": started, "ended_at": ended, "duration": end - started, "host": host,
+                    "params": _safe_json(params), "tags": _safe_json(tags), "notes": notes, "metrics": metrics,
+                    "resource": {"labels": labels, "power_w": power_w, "util_pct": util_pct, "bucket_sec": bk},
+                    "energy_kwh": e_kwh, "cost": cost, "avg_w": avg_w, "peak_util": peak_u,
+                    "currency": ctx["currency"], "tariff_mode": ctx["mode"]})
+
+# ── MLflow sync (pull) — mirror MLflow runs in as source='mlflow', pure REST ───
+_MLF_STATUS = {"RUNNING": "running", "FINISHED": "finished", "FAILED": "failed",
+               "KILLED": "killed", "SCHEDULED": "running"}
+
+def _mlf(method, path, payload=None, params=None, timeout=15):
+    base = (get_settings().get("mlflow_uri") or "").rstrip("/")
+    if not base:
+        return None
+    url = base + path + ("?" + urllib.parse.urlencode(params) if params else "")
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    hdr = {"Content-Type": "application/json"}
+    tok = get_settings().get("mlflow_token")
+    if tok:
+        hdr["Authorization"] = "Bearer " + tok
+    req = urllib.request.Request(url, data=data, headers=hdr, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        body = r.read()
+        return json.loads(body) if body else {}
+
+def _ms_to_s(v):
+    return int(v) // 1000 if v else None
+
+def sync_mlflow():
+    """Pull experiments/runs/metrics from the configured MLflow server into
+    runs/run_metrics as source='mlflow'. Idempotent via uniq(source,ext_id)."""
+    if not (get_settings().get("mlflow_uri") or "").strip():
+        return 0
+    exp_ids, tok = [], None
+    while True:
+        body = _mlf("POST", "/api/2.0/mlflow/experiments/search",
+                    {"max_results": 1000, **({"page_token": tok} if tok else {})}) or {}
+        exp_ids += [e["experiment_id"] for e in body.get("experiments", [])]
+        tok = body.get("next_page_token")
+        if not tok:
+            break
+    if not exp_ids:
+        return 0
+    now, synced, tok = int(time.time()), 0, None
+    while True:
+        body = _mlf("POST", "/api/2.0/mlflow/runs/search",
+                    {"experiment_ids": exp_ids, "max_results": 1000,
+                     **({"page_token": tok} if tok else {})}) or {}
+        for run in body.get("runs", []):
+            info, data = run.get("info", {}), run.get("data", {})
+            ext = info.get("run_id") or info.get("run_uuid")
+            if not ext:
+                continue
+            tagd = {t["key"]: t["value"] for t in data.get("tags", [])}
+            name = info.get("run_name") or tagd.get("mlflow.runName") or ext[:8]
+            started = _ms_to_s(info.get("start_time")) or now
+            ended = _ms_to_s(info.get("end_time"))
+            status = _MLF_STATUS.get(info.get("status"), "running")
+            params = {p["key"]: p["value"] for p in data.get("params", [])}
+            tags = {k: v for k, v in tagd.items() if not k.startswith("mlflow.")}
+            with LOCK:
+                row = DB.execute("SELECT id FROM runs WHERE source='mlflow' AND ext_id=?", (ext,)).fetchone()
+                rid = row[0] if row else uuid.uuid4().hex
+                DB.execute("INSERT INTO runs(id,name,source,status,started_at,ended_at,host,params,tags,"
+                           "notes,heartbeat_at,ext_id,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) "
+                           "ON CONFLICT(source,ext_id) DO UPDATE SET status=excluded.status, "
+                           "ended_at=excluded.ended_at, name=excluded.name, params=excluded.params, "
+                           "tags=excluded.tags, heartbeat_at=excluded.heartbeat_at",
+                           (rid, name, "mlflow", status, started, ended, "mlflow",
+                            json.dumps(params, separators=(",", ":")),
+                            json.dumps(tags, separators=(",", ":")), "", now, ext, now))
+                DB.execute("DELETE FROM run_metrics WHERE run_id=?", (rid,))
+                DB.commit()
+            for m in data.get("metrics", []):
+                hist = _mlf("GET", "/api/2.0/mlflow/metrics/get-history",
+                            params={"run_id": ext, "metric_key": m["key"]}) or {}
+                rows = [(rid, _ms_to_s(h.get("timestamp")) or started, int(h.get("step") or 0),
+                         m["key"], float(h["value"])) for h in hist.get("metrics", [])]
+                if rows:
+                    with LOCK:
+                        DB.executemany("INSERT INTO run_metrics(run_id,ts,step,key,value) VALUES(?,?,?,?,?)", rows)
+                        DB.commit()
+            synced += 1
+        tok = body.get("next_page_token")
+        if not tok:
+            break
+    return synced
+
+@app.route("/api/integration/mlflow/sync", methods=["GET", "POST"])
+def api_mlflow_sync():
+    """GET -> reachability probe (green/red). POST -> sync now."""
+    if not (get_settings().get("mlflow_uri") or "").strip():
+        return jsonify({"ok": False, "error": "no MLflow URI configured"}), 400
+    if request.method == "POST":
+        try:
+            return jsonify({"ok": True, "synced": sync_mlflow()})
+        except Exception as e:
+            return jsonify({"ok": False, "error": str(e)[:200]}), 502
+    try:
+        _mlf("POST", "/api/2.0/mlflow/experiments/search", {"max_results": 1})
+        return jsonify({"ok": True, "reachable": True})
+    except Exception as e:
+        return jsonify({"ok": False, "reachable": False, "error": str(e)[:200]}), 502
 
 # ── Container logs over SSE (issue #28) ───────────────────────────────────────
 _CT_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -746,10 +746,33 @@ a{color:var(--info)}
   <p class="cap">One panel per model <b>server</b>: its VRAM timeline (shared by the models it hosts) plus each model's own peak &amp; average. A server is shown even while <b>Idle</b> (model unloaded / between requests), so nothing vanishes when VRAM is released. Recognised: Ollama, vLLM, SGLang, llama.cpp, LocalAI, HF TGI/TEI, LoRAX, mistral.rs, Aphrodite, koboldcpp, tabbyAPI, text-generation-webui, LM Studio, xinference, OpenLLM, LiteLLM, GPUStack, Cortex/Jan, Ramalama, Nexa, Triton, Infinity, faster-whisper/Speaches, Whisper ASR webservice/WhisperX, Wyoming (HA voice), OpenedAI-Speech, Stable Diffusion (A1111/Forge/SD.Next), InvokeAI, ComfyUI.</p>
 </section>
 
-<!-- ───────── Experiments / Training ───────── -->
+<!-- ───────── Experiments / Runs ───────── -->
 <section data-tab="experiments" hidden>
+  <div class="card" id="runs-card">
+    <h2 style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">🧪 Runs
+      <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— pushed from your notebooks &amp; MLflow, priced with real GPU energy</span>
+      <select id="runs-status" style="margin-left:auto;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:4px 8px;font:inherit;font-size:12px">
+        <option value="">all status</option><option value="running">running</option>
+        <option value="finished">finished</option><option value="failed">failed</option><option value="killed">killed</option>
+      </select></h2>
+    <div id="runs-empty" class="topproc-empty" hidden>
+      No runs yet. Push one from Jupyter/Colab/Kaggle with the tiny client, or wire up MLflow — set it up in
+      <a href="#" id="runs-settings-link">Settings → Integrations</a>.
+    </div>
+    <table id="runs-table" style="margin-top:6px"><thead><tr>
+      <th>Run</th><th>Source</th><th>Status</th><th>Started</th><th>Duration</th><th>Metrics</th><th>Energy</th><th>Cost</th>
+    </tr></thead><tbody id="runs-tbody"></tbody></table>
+  </div>
+  <div class="card" id="run-detail" hidden>
+    <h2 id="run-detail-title">Run</h2>
+    <div id="run-detail-meta" class="cap"></div>
+    <div id="run-metric-charts"></div>
+    <h2 style="margin-top:6px;font-size:13px">⚡ GPU power &amp; utilisation during this run</h2>
+    <div class="chartbox short"><canvas id="run-resource"></canvas></div>
+    <p class="cap" id="run-cost-cap"></p>
+  </div>
   <div class="card" id="train-card">
-    <h2>🔬 Training runs <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— detected on the hub right now</span></h2>
+    <h2>🔬 Auto-detected on the hub <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— training processes running now (no push needed)</span></h2>
     <div id="train-body"></div>
   </div>
   <div class="card" id="devtools-card" hidden>
@@ -796,6 +819,7 @@ a{color:var(--info)}
     <div class="subtabs" id="set-subtabs">
       <button type="button" class="subtab on" data-sp="alerts">🔔 Alerts</button>
       <button type="button" class="subtab"    data-sp="costs">💰 Costs</button>
+      <button type="button" class="subtab"    data-sp="integrations">🧪 Integrations</button>
     </div>
 
     <!-- ── Alerts sub-page ── -->
@@ -944,6 +968,54 @@ a{color:var(--info)}
       </div>
       </div>
     </div><!-- /set-pane-costs -->
+
+    <!-- ── Integrations sub-page ── -->
+    <div id="set-pane-integrations" hidden>
+      <p class="cap" style="margin:2px 0 12px">Push run/session data from Jupyter, Colab or Kaggle (or mirror MLflow) — each run comes back priced with the real GPU energy it used. Writes need the API key; the dashboard reads are open on your LAN.</p>
+
+      <div class="card-sub" style="font-weight:600">🔑 API key</div>
+      <div id="intg_key_state" class="cap" style="margin:4px 0">…</div>
+      <div id="intg_key_reveal" hidden style="margin:6px 0">
+        <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Your new key — copy it now, it won't be shown again</div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap">
+          <input type="text" id="intg_key_value" readonly style="flex:1;min-width:240px;background:#0d1117;color:var(--tx);border:1px solid var(--ok);border-radius:7px;padding:7px 10px;font:inherit">
+          <button class="rb" id="intg_key_copy">Copy</button>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
+        <button class="rb" id="intg_key_gen">Generate / regenerate key</button>
+        <a class="rb" id="intg_client_dl" href="/static/homelab_run.py" download>Download client (homelab_run.py)</a>
+      </div>
+      <div class="cap" style="margin-top:8px">Quickstart in a notebook:</div>
+      <pre class="cmd" id="intg_snippet" style="white-space:pre-wrap">import homelab_run as homelab
+homelab.configure(url="http://THIS-HOST:9800", key="hlm_…")
+with homelab.run("my-finetune", params={"lr":2e-4}) as r:
+    for step, loss in enumerate(train()):
+        r.log_metric("loss", loss, step=step)</pre>
+      <div class="cap">Colab/Kaggle run in the cloud — point <code>url</code> at a Tailscale/ngrok address that reaches this hub.</div>
+
+      <div class="card-sub" style="font-weight:600;margin-top:16px">🟢 MLflow (pull)</div>
+      <div class="cap" style="margin:4px 0">Mirror runs from an MLflow tracking server — they appear under Runs with GPU cost attached. Synced every ~5 min.</div>
+      <div style="display:grid;grid-template-columns:1fr;gap:14px;max-width:680px">
+        <div>
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow tracking URI</div>
+          <input type="text" id="al_mlflow_uri" placeholder="http://mlflow.lan:5000"
+                 style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+        </div>
+        <div>
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow bearer token (optional)</div>
+          <input type="text" id="al_mlflow_token" placeholder="only for a secured MLflow" autocomplete="off"
+                 style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+          <div class="cap" id="al_mlflow_token_state" style="margin-top:4px"></div>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+        <button class="rb on" id="al_save_intg">Save</button>
+        <button class="rb" id="intg_mlflow_test">Test connection</button>
+        <button class="rb" id="intg_mlflow_sync">Sync now</button>
+      </div>
+      <div id="intg_status" class="cap" style="margin-top:6px"></div>
+    </div><!-- /set-pane-integrations -->
   </div>
 </section>
 
@@ -2139,6 +2211,9 @@ async function loadAlerts(){
   document.getElementById('al_night_start').value = s.night_start||'22:00';
   document.getElementById('al_night_end').value   = s.night_end||'06:00';
   const idleW=document.getElementById('al_idle_w'); if(idleW) idleW.value = s.system_idle_watts||'';
+  const mu=document.getElementById('al_mlflow_uri'); if(mu) mu.value = s.mlflow_uri||'';
+  const mts=document.getElementById('al_mlflow_token_state');
+  if(mts) mts.textContent = s.mlflow_token_set ? 'A token is saved. Leave blank to keep it; type a new one to replace; type CLEAR and save to remove.' : 'No token saved.';
   buildCountrySelect().then(()=>{ document.getElementById('al_country').value = s.country||''; });
   setTariffMode(s.tariff_mode==='dual');
   // The webhook is a secret — server only returns whether one is set.
@@ -2178,6 +2253,7 @@ async function saveAlerts(){
     night_start:      document.getElementById('al_night_start').value || '22:00',
     night_end:        document.getElementById('al_night_end').value   || '06:00',
     system_idle_watts: (document.getElementById('al_idle_w')||{}).value || '',
+    mlflow_uri:        (document.getElementById('al_mlflow_uri')||{}).value || '',
     country:          document.getElementById('al_country').value,
   };
   // Only send the webhook field if the user actually typed in it — empty means
@@ -2189,10 +2265,14 @@ async function saveAlerts(){
   const tv = document.getElementById('al_telegram_token').value;
   if(tv === 'CLEAR'){ body.telegram_token=''; }
   else if(tv && tv.trim()){ body.telegram_token = tv.trim(); }
+  const mtv = (document.getElementById('al_mlflow_token')||{}).value;
+  if(mtv === 'CLEAR'){ body.mlflow_token=''; }
+  else if(mtv && mtv.trim()){ body.mlflow_token = mtv.trim(); }
   let j; try{ j=await(await fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},
     body:JSON.stringify(body)})).json(); }catch(e){ showAlertStatus('critical','Could not save settings: '+e); return; }
   document.getElementById('al_discord').value='';
   document.getElementById('al_telegram_token').value='';
+  const mtok=document.getElementById('al_mlflow_token'); if(mtok) mtok.value='';
   await loadAlerts();
   showAlertStatus('ok','Settings saved.');
 }
@@ -2774,13 +2854,70 @@ function paintAiBand(g,x,loaded,serving){
     : 'No GPU detected on the hub — showing model servers only.';
 }
 
+// ── Runs (pushed from notebooks / MLflow) — the primary Experiments view ──────
+const RUN_SRC={jupyter:'🟣',colab:'🟠',kaggle:'🔵',mlflow:'🟢',api:'⚪',cli:'⚫'};
+const RUN_ST={running:'▶️',finished:'✅',failed:'⚠️',killed:'⛔'};
+async function renderRuns(){
+  const card=document.getElementById('runs-card'); if(!card) return;
+  const status=(document.getElementById('runs-status')||{}).value||'';
+  let j; try{ j=await(await fetch('/api/runs?range='+encodeURIComponent(R)+(status?'&status='+status:''))).json(); }catch(e){ return; }
+  const cur=j.currency||'$', runs=j.runs||[];
+  const empty=document.getElementById('runs-empty'), tbl=document.getElementById('runs-table'), tb=document.getElementById('runs-tbody');
+  if(!runs.length){ empty.hidden=false; if(tbl) tbl.style.display='none';
+    const lk=document.getElementById('runs-settings-link'); if(lk) lk.onclick=e=>{e.preventDefault();showTab('alerts');if(typeof setSettingsPane==='function')setSettingsPane('integrations');};
+    return; }
+  empty.hidden=true; if(tbl) tbl.style.display='';
+  const fmtTs=ts=>new Date(ts*1000).toLocaleString([], {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+  tb.innerHTML=runs.map(r=>{
+    const mets=Object.entries(r.metrics_latest||{}).slice(0,3).map(([k,v])=>`${esc(k)} ${(+v).toFixed(3)}`).join(' · ');
+    return `<tr data-id="${esc(r.id)}" style="cursor:pointer">
+      <td><b>${esc(r.name)}</b></td>
+      <td><span class="mchip">${RUN_SRC[r.source]||'•'} ${esc(r.source)}</span></td>
+      <td>${RUN_ST[r.status]||''} ${esc(r.status)}</td>
+      <td>${fmtTs(r.started_at)}</td><td>${fmtDur(r.duration)}</td>
+      <td class="muted">${mets||'—'}</td>
+      <td>${(r.energy_kwh||0).toFixed(3)} kWh</td>
+      <td>${cur}${(r.cost||0).toFixed(2)}</td></tr>`;
+  }).join('');
+  tb.querySelectorAll('tr').forEach(tr=>tr.onclick=()=>openRun(tr.dataset.id));
+}
+async function openRun(id){
+  let j; try{ j=await(await fetch('/api/runs/'+encodeURIComponent(id))).json(); }catch(e){ return; }
+  if(!j || j.error) return;
+  const cur=j.currency||'$';
+  document.getElementById('run-detail').hidden=false;
+  document.getElementById('run-detail-title').textContent=j.name;
+  const params=j.params?(' · params '+esc(JSON.stringify(j.params))):'';
+  document.getElementById('run-detail-meta').innerHTML=`${RUN_SRC[j.source]||''} ${esc(j.source)} · ${esc(j.status)} · ${esc(j.host||'')} · ${fmtDur(j.duration)}${params}`;
+  const host=document.getElementById('run-metric-charts'); host.innerHTML='';
+  const keys=Object.keys(j.metrics||{});
+  keys.forEach((k,i)=>{
+    const id2='runmetric'+i, m=j.metrics[k];
+    host.insertAdjacentHTML('beforeend',`<div style="margin-top:8px"><div class="cap" style="margin-bottom:2px">${esc(k)}</div><div class="chartbox short"><canvas id="${id2}"></canvas></div></div>`);
+    mk(id2,{type:'line',data:{labels:m.steps,datasets:[{label:k,data:m.values,borderColor:colorFor(k),backgroundColor:colorFor(k)+'22',fill:true,pointRadius:0,tension:.2}]},
+      options:{responsive:true,maintainAspectRatio:false,scales:{x:{ticks:{color:cv('--mut'),maxTicksLimit:8}},y:{ticks:{color:cv('--mut')}}},plugins:{legend:{display:false}}}});
+  });
+  if(!keys.length) host.innerHTML='<div class="muted" style="margin-top:6px">No metrics logged for this run.</div>';
+  const res=j.resource||{labels:[],power_w:[],util_pct:[]}, labels=fmtLabels(res.labels||[]);
+  mk('run-resource',{type:'line',data:{labels,datasets:[
+    {label:'Power (W)',data:res.power_w,borderColor:'#3fb950',backgroundColor:'#3fb95022',fill:true,pointRadius:0,yAxisID:'y',tension:.2},
+    {label:'Util (%)',data:res.util_pct,borderColor:'#4dabf7',pointRadius:0,yAxisID:'y1',tension:.2}]},
+    options:{responsive:true,maintainAspectRatio:false,interaction:{mode:'index',intersect:false},
+      scales:{x:{grid:{color:cv('--free')},ticks:{color:cv('--mut'),maxTicksLimit:10}},
+        y:{position:'left',min:0,grid:{color:cv('--free')},ticks:{color:cv('--mut'),callback:v=>v+' W'}},
+        y1:{position:'right',min:0,max:100,grid:{display:false},ticks:{color:cv('--mut'),callback:v=>v+'%'}}},
+      plugins:{legend:{labels:{color:cv('--tx'),boxWidth:12}}}}});
+  document.getElementById('run-cost-cap').textContent=`This run used ${(j.energy_kwh||0).toFixed(3)} kWh and cost ${cur}${(j.cost||0).toFixed(2)} in GPU energy over its window · peak util ${j.peak_util}% · avg ${j.avg_w} W.`;
+  document.getElementById('run-detail').scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+
 // ── Experiments / Training tab ───────────────────────────────────────────────
-// Live training-run cards (auto-detected from /proc on the hub) + a table of GPU
-// activity sessions reconstructed from power/util history, with energy and cost.
+// Auto-detected training processes (no push) + GPU activity sessions, below Runs.
 let EXP_AT=0;
 async function renderExperiments(force){
   if(CURRENT_HOST!=='local'){ renderLocalOnlyNotice('experiments'); return; }
   clearLocalOnlyNotice('experiments');
+  renderRuns();                                     // pushed/MLflow runs (primary view)
   if(!force && Date.now()-EXP_AT < 15000) return;   // throttle the live refresh
   EXP_AT=Date.now();
   let j; try{ j=await(await fetch('/api/sessions?range='+encodeURIComponent(R))).json(); }catch(e){ return; }
@@ -3825,12 +3962,43 @@ if(al_save_costs) al_save_costs.onclick = saveAlerts;   // both panes persist al
 document.getElementById('al_mode_single').onclick = () => setTariffMode(false);
 document.getElementById('al_mode_dual').onclick   = () => setTariffMode(true);
 document.getElementById('al_country').onchange    = applyCountryPrefill;
-// Settings sub-tabs: Alerts / Costs (more added later, e.g. Integrations).
+// Settings sub-tabs: Alerts / Costs / Integrations.
 function setSettingsPane(name){
   document.querySelectorAll('#set-subtabs .subtab').forEach(b=>b.classList.toggle('on', b.dataset.sp===name));
   document.querySelectorAll('[id^="set-pane-"]').forEach(p=>p.hidden = p.id !== 'set-pane-'+name);
+  if(name==='integrations') loadIntegrations();
 }
 document.querySelectorAll('#set-subtabs .subtab').forEach(b=>b.onclick=()=>setSettingsPane(b.dataset.sp));
+
+// ── Integrations settings (API key + MLflow) ──────────────────────────────────
+async function loadIntegrations(){
+  let j; try{ j=await(await fetch('/api/integration/key')).json(); }catch(e){ return; }
+  const st=document.getElementById('intg_key_state');
+  if(st) st.innerHTML = j.has_key
+    ? 'A key is set: <code>'+esc(j.key_masked)+'</code>. Regenerating invalidates the old one.'
+    : 'No API key yet — generate one so notebooks can push runs (ingest is disabled until you do).';
+  const snip=document.getElementById('intg_snippet');
+  if(snip) snip.textContent = `import homelab_run as homelab\nhomelab.configure(url="http://${location.hostname}:9800", key="hlm_…")\nwith homelab.run("my-finetune", params={"lr":2e-4}) as r:\n    for step, loss in enumerate(train()):\n        r.log_metric("loss", loss, step=step)`;
+}
+function intgStatus(level,msg){ const el=document.getElementById('intg_status'); if(el){ el.textContent=msg; el.style.color = level==='ok'?'var(--ok)':level==='err'?'var(--crit)':'var(--mut)'; } }
+(function wireIntegrations(){
+  const gen=document.getElementById('intg_key_gen');
+  if(gen) gen.onclick=async()=>{ if(!confirm('Generate a new API key? Any client using the old key will stop working.')) return;
+    let j; try{ j=await(await fetch('/api/integration/key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({regenerate:true})})).json(); }catch(e){ intgStatus('err','Failed: '+e); return; }
+    if(j.key){ document.getElementById('intg_key_reveal').hidden=false; document.getElementById('intg_key_value').value=j.key; loadIntegrations(); intgStatus('ok','New key generated — copy it now.'); } };
+  const cp=document.getElementById('intg_key_copy');
+  if(cp) cp.onclick=()=>{ const v=document.getElementById('intg_key_value').value; copyText(v); intgStatus('ok','Key copied to clipboard.'); };
+  const si=document.getElementById('al_save_intg');
+  if(si) si.onclick=saveAlerts;
+  const tst=document.getElementById('intg_mlflow_test');
+  if(tst) tst.onclick=async()=>{ intgStatus('info','Testing MLflow…'); let j; try{ j=await(await fetch('/api/integration/mlflow/sync')).json(); }catch(e){ intgStatus('err','Failed: '+e); return; }
+    intgStatus(j.ok?'ok':'err', j.ok?'MLflow reachable ✓':'MLflow unreachable: '+(j.error||'')); };
+  const syn=document.getElementById('intg_mlflow_sync');
+  if(syn) syn.onclick=async()=>{ intgStatus('info','Syncing from MLflow…'); let j; try{ j=await(await fetch('/api/integration/mlflow/sync',{method:'POST'})).json(); }catch(e){ intgStatus('err','Failed: '+e); return; }
+    if(j.ok){ intgStatus('ok','Synced '+(j.synced||0)+' run(s) from MLflow.'); if(TAB==='experiments') renderRuns(); } else intgStatus('err','Sync failed: '+(j.error||'')); };
+  const rs=document.getElementById('runs-status');
+  if(rs) rs.onchange=()=>renderRuns();
+})();
 document.getElementById('bk_download').onclick = downloadBackup;
 document.getElementById('bk_restore_btn').onclick = () => document.getElementById('bk_file').click();
 document.getElementById('bk_file').onchange = e => { const f=e.target.files&&e.target.files[0]; if(f) restoreBackup(f); };

--- a/static/homelab_run.py
+++ b/static/homelab_run.py
@@ -1,0 +1,192 @@
+"""homelab_run.py — tiny client for HomeLab Monitor's run-tracking API.
+
+Push training/session metadata + metrics to your self-hosted HomeLab Monitor and
+pull it back, with real GPU energy/cost attached by the hub. Stdlib-only (urllib);
+uses `requests` automatically if it's installed. Copy this one file anywhere — or
+download it from your hub at  http://<hub>:9800/static/homelab_run.py
+
+Quickstart (Jupyter / Colab / Kaggle):
+
+    import homelab_run as homelab
+    homelab.configure(url="http://homelab.lan:9800", key="hlm_xxx")  # or env vars
+
+    with homelab.run("sft-llama3-lora", params={"lr": 2e-4, "bs": 8}) as r:
+        for step, loss in enumerate(train()):
+            r.log_metric("loss", loss, step=step)
+        r.log_params({"final_eval": 0.81})
+
+    # pull it back (e.g. from another notebook), with cost attached by the hub:
+    print(homelab.pull(r.id)["cost"], homelab.list_runs(range="7d"))
+
+Colab/Kaggle note: those run in the cloud, so the hub URL must be reachable from
+the internet — expose it via Tailscale (recommended) or an ngrok/Cloudflare tunnel
+and pass that https URL. On your LAN, plain http://host:9800 works.
+"""
+import os, sys, json, time, uuid, socket, threading, urllib.request, urllib.error
+
+try:
+    import requests as _rq           # optional; nicer, but never required
+except Exception:
+    _rq = None
+
+_CFG = {"url": os.environ.get("HOMELAB_URL", "http://localhost:9800"),
+        "key": os.environ.get("HOMELAB_KEY", ""), "timeout": 10}
+
+
+def configure(url=None, key=None, timeout=None):
+    if url is not None:     _CFG["url"] = url.rstrip("/")
+    if key is not None:     _CFG["key"] = key
+    if timeout is not None: _CFG["timeout"] = timeout
+
+
+def _headers():
+    h = {"Content-Type": "application/json"}
+    if _CFG["key"]:
+        h["Authorization"] = "Bearer " + _CFG["key"]
+        h["X-API-Key"] = _CFG["key"]
+    return h
+
+
+def _request(method, path, payload=None):
+    url = _CFG["url"].rstrip("/") + path
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    if _rq is not None:
+        resp = _rq.request(method, url, data=data, headers=_headers(), timeout=_CFG["timeout"])
+        if resp.status_code >= 400:
+            raise RuntimeError(f"{method} {path} -> {resp.status_code}: {resp.text[:200]}")
+        return resp.json() if resp.content else {}
+    req = urllib.request.Request(url, data=data, headers=_headers(), method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=_CFG["timeout"]) as r:
+            body = r.read()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"{method} {path} -> {e.code}: {e.read()[:200].decode('utf-8', 'replace')}")
+
+
+def _detect_source():
+    if "google.colab" in sys.modules:            return "colab"
+    if os.environ.get("KAGGLE_KERNEL_RUN_TYPE"): return "kaggle"
+    try:
+        import IPython
+        if IPython.get_ipython() is not None:    return "jupyter"
+    except Exception:
+        pass
+    return "cli"
+
+
+class Run:
+    """One tracked run. Use via homelab.run(...) (context manager) or manually:
+        r = homelab.run("name").start(); r.log_metric(...); r.finish()
+    """
+    def __init__(self, name, params=None, tags=None, notes=None, source=None,
+                 heartbeat=30, buffer=True):
+        self.id = uuid.uuid4().hex
+        self.name = name
+        self.params = dict(params or {})
+        self.tags = tags or []
+        self.notes = notes or ""
+        self.source = source or _detect_source()
+        self.host = socket.gethostname()
+        self._hb_interval = heartbeat
+        self._buffer = buffer
+        self._buf = []
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._started = False
+
+    def start(self):
+        _request("POST", "/api/runs", {
+            "id": self.id, "name": self.name, "source": self.source, "host": self.host,
+            "params": self.params, "tags": self.tags, "notes": self.notes,
+            "started_at": int(time.time())})
+        self._started = True
+        if self._hb_interval:
+            threading.Thread(target=self._heartbeat_loop, daemon=True).start()
+        return self
+
+    def _heartbeat_loop(self):
+        while not self._stop.wait(self._hb_interval):
+            try:
+                self.flush()
+                _request("PATCH", f"/api/runs/{self.id}", {"status": "running"})
+            except Exception:
+                pass                          # never let telemetry crash training
+
+    def log_metric(self, key, value, step=None, ts=None):
+        pt = {"key": key, "value": float(value),
+              "step": int(step) if step is not None else 0,
+              "ts": int(ts) if ts is not None else int(time.time())}
+        if self._buffer:
+            with self._lock:
+                self._buf.append(pt)
+                flush = len(self._buf) >= 100
+            if flush:
+                self.flush()
+        else:
+            _request("POST", f"/api/runs/{self.id}/metrics", {"metrics": [pt]})
+        return self
+
+    def log_metrics(self, d, step=None, ts=None):
+        for k, v in (d or {}).items():
+            self.log_metric(k, v, step=step, ts=ts)
+        return self
+
+    def flush(self):
+        with self._lock:
+            pts, self._buf = self._buf, []
+        if pts:
+            _request("POST", f"/api/runs/{self.id}/metrics", {"metrics": pts})
+        return self
+
+    def log_params(self, d):
+        self.params.update(d or {})
+        _request("PATCH", f"/api/runs/{self.id}", {"params": self.params})
+        return self
+
+    def set_notes(self, text):
+        self.notes = text
+        _request("PATCH", f"/api/runs/{self.id}", {"notes": text})
+        return self
+
+    def _terminate(self, status):
+        self._stop.set()
+        try:
+            self.flush()
+        except Exception:
+            pass
+        _request("POST", f"/api/runs/{self.id}/finish",
+                 {"status": status, "ended_at": int(time.time())})
+
+    def finish(self):
+        self._terminate("finished"); return self
+
+    def fail(self):
+        self._terminate("failed"); return self
+
+    def pull(self):
+        return pull(self.id)
+
+    def __enter__(self):
+        if not self._started:
+            self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._terminate("failed" if exc_type else "finished")
+        return False                          # don't suppress exceptions
+
+
+def run(name, **kw):
+    """Create a Run. `with homelab.run('x') as r: ...` starts/finishes it for you."""
+    return Run(name, **kw)
+
+
+def pull(run_id):
+    """Full run + metrics + GPU power/util/cost series (dict)."""
+    return _request("GET", f"/api/runs/{run_id}")
+
+
+def list_runs(range="7d", status=None):
+    path = f"/api/runs?range={range}" + (f"&status={status}" if status else "")
+    return _request("GET", path)["runs"]

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,118 @@
+"""Unit tests for the experiment-tracking integration API: key auth, run ingest/
+query, GPU-cost attachment over the run window, and MLflow sync."""
+import os
+import sys
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestRunsApi(unittest.TestCase):
+    def setUp(self):
+        self.c = app.app.test_client()
+        with app.LOCK:
+            app.DB.execute("DELETE FROM runs")
+            app.DB.execute("DELETE FROM run_metrics")
+            app.DB.commit()
+        app.save_settings({"api_key": "", "kwh_price": "0.30", "currency": "$", "tariff_mode": "single"})
+
+    def tearDown(self):
+        app.save_settings({"api_key": "", "mlflow_uri": ""})
+
+    def test_ingest_fail_closed_without_key(self):
+        r = self.c.post("/api/runs", json={"name": "x"})
+        self.assertEqual(r.status_code, 401)              # no key generated => writes rejected
+
+    def test_bad_key_rejected(self):
+        app._gen_api_key()
+        r = self.c.post("/api/runs", json={"name": "x"}, headers={"Authorization": "Bearer wrong"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_full_push_pull_flow(self):
+        key = app._gen_api_key()
+        h = {"Authorization": "Bearer " + key}
+        now = int(time.time())
+        r = self.c.post("/api/runs", json={"id": "run1", "name": "sft", "source": "jupyter",
+                                           "started_at": now - 50, "params": {"lr": 2e-4}}, headers=h)
+        self.assertEqual(r.get_json()["id"], "run1")
+        self.c.post("/api/runs/run1/metrics",
+                    json={"metrics": [{"key": "loss", "value": 0.5, "step": 0},
+                                      {"key": "loss", "value": 0.3, "step": 1}]}, headers=h)
+        self.c.post("/api/runs/run1/finish", json={"status": "finished", "ended_at": now}, headers=h)
+        # list (open read, no key)
+        j = self.c.get("/api/runs?range=7d").get_json()
+        run = next(x for x in j["runs"] if x["id"] == "run1")
+        self.assertEqual(run["status"], "finished")
+        self.assertEqual(run["source"], "jupyter")
+        self.assertEqual(run["metrics_latest"]["loss"], 0.3)        # latest value per key
+        # detail
+        d = self.c.get("/api/runs/run1").get_json()
+        self.assertEqual(len(d["metrics"]["loss"]["values"]), 2)
+        self.assertEqual(d["params"], {"lr": 2e-4})
+
+    def test_metrics_unknown_run_404(self):
+        key = app._gen_api_key()
+        r = self.c.post("/api/runs/nope/metrics",
+                        json={"key": "loss", "value": 1.0}, headers={"X-API-Key": key})
+        self.assertEqual(r.status_code, 404)
+
+    def test_cost_attached_over_window(self):
+        key = app._gen_api_key()
+        h = {"Authorization": "Bearer " + key}
+        now = int(time.time())
+        with app.LOCK:
+            app.DB.execute("DELETE FROM samples")
+            for i in range(10):                                    # 100s of 200W GPU samples
+                app.DB.execute("INSERT OR REPLACE INTO samples(ts,util,mem_used,mem_total,power,temp) "
+                               "VALUES(?,?,?,?,?,?)", (now - 100 + i * 10, 80, 8000, 24000, 200, 60))
+            app.DB.commit()
+        self.c.post("/api/runs", json={"id": "r2", "name": "train", "started_at": now - 100}, headers=h)
+        self.c.post("/api/runs/r2/finish", json={"ended_at": now}, headers=h)
+        d = self.c.get("/api/runs/r2").get_json()
+        self.assertGreater(d["energy_kwh"], 0)                     # GPU energy during the run window
+        self.assertGreater(d["cost"], 0)
+        self.assertEqual(d["peak_util"], 80)
+        self.assertGreater(len(d["resource"]["power_w"]), 0)
+
+
+class TestMlflowSync(unittest.TestCase):
+    def tearDown(self):
+        app.save_settings({"mlflow_uri": ""})
+        with app.LOCK:
+            app.DB.execute("DELETE FROM runs WHERE source='mlflow'")
+            app.DB.commit()
+
+    def test_pull_mirrors_runs_idempotently(self):
+        app.save_settings({"mlflow_uri": "http://mlflow.test"})
+
+        def fake_mlf(method, path, payload=None, params=None, timeout=15):
+            if "experiments/search" in path:
+                return {"experiments": [{"experiment_id": "1"}]}
+            if "runs/search" in path:
+                return {"runs": [{"info": {"run_id": "abc", "run_name": "nightly-eval",
+                                           "status": "FINISHED", "start_time": 1000000, "end_time": 2000000},
+                                  "data": {"metrics": [{"key": "acc"}],
+                                           "params": [{"key": "lr", "value": "0.1"}], "tags": []}}]}
+            if "metrics/get-history" in path:
+                return {"metrics": [{"timestamp": 1500000, "step": 1, "value": 0.81}]}
+            return {}
+
+        with patch("app._mlf", side_effect=fake_mlf):
+            n1 = app.sync_mlflow()
+            n2 = app.sync_mlflow()                                 # second sync: idempotent upsert
+        self.assertEqual(n1, 1)
+        with app.LOCK:
+            rows = app.DB.execute("SELECT name,status,started_at FROM runs WHERE source='mlflow' AND ext_id='abc'").fetchall()
+            mcount = app.DB.execute("SELECT COUNT(*) FROM run_metrics WHERE key='acc'").fetchone()[0]
+        self.assertEqual(len(rows), 1)                            # not duplicated on re-sync
+        self.assertEqual(rows[0][0], "nightly-eval")
+        self.assertEqual(rows[0][1], "finished")
+        self.assertEqual(rows[0][2], 1000)                        # 1000000 ms -> 1000 s
+        self.assertEqual(mcount, 1)                               # history replaced, not appended
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Integrations (#5) — integrations, not detection

Pivots **Experiments** from `/proc` auto-detection to a real **push/pull Runs API** — a notebook pushes a session, and it comes back **priced with the run's real GPU energy**.

### Backend
- `runs` + `run_metrics` tables. **One Bearer API key** (`secrets`, constant-time compare, **fail-closed** — ingest disabled until you generate one), shown masked in Settings with regenerate. **Writes gated; reads LAN-open** for the browser.
- **Ingest** (key-gated): create / heartbeat / batched metrics / finish. **Read**: list (+status filter) and detail — each integrates `samples.power` over the run window to attach **energy kWh + cost** (dual-tariff aware) and a GPU power/util series. Stale-run **janitor** flips crashed runs to `killed`.
- **MLflow pull** (pure REST, no `mlflow` dep): mirrors experiments/runs/metrics in as `source=mlflow` (idempotent), so MLflow runs get GPU cost too. Auto-sync ~5 min + **Sync now**.

### Client — `static/homelab_run.py`
Single stdlib file (uses `requests` if present) for Jupyter/Colab/Kaggle:
```python
with homelab.run("sft-llama3") as r:
    r.log_metric("loss", loss, step=i)
```
Buffered metrics, daemon heartbeat, source auto-detect, `pull()`/`list_runs()`. Download link in Settings → Integrations.

### UI
Experiments tab leads with a **Runs table** → click for **metric charts + the run's GPU power/util/cost graph** on the same time base. Auto-detected training + GPU sessions kept below as supporting context. New **Settings → Integrations** (key + snippet + client download + MLflow).

**108 tests green** (auth fail-closed/bad-key/404, full push→pull, cost-over-window, MLflow idempotency + ms→s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)