### PR TITLE
refactor(ui): batch 1 — form fields → .field component (pixel-identical)

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -790,7 +790,7 @@ h2 .hic{ opacity:.9 }
   <div class="card" id="runs-card">
     <h2 style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">🧪 Runs
       <span class="muted" style="font-size:12px;font-weight:400;text-transform:none">— pushed from your notebooks &amp; MLflow, priced with real GPU energy</span>
-      <select id="runs-status" style="margin-left:auto;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:4px 8px;font:inherit;font-size:12px">
+      <select id="runs-status" style="margin-left:auto;padding:4px 8px;font-size:12px">
         <option value="">all status</option><option value="running">running</option>
         <option value="finished">finished</option><option value="failed">failed</option><option value="killed">killed</option>
       </select></h2>
@@ -880,7 +880,7 @@ h2 .hic{ opacity:.9 }
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Discord webhook URL</div>
         <div style="display:flex;gap:6px">
           <input type="text" id="al_discord" placeholder="https://discord.com/api/webhooks/…" autocomplete="off" spellcheck="false"
-                 style="flex:1;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="flex:1">
         </div>
         <div class="cap" id="al_discord_state" style="margin-top:4px"></div>
       </div>
@@ -889,9 +889,9 @@ h2 .hic{ opacity:.9 }
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">ntfy.sh topic</div>
         <div style="display:flex;gap:6px;flex-wrap:wrap">
           <input type="text" id="al_ntfy_topic" placeholder="my-homelab-alerts" autocomplete="off" spellcheck="false"
-                 style="flex:2;min-width:180px;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="flex:2;min-width:180px">
           <input type="text" id="al_ntfy_server" placeholder="https://ntfy.sh" autocomplete="off" spellcheck="false"
-                 style="flex:1;min-width:160px;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="flex:1;min-width:160px">
         </div>
         <div class="cap">Topic is required; server defaults to <code>https://ntfy.sh</code>. Self-hosted ntfy works too.</div>
       </div>
@@ -900,7 +900,7 @@ h2 .hic{ opacity:.9 }
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Telegram bot token</div>
         <div style="display:flex;gap:6px">
           <input type="text" id="al_telegram_token" placeholder="123456:ABC-DEF…" autocomplete="off" spellcheck="false"
-                 style="flex:1;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="flex:1">
         </div>
         <div class="cap" id="al_telegram_state" style="margin-top:4px"></div>
       </div>
@@ -909,7 +909,7 @@ h2 .hic{ opacity:.9 }
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Telegram chat ID</div>
         <div style="display:flex;gap:6px">
           <input type="text" id="al_telegram_chat_id" placeholder="-1001234567890" autocomplete="off" spellcheck="false"
-                 style="flex:1;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="flex:1">
         </div>
         <div class="cap">Required with a bot token. Message your bot once, then read <code>chat.id</code> from <code>getUpdates</code>.</div>
       </div>
@@ -917,7 +917,7 @@ h2 .hic{ opacity:.9 }
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Minimum severity</div>
-          <select id="al_minlevel" style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+          <select id="al_minlevel" style="width:100%">
             <option value="warning">warning</option>
             <option value="critical">critical only</option>
           </select>
@@ -925,7 +925,7 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Disk alert threshold (%)</div>
           <input type="number" id="al_disk" min="50" max="99" step="1"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
       </div>
 
@@ -947,7 +947,7 @@ h2 .hic{ opacity:.9 }
       <!-- Country prefill — don't know your rates? pick a country for a typical estimate -->
       <div>
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Don't know your rates? Pick your country</div>
-        <select id="al_country" style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+        <select id="al_country" style="width:100%">
           <option value="">— Select to prefill a typical estimate —</option>
         </select>
         <div class="cap" id="al_tariff_src" style="margin-top:4px">Indicative estimate — always edit to match your own bill.</div>
@@ -966,12 +966,12 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" id="al_kwh_label" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Price (per kWh)</div>
           <input type="number" id="al_kwh" min="0" step="0.0001" placeholder="e.g. 0.30"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Currency symbol</div>
           <input type="text" id="al_currency" maxlength="4" placeholder="$"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
       </div>
 
