### PR TITLE
feat(integrations): full multi-key API management (create/revoke, expiry, per-key)

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,14 +18,14 @@ Adding a new monitor (it's meant to be easy):
   2. Populate it from `health_scan()` so the background thread keeps it fresh.
   3. Expose it via `/api/health` and add a matching tab/panel in dashboard.html.
 """
-import os, re, glob, time, json, socket, sqlite3, threading, subprocess, http.client, urllib.parse, urllib.request, ipaddress, shlex, struct, shutil, tempfile, secrets, hmac, uuid
+import os, re, glob, time, json, socket, sqlite3, threading, subprocess, http.client, urllib.parse, urllib.request, ipaddress, shlex, struct, shutil, tempfile, secrets, hmac, uuid, hashlib
 from functools import wraps
 try:
     import fcntl                       # Linux-only; used for per-iface IPv4 (SIOCGIFADDR)
 except ImportError:
     fcntl = None
 from concurrent.futures import ThreadPoolExecutor
-from flask import Flask, request, jsonify, Response, send_file, after_this_request
+from flask import Flask, request, jsonify, Response, send_file, after_this_request, g
 import db_backup
 try:
     from prometheus_client import (Gauge, generate_latest, CONTENT_TYPE_LATEST,
@@ -118,6 +118,9 @@ CREATE TABLE IF NOT EXISTS runs(
   notes TEXT, heartbeat_at INTEGER, ext_id TEXT, created_at INTEGER NOT NULL);
 CREATE TABLE IF NOT EXISTS run_metrics(run_id TEXT NOT NULL, ts INTEGER NOT NULL,
   step INTEGER DEFAULT 0, key TEXT NOT NULL, value REAL NOT NULL);
+CREATE TABLE IF NOT EXISTS api_keys(
+  id TEXT PRIMARY KEY, name TEXT NOT NULL, key_hash TEXT NOT NULL UNIQUE, prefix TEXT NOT NULL,
+  created_at INTEGER NOT NULL, expires_at INTEGER, last_used_at INTEGER);
 CREATE INDEX IF NOT EXISTS idx_powerproc_ts   ON power_proc(ts);
 CREATE INDEX IF NOT EXISTS idx_powerproc_name ON power_proc(name, ts);
 CREATE INDEX IF NOT EXISTS idx_runs_started   ON runs(started_at);
@@ -130,6 +133,8 @@ _SAMPLE_MIGRATIONS = ("cpu REAL", "ram_used REAL", "ram_total REAL", "load1 REAL
                       "cpu_power REAL", "dram_power REAL")
 # Per-host adaptive poll-timeout state (issue #99); added to the hosts table.
 _HOST_MIGRATIONS = ("poll_timeout INTEGER", "poll_fails INTEGER DEFAULT 0", "poll_calibrated_at INTEGER")
+# Which API key pushed a run (for per-key attribution); added to the runs table.
+_RUNS_MIGRATIONS = ("key_id TEXT",)
 
 def _data_dir():
     return os.path.dirname(os.path.abspath(DB_PATH)) or "."
@@ -159,6 +164,26 @@ def _apply_schema_migrations(conn):
             conn.execute(f"ALTER TABLE hosts ADD COLUMN {col}")
         except sqlite3.OperationalError:
             pass
+    for col in _RUNS_MIGRATIONS:
+        try:
+            conn.execute(f"ALTER TABLE runs ADD COLUMN {col}")
+        except sqlite3.OperationalError:
+            pass
+    # Migrate a legacy single instance-wide api_key (the previous design) into the
+    # api_keys table as a named key, then clear the setting — so existing clients
+    # keep working under the new multi-key model.
+    try:
+        row = conn.execute("SELECT value FROM settings WHERE key='api_key'").fetchone()
+        legacy = (row[0] if row else "") or ""
+        if legacy:
+            h = hashlib.sha256(legacy.encode("utf-8")).hexdigest()
+            if not conn.execute("SELECT 1 FROM api_keys WHERE key_hash=?", (h,)).fetchone():
+                conn.execute("INSERT INTO api_keys(id,name,key_hash,prefix,created_at,expires_at,last_used_at) "
+                             "VALUES(?,?,?,?,?,?,?)",
+                             (uuid.uuid4().hex, "default (migrated)", h, legacy[:12], int(time.time()), None, None))
+            conn.execute("UPDATE settings SET value='' WHERE key='api_key'")
+    except sqlite3.OperationalError:
+        pass
     conn.commit()
 
 def reopen_db():
@@ -4417,19 +4442,46 @@ MAX_RUN_FIELD, MAX_RUN_JSON, MAX_METRICS_REQ = 4096, 64 * 1024, 1000
 RUN_SOURCES = {"jupyter", "colab", "kaggle", "mlflow", "api", "cli"}
 RUN_STATUS  = {"running", "finished", "failed", "killed"}
 
-def _get_api_key():
-    return get_settings().get("api_key") or ""
+# Multiple named API keys, each optionally with an expiry, stored HASHED (sha256 —
+# the plaintext is shown once at creation and never persisted). Runs are attributed
+# to the key that pushed them, so you can track per-key usage and revoke individually.
+def _hash_key(k):
+    return hashlib.sha256(k.encode("utf-8")).hexdigest()
 
-def _gen_api_key():
+def _create_api_key(name, expires_in_days=None):
+    """Mint a key: persist its hash + metadata, return (id, plaintext). The plaintext
+    is the only time it's available."""
     key = "hlm_" + secrets.token_urlsafe(32)
-    save_settings({"api_key": key})
-    return key
+    kid, now = uuid.uuid4().hex, int(time.time())
+    exp = (now + int(expires_in_days) * 86400) if expires_in_days else None
+    with LOCK:
+        DB.execute("INSERT INTO api_keys(id,name,key_hash,prefix,created_at,expires_at,last_used_at) "
+                   "VALUES(?,?,?,?,?,?,?)", (kid, (name or "key")[:128], _hash_key(key), key[:12], now, exp, None))
+        DB.commit()
+    return kid, key
 
-def _key_ok(presented):
-    real = _get_api_key()
-    if not real or not presented:
-        return False                       # fail-closed: no key set => ingest disabled
-    return hmac.compare_digest(presented, real)
+def _gen_api_key(name="default", expires_in_days=None):
+    """Back-compat shim (used by tests): mint a key and return the plaintext."""
+    return _create_api_key(name, expires_in_days)[1]
+
+def _key_lookup(presented):
+    """Return the id of a live (non-expired) key matching `presented`, else None,
+    and stamp its last_used_at. Stored value is a hash, so the lookup never exposes
+    a usable secret. Fail-closed: no keys => all ingest rejected."""
+    if not presented:
+        return None
+    now = int(time.time())
+    with LOCK:
+        row = DB.execute("SELECT id, expires_at FROM api_keys WHERE key_hash=?",
+                         (_hash_key(presented),)).fetchone()
+        if not row:
+            return None
+        kid, exp = row
+        if exp and exp < now:
+            return None
+        DB.execute("UPDATE api_keys SET last_used_at=? WHERE id=?", (now, kid))
+        DB.commit()
+    return kid
 
 def _presented_key():
     auth = request.headers.get("Authorization", "")
@@ -4440,8 +4492,10 @@ def _presented_key():
 def require_api_key(fn):
     @wraps(fn)
     def wrapper(*a, **kw):
-        if not _key_ok(_presented_key()):
-            return jsonify({"ok": False, "error": "missing or invalid API key"}), 401
+        kid = _key_lookup(_presented_key())
+        if not kid:
+            return jsonify({"ok": False, "error": "missing, invalid, or expired API key"}), 401
+        g.api_key_id = kid
         return fn(*a, **kw)
     return wrapper
 
@@ -4479,15 +4533,41 @@ def _run_cost_window(cur, started, ended, ctx):
         cost += p * kwh_per * (_price_at(ctx, ts) or 0.0)
     return round(e_kwh, 4), round(cost, 4), (round(sum_p / n) if n else 0), round(peak_u)
 
-@app.route("/api/integration/key", methods=["GET", "POST"])
-def api_integration_key():
-    """GET -> {has_key, key_masked}. POST {regenerate:true} -> {key} (revealed once)."""
+@app.route("/api/integration/keys", methods=["GET", "POST"])
+def api_keys_route():
+    """GET -> {keys:[{id,name,prefix,created_at,expires_at,last_used_at,expired,runs}]}
+    (never the secret). POST {name, expires_in_days?} -> {id, key} (key revealed once)."""
     if request.method == "POST":
-        if (request.get_json(silent=True) or {}).get("regenerate"):
-            return jsonify({"ok": True, "key": _gen_api_key()})
-        return jsonify({"ok": False, "error": "nothing to do"}), 400
-    k = _get_api_key()
-    return jsonify({"has_key": bool(k), "key_masked": (k[:8] + "…" + k[-4:]) if k else ""})
+        body = request.get_json(silent=True) or {}
+        days = body.get("expires_in_days")
+        try:
+            days = int(days) if days not in (None, "", 0, "0") else None
+        except (TypeError, ValueError):
+            days = None
+        if days is not None and days <= 0:
+            days = None
+        kid, key = _create_api_key(_clip(body.get("name") or "key", 128), days)
+        return jsonify({"ok": True, "id": kid, "key": key})
+    now = int(time.time())
+    with LOCK:
+        rows = DB.execute("SELECT id,name,prefix,created_at,expires_at,last_used_at "
+                          "FROM api_keys ORDER BY created_at DESC").fetchall()
+        counts = dict(DB.execute("SELECT key_id, COUNT(*) FROM runs WHERE key_id IS NOT NULL "
+                                 "GROUP BY key_id").fetchall())
+    keys = [{"id": kid, "name": name, "prefix": prefix, "created_at": created,
+             "expires_at": exp, "last_used_at": used, "expired": bool(exp and exp < now),
+             "runs": counts.get(kid, 0)}
+            for (kid, name, prefix, created, exp, used) in rows]
+    return jsonify({"keys": keys, "has_key": bool(keys)})
+
+@app.route("/api/integration/keys/<kid>", methods=["DELETE"])
+def api_keys_delete(kid):
+    """Revoke (remove) a key. Runs it pushed are kept; they just lose live attribution."""
+    with LOCK:
+        cur = DB.execute("DELETE FROM api_keys WHERE id=?", (kid,))
+        DB.commit()
+    return (jsonify({"ok": True}) if cur.rowcount
+            else (jsonify({"ok": False, "error": "unknown key"}), 404))
 
 @app.route("/api/runs", methods=["POST"])
 @require_api_key
@@ -4505,11 +4585,12 @@ def api_runs_create():
         return jsonify({"ok": False, "error": str(e)}), 413
     with LOCK:
         DB.execute("INSERT INTO runs(id,name,source,status,started_at,ended_at,host,params,tags,notes,"
-                   "heartbeat_at,ext_id,created_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) "
+                   "heartbeat_at,ext_id,created_at,key_id) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
                    "ON CONFLICT(id) DO NOTHING",
                    (rid, _clip(body.get("name") or "run", MAX_RUN_FIELD), source, "running",
                     int(body.get("started_at") or now), None, _clip(body.get("host"), 256),
-                    params, tags, _clip(body.get("notes"), MAX_RUN_FIELD), now, None, now))
+                    params, tags, _clip(body.get("notes"), MAX_RUN_FIELD), now, None, now,
+                    getattr(g, "api_key_id", None)))
         DB.commit()
     return jsonify({"ok": True, "id": rid})
 
