### PR TITLE
chore: open the post-0.16.0 dev cycle (0.17.0-next)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [Unreleased] — `next`
+
+_Nothing here yet — `next` is the preview branch; changes land here before the next tagged release._
+
 ## [0.16.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.16.0) — 2026-06-14 · **The AI Lab Cockpit**
 *Your GPU, your models, and your power bill — finally on the same page.*
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.16.0"
+VERSION      = "0.17.0-next"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))


### PR DESCRIPTION
Routine post-release: bump `next` to `0.17.0-next` (restores the preview badge, keeps next ahead of the `0.16.0` tag) + an empty `[Unreleased]` changelog stub.