@@ -980,17 +980,17 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night price (per kWh)</div>
           <input type="number" id="al_kwh_night" min="0" step="0.0001" placeholder="e.g. 0.15"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night starts</div>
           <input type="time" id="al_night_start" value="22:00"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night ends</div>
           <input type="time" id="al_night_end" value="06:00"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
       </div>
       <p class="cap" style="margin-top:-4px">Powers the <b>💰 Costs</b> page and the Power &amp; cost cards from power history. <b>Day &amp; Night</b> bills each sample at the night rate inside the window (it may cross midnight) and the day rate otherwise — leave the night price blank to use the single average. Leave the price blank to hide the cost cards.</p>
@@ -998,7 +998,7 @@ h2 .hic{ opacity:.9 }
       <div style="max-width:340px">
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Rest-of-system baseline (W) — optional</div>
         <input type="number" id="al_idle_w" min="0" step="1" placeholder="e.g. 60 (mainboard, fans, disks)"
-               style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+               style="width:100%">
         <div class="cap" style="margin-top:4px">GPU and CPU-package power are <b>measured</b>. Wall power is never guessed. Set a flat baseline here only if you want an "Other" band on the Costs chart for the rest of the box.</div>
       </div>
 
@@ -1020,11 +1020,11 @@ h2 .hic{ opacity:.9 }
         <div style="flex:2;min-width:160px">
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">New key name</div>
           <input type="text" id="intg_key_name" placeholder="e.g. colab-laptop" autocomplete="off"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
         <div style="flex:1;min-width:120px">
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Expires in</div>
-          <select id="intg_key_exp" style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+          <select id="intg_key_exp" style="width:100%">
             <option value="">Never</option><option value="7">7 days</option><option value="30">30 days</option>
             <option value="90">90 days</option><option value="365">1 year</option>
           </select>
@@ -1034,7 +1034,7 @@ h2 .hic{ opacity:.9 }
       <div id="intg_key_reveal" hidden style="margin:6px 0">
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Your new key — copy it now, it won't be shown again</div>
         <div style="display:flex;gap:6px;flex-wrap:wrap">
-          <input type="text" id="intg_key_value" readonly style="flex:1;min-width:240px;background:var(--inset);color:var(--tx);border:1px solid var(--ok);border-radius:7px;padding:7px 10px;font:inherit">
+          <input type="text" id="intg_key_value" readonly style="flex:1;min-width:240px;border:1px solid var(--ok)">
           <button class="rb" id="intg_key_copy">Copy</button>
         </div>
       </div>
@@ -1061,12 +1061,12 @@ with homelab.run("my-finetune", params={"lr":2e-4}) as r:
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow tracking URI</div>
           <input type="text" id="al_mlflow_uri" placeholder="http://mlflow.lan:5000"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow bearer token (optional)</div>
           <input type="text" id="al_mlflow_token" placeholder="only for a secured MLflow" autocomplete="off"
-                 style="width:100%;background:var(--inset);color:var(--tx);border:1px solid var(--bd);border-radius:7px;padding:7px 10px;font:inherit">
+                 style="width:100%">
           <div class="cap" id="al_mlflow_token_state" style="margin-top:4px"></div>
         </div>
       </div>

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -606,6 +606,7 @@ input:not([type=checkbox]):not([type=radio]):not([type=range]):not([type=file]),
   transition:border-color .15s ease, box-shadow .15s ease; }
 input:not([type=checkbox]):not([type=radio]):hover,select:hover,textarea:hover{ border-color:var(--mut); }
 input[type=checkbox],input[type=radio]{ accent-color:var(--accent); }