@@ -4584,17 +4665,21 @@ def api_runs_list():
     ctx = _cost_ctx()
     rng = request.args.get("range", "7d"); span = RANGES.get(rng, 604800)
     status = request.args.get("status")
+    key_filter = request.args.get("key")
     now = int(time.time()); since = 0 if span is None else now - span
-    q = ("SELECT id,name,source,status,started_at,ended_at,host,params,tags,notes "
+    q = ("SELECT id,name,source,status,started_at,ended_at,host,params,tags,notes,key_id "
          "FROM runs WHERE (ended_at IS NULL OR ended_at>=?) AND started_at<=? ")
     args = [since, now]
     if status in RUN_STATUS:
         q += "AND status=? "; args.append(status)
+    if key_filter:
+        q += "AND key_id=? "; args.append(key_filter)
     q += "ORDER BY started_at DESC LIMIT 500"
     out = []
     with LOCK:
         cur = DB.cursor()
-        for (rid, name, source, st, started, ended, host, params, tags, notes) in cur.execute(q, args).fetchall():
+        key_names = dict(cur.execute("SELECT id, name FROM api_keys").fetchall())
+        for (rid, name, source, st, started, ended, host, params, tags, notes, key_id) in cur.execute(q, args).fetchall():
             e_kwh, cost, avg_w, peak_u = _run_cost_window(cur, started, ended, ctx)
             kv = {}
             # latest value per key = the last-logged row (max rowid), robust even when
@@ -4606,6 +4691,7 @@ def api_runs_list():
             out.append({"id": rid, "name": name, "source": source, "status": st,
                         "started_at": started, "ended_at": ended, "duration": (ended or now) - started,
                         "host": host, "params": _safe_json(params), "tags": _safe_json(tags), "notes": notes,
+                        "key_id": key_id, "key_name": key_names.get(key_id),
                         "metrics_latest": kv, "energy_kwh": e_kwh, "cost": cost, "avg_w": avg_w, "peak_util": peak_u})
     return jsonify({"range": rng, "currency": ctx["currency"], "tariff_mode": ctx["mode"], "runs": out})
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -973,8 +973,25 @@ a{color:var(--info)}
     <div id="set-pane-integrations" hidden>
       <p class="cap" style="margin:2px 0 12px">Push run/session data from Jupyter, Colab or Kaggle (or mirror MLflow) — each run comes back priced with the real GPU energy it used. Writes need the API key; the dashboard reads are open on your LAN.</p>
 
-      <div class="card-sub" style="font-weight:600">🔑 API key</div>
-      <div id="intg_key_state" class="cap" style="margin:4px 0">…</div>
+      <div class="card-sub" style="font-weight:600">🔑 API keys</div>
+      <div class="cap" style="margin:4px 0">Create one key per machine/notebook so you can track and revoke each independently. Keys are stored hashed — the secret is shown once, at creation.</div>
+
+      <!-- Create a key -->
+      <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end;margin:8px 0">
+        <div style="flex:2;min-width:160px">
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">New key name</div>
+          <input type="text" id="intg_key_name" placeholder="e.g. colab-laptop" autocomplete="off"
+                 style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+        </div>
+        <div style="flex:1;min-width:120px">
+          <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Expires in</div>
+          <select id="intg_key_exp" style="width:100%;background:#0d1117;color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+            <option value="">Never</option><option value="7">7 days</option><option value="30">30 days</option>
+            <option value="90">90 days</option><option value="365">1 year</option>
+          </select>
+        </div>
+        <button class="rb on" id="intg_key_create">Create key</button>
+      </div>
       <div id="intg_key_reveal" hidden style="margin:6px 0">
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Your new key — copy it now, it won't be shown again</div>
         <div style="display:flex;gap:6px;flex-wrap:wrap">
@@ -982,8 +999,13 @@ a{color:var(--info)}
           <button class="rb" id="intg_key_copy">Copy</button>
         </div>
       </div>
-      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
-        <button class="rb" id="intg_key_gen">Generate / regenerate key</button>
+
+      <!-- Existing keys -->
+      <table style="margin-top:6px"><thead><tr>
+        <th>Name</th><th>Key</th><th>Created</th><th>Expires</th><th>Last used</th><th>Runs</th><th></th>
+      </tr></thead><tbody id="intg_key_tbody"></tbody></table>
+
+      <div style="margin-top:8px">
         <a class="rb" id="intg_client_dl" href="/static/homelab_run.py" download>Download client (homelab_run.py)</a>
       </div>
       <div class="cap" style="margin-top:8px">Quickstart in a notebook:</div>
@@ -3970,22 +3992,42 @@ function setSettingsPane(name){
 }
 document.querySelectorAll('#set-subtabs .subtab').forEach(b=>b.onclick=()=>setSettingsPane(b.dataset.sp));
 
-// ── Integrations settings (API key + MLflow) ──────────────────────────────────
+// ── Integrations settings (API keys + MLflow) ─────────────────────────────────
 async function loadIntegrations(){
-  let j; try{ j=await(await fetch('/api/integration/key')).json(); }catch(e){ return; }
-  const st=document.getElementById('intg_key_state');
-  if(st) st.innerHTML = j.has_key
-    ? 'A key is set: <code>'+esc(j.key_masked)+'</code>. Regenerating invalidates the old one.'
-    : 'No API key yet — generate one so notebooks can push runs (ingest is disabled until you do).';
+  let j; try{ j=await(await fetch('/api/integration/keys')).json(); }catch(e){ return; }
+  const tb=document.getElementById('intg_key_tbody'); if(tb){
+    const keys=j.keys||[];
+    const fmtD=ts=>ts?new Date(ts*1000).toLocaleDateString([], {year:'numeric',month:'short',day:'numeric'}):'—';
+    const fmtU=ts=>ts?fmtMcpAge(Math.max(0,Math.floor(Date.now()/1000)-ts)):'never';
+    tb.innerHTML = keys.length ? keys.map(k=>`<tr>
+      <td><b>${esc(k.name)}</b></td>
+      <td><code>${esc(k.prefix)}…</code></td>
+      <td>${fmtD(k.created_at)}</td>
+      <td>${k.expires_at?(k.expired?'<span class="badge crit">expired</span> ':'')+fmtD(k.expires_at):'never'}</td>
+      <td>${fmtU(k.last_used_at)}</td>
+      <td>${k.runs}</td>
+      <td><button class="rb" data-del="${esc(k.id)}" style="padding:3px 9px">Revoke</button></td></tr>`).join('')
+      : '<tr><td colspan="7" class="muted">No keys yet — create one above so notebooks can push runs (ingest is disabled until you do).</td></tr>';
+    tb.querySelectorAll('button[data-del]').forEach(b=>b.onclick=()=>deleteKey(b.dataset.del));
+  }
   const snip=document.getElementById('intg_snippet');
   if(snip) snip.textContent = `import homelab_run as homelab\nhomelab.configure(url="http://${location.hostname}:9800", key="hlm_…")\nwith homelab.run("my-finetune", params={"lr":2e-4}) as r:\n    for step, loss in enumerate(train()):\n        r.log_metric("loss", loss, step=step)`;
 }
+async function deleteKey(id){
+  if(!confirm('Revoke this API key? Any client still using it will stop working immediately.')) return;
+  try{ await fetch('/api/integration/keys/'+encodeURIComponent(id),{method:'DELETE'}); }catch(e){ intgStatus('err','Failed: '+e); return; }
+  intgStatus('ok','Key revoked.'); loadIntegrations();
+}
 function intgStatus(level,msg){ const el=document.getElementById('intg_status'); if(el){ el.textContent=msg; el.style.color = level==='ok'?'var(--ok)':level==='err'?'var(--crit)':'var(--mut)'; } }
 (function wireIntegrations(){
-  const gen=document.getElementById('intg_key_gen');
-  if(gen) gen.onclick=async()=>{ if(!confirm('Generate a new API key? Any client using the old key will stop working.')) return;
-    let j; try{ j=await(await fetch('/api/integration/key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({regenerate:true})})).json(); }catch(e){ intgStatus('err','Failed: '+e); return; }
-    if(j.key){ document.getElementById('intg_key_reveal').hidden=false; document.getElementById('intg_key_value').value=j.key; loadIntegrations(); intgStatus('ok','New key generated — copy it now.'); } };
+  const cr=document.getElementById('intg_key_create');
+  if(cr) cr.onclick=async()=>{
+    const name=(document.getElementById('intg_key_name').value||'').trim();
+    const exp=document.getElementById('intg_key_exp').value;
+    let j; try{ j=await(await fetch('/api/integration/keys',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({name:name||'key', expires_in_days: exp?parseInt(exp,10):null})})).json(); }catch(e){ intgStatus('err','Failed: '+e); return; }
+    if(j.key){ document.getElementById('intg_key_reveal').hidden=false; document.getElementById('intg_key_value').value=j.key;
+      document.getElementById('intg_key_name').value=''; loadIntegrations(); intgStatus('ok','Key created — copy it now, it won’t be shown again.'); } };
   const cp=document.getElementById('intg_key_copy');
   if(cp) cp.onclick=()=>{ const v=document.getElementById('intg_key_value').value; copyText(v); intgStatus('ok','Key copied to clipboard.'); };
   const si=document.getElementById('al_save_intg');

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -16,6 +16,7 @@ class TestRunsApi(unittest.TestCase):
         with app.LOCK:
             app.DB.execute("DELETE FROM runs")
             app.DB.execute("DELETE FROM run_metrics")
+            app.DB.execute("DELETE FROM api_keys")
             app.DB.commit()
         app.save_settings({"api_key": "", "kwh_price": "0.30", "currency": "$", "tariff_mode": "single"})
 
@@ -76,6 +77,59 @@ class TestRunsApi(unittest.TestCase):
         self.assertGreater(d["cost"], 0)
         self.assertEqual(d["peak_util"], 80)
         self.assertGreater(len(d["resource"]["power_w"]), 0)
+
+
+class TestApiKeys(unittest.TestCase):
+    def setUp(self):
+        self.c = app.app.test_client()
+        with app.LOCK:
+            app.DB.execute("DELETE FROM api_keys")
+            app.DB.execute("DELETE FROM runs")
+            app.DB.commit()
+
+    def test_create_list_revoke(self):
+        r = self.c.post("/api/integration/keys", json={"name": "laptop"}).get_json()
+        kid, key = r["id"], r["key"]
+        self.assertTrue(key.startswith("hlm_"))
+        j = self.c.get("/api/integration/keys").get_json()
+        self.assertEqual(len(j["keys"]), 1)
+        self.assertEqual(j["keys"][0]["name"], "laptop")
+        self.assertNotIn("key", j["keys"][0])          # plaintext never listed
+        self.assertNotIn("key_hash", j["keys"][0])      # hash never exposed
+        h = {"Authorization": "Bearer " + key}
+        self.assertEqual(self.c.post("/api/runs", json={"name": "x"}, headers=h).status_code, 200)
+        self.assertEqual(self.c.delete("/api/integration/keys/" + kid).status_code, 200)
+        self.assertEqual(self.c.post("/api/runs", json={"name": "y"}, headers=h).status_code, 401)  # revoked
+
+    def test_expired_key_rejected(self):
+        r = self.c.post("/api/integration/keys", json={"name": "old", "expires_in_days": 30}).get_json()
+        with app.LOCK:                                  # backdate it past expiry
+            app.DB.execute("UPDATE api_keys SET expires_at=? WHERE id=?", (int(time.time()) - 10, r["id"]))
+            app.DB.commit()
+        resp = self.c.post("/api/runs", json={"name": "x"}, headers={"Authorization": "Bearer " + r["key"]})
+        self.assertEqual(resp.status_code, 401)
+        j = self.c.get("/api/integration/keys").get_json()
+        self.assertTrue(j["keys"][0]["expired"])
+
+    def test_per_key_attribution_and_filter(self):
+        ka = self.c.post("/api/integration/keys", json={"name": "A"}).get_json()
+        self.c.post("/api/integration/keys", json={"name": "B"}).get_json()
+        self.c.post("/api/runs", json={"id": "ra", "name": "r"}, headers={"Authorization": "Bearer " + ka["key"]})
+        byname = {k["name"]: k for k in self.c.get("/api/integration/keys").get_json()["keys"]}
+        self.assertEqual(byname["A"]["runs"], 1)
+        self.assertEqual(byname["B"]["runs"], 0)
+        self.assertIsNotNone(byname["A"]["last_used_at"])
+        runs = self.c.get("/api/runs?range=7d&key=" + ka["id"]).get_json()["runs"]
+        self.assertEqual(runs[0]["key_name"], "A")
+        self.assertEqual(runs[0]["key_id"], ka["id"])
+
+    def test_legacy_single_key_migrated(self):
+        app.save_settings({"api_key": "hlm_legacytestkey123"})
+        app._apply_schema_migrations(app.DB)             # migrates the setting into api_keys
+        resp = self.c.post("/api/runs", json={"name": "x"},
+                           headers={"Authorization": "Bearer hlm_legacytestkey123"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(app.get_settings().get("api_key", ""), "")   # setting cleared
 
 
 class TestMlflowSync(unittest.TestCase):


### PR DESCRIPTION
## Full API key management

Replaces the single instance-wide key with proper, full-featured key management.

- **Multiple named keys** (new `api_keys` table), each stored **hashed** (sha256) — the secret is shown **once** at creation, never persisted.
- **Per-key expiry** (7/30/90/365 days or never), enforced at auth; `last_used_at` stamped on use.
- **Per-key attribution**: runs carry `key_id`, so the keys table shows a **run count per key**, `/api/runs?key=<id>` filters to one key, and each run exposes `key_name`.
- **Create / revoke** via `GET/POST /api/integration/keys` + `DELETE /api/integration/keys/<id>`. List never returns the secret; revoke is instant.
- **Backward compatible**: a legacy single `api_key` is migrated into the table on startup, then the setting cleared — existing clients keep working.

UI (Settings → Integrations): create-key form (name + expiry) revealing the secret once, and a table of keys with prefix / created / expires / last-used / run count / Revoke.

Tests: create/list/revoke, secret-never-listed, expiry rejected, per-key attribution + filter + last_used, legacy migration. **112 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)