+.field{ width:100% }
 button,.rb,.nrow,.subtab,a{ transition:border-color .15s ease, background .15s ease, color .15s ease; }
 /* Visible keyboard focus everywhere — was a single rule in the whole app. */
 :where(a,button,.rb,.nrow,.subtab,[tabindex],[role="button"]):focus-visible{
@@ -917,7 +918,7 @@ h2 .hic{ opacity:.9 }
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Minimum severity</div>
-          <select id="al_minlevel" style="width:100%">
+          <select id="al_minlevel" class="field">
             <option value="warning">warning</option>
             <option value="critical">critical only</option>
           </select>
@@ -925,7 +926,7 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Disk alert threshold (%)</div>
           <input type="number" id="al_disk" min="50" max="99" step="1"
-                 style="width:100%">
+                 class="field">
         </div>
       </div>
 
@@ -947,7 +948,7 @@ h2 .hic{ opacity:.9 }
       <!-- Country prefill — don't know your rates? pick a country for a typical estimate -->
       <div>
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Don't know your rates? Pick your country</div>
-        <select id="al_country" style="width:100%">
+        <select id="al_country" class="field">
           <option value="">— Select to prefill a typical estimate —</option>
         </select>
         <div class="cap" id="al_tariff_src" style="margin-top:4px">Indicative estimate — always edit to match your own bill.</div>
@@ -966,12 +967,12 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" id="al_kwh_label" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Price (per kWh)</div>
           <input type="number" id="al_kwh" min="0" step="0.0001" placeholder="e.g. 0.30"
-                 style="width:100%">
+                 class="field">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Currency symbol</div>
           <input type="text" id="al_currency" maxlength="4" placeholder="$"
-                 style="width:100%">
+                 class="field">
         </div>
       </div>
 
@@ -980,17 +981,17 @@ h2 .hic{ opacity:.9 }
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night price (per kWh)</div>
           <input type="number" id="al_kwh_night" min="0" step="0.0001" placeholder="e.g. 0.15"
-                 style="width:100%">
+                 class="field">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night starts</div>
           <input type="time" id="al_night_start" value="22:00"
-                 style="width:100%">
+                 class="field">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Night ends</div>
           <input type="time" id="al_night_end" value="06:00"
-                 style="width:100%">
+                 class="field">
         </div>
       </div>
       <p class="cap" style="margin-top:-4px">Powers the <b>💰 Costs</b> page and the Power &amp; cost cards from power history. <b>Day &amp; Night</b> bills each sample at the night rate inside the window (it may cross midnight) and the day rate otherwise — leave the night price blank to use the single average. Leave the price blank to hide the cost cards.</p>
@@ -998,7 +999,7 @@ h2 .hic{ opacity:.9 }
       <div style="max-width:340px">
         <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Rest-of-system baseline (W) — optional</div>
         <input type="number" id="al_idle_w" min="0" step="1" placeholder="e.g. 60 (mainboard, fans, disks)"
-               style="width:100%">
+               class="field">
         <div class="cap" style="margin-top:4px">GPU and CPU-package power are <b>measured</b>. Wall power is never guessed. Set a flat baseline here only if you want an "Other" band on the Costs chart for the rest of the box.</div>
       </div>
 
@@ -1020,11 +1021,11 @@ h2 .hic{ opacity:.9 }
         <div style="flex:2;min-width:160px">
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">New key name</div>
           <input type="text" id="intg_key_name" placeholder="e.g. colab-laptop" autocomplete="off"
-                 style="width:100%">
+                 class="field">
         </div>
         <div style="flex:1;min-width:120px">
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">Expires in</div>
-          <select id="intg_key_exp" style="width:100%">
+          <select id="intg_key_exp" class="field">
             <option value="">Never</option><option value="7">7 days</option><option value="30">30 days</option>
             <option value="90">90 days</option><option value="365">1 year</option>
           </select>
@@ -1061,12 +1062,12 @@ with homelab.run("my-finetune", params={"lr":2e-4}) as r:
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow tracking URI</div>
           <input type="text" id="al_mlflow_uri" placeholder="http://mlflow.lan:5000"
-                 style="width:100%">
+                 class="field">
         </div>
         <div>
           <div class="muted" style="font-size:12px;text-transform:uppercase;letter-spacing:.02em;margin-bottom:5px">MLflow bearer token (optional)</div>
           <input type="text" id="al_mlflow_token" placeholder="only for a secured MLflow" autocomplete="off"
-                 style="width:100%">
+                 class="field">
           <div class="cap" id="al_mlflow_token_state" style="margin-top:4px"></div>
         </div>
       </div>


### PR DESCRIPTION
**Batch 1 of the inline-style consolidation** (review-after-each cadence).

Form fields each repeated the same 6-property inline style block; the craft-pass base `input/select/textarea` rule provides those identically, so:
- removed **118 redundant inline props** from 20 controls,
- promoted 13 `width:100%` controls to a real **`.field` class**,
- inline `style=` attributes **200 → 187**.

**Renders pixel-identical** — this is markup cleanup toward a component layer, not a visual change. The review here is just: *confirm nothing broke* across Settings/Hosts inputs in both themes.

Correction noted in commits: the earlier "light theme broken" finding was inaccurate (an existing `.content input{...!important}` rule already handled it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)