### PR TITLE
feat: opt-in one-click self-update from the dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,12 @@ CHECK_UPDATES = os.environ.get("CHECK_UPDATES", "true").strip().lower() not in (
 # this network lookup and keep the offline package counts.
 CHECK_OS_UPDATES = os.environ.get("CHECK_OS_UPDATES", "true").strip().lower() not in ("0", "false", "no", "off")
 UPDATE_REPO   = os.environ.get("UPDATE_REPO", "SikamikanikoBG/homelab-monitor")
+# Opt-in one-click self-update button. OFF by default: this is the first action
+# that *writes* (it recreates this very container via a detached docker:cli helper
+# and restarts the app). Needs the docker socket mounted read-write. See
+# start_self_update() and website/configuration.md.
+ALLOW_SELF_UPDATE = os.environ.get("ALLOW_SELF_UPDATE", "").strip().lower() in ("1", "true", "yes", "on")
+SELF_UPDATE_HELPER_IMAGE = os.environ.get("SELF_UPDATE_HELPER_IMAGE", "docker:cli")
 # Split cache: once we know there's an update, the answer won't change for hours
 # so we can cache it long. But "no update found" / network errors should expire
 # sooner — otherwise a release published right after deploy stays invisible for
@@ -226,18 +232,30 @@ _scan_since = {}
 _cpu_prev = {"idle": 0, "total": 0}
 
 # ── Docker API over the unix socket ────────────────────────────────────────────
-def _docker(path):
-    # close() must run even when connect/request/read raise (dockerd slow,
-    # restarting, unreachable) — otherwise the manually-created AF_UNIX socket fd
-    # leaks on every failed call and the process eventually hits its fd limit.
-    c = http.client.HTTPConnection("localhost", timeout=4)
+def _docker_req(method, path, body=None, timeout=8):
+    """Talk to the Docker Engine API over its AF_UNIX socket with an arbitrary
+    method + optional JSON body. Returns (status_code, raw_bytes). Used for the
+    self-update flow, which has to POST (create/start the helper container) —
+    _docker() below is the GET-only convenience wrapper everything else uses.
+    close() runs even on error so the hand-made socket fd never leaks."""
+    c = http.client.HTTPConnection("localhost", timeout=timeout)
     c.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
-        c.sock.settimeout(4); c.sock.connect(DOCKER_SOCK)
-        c.request("GET", path)
-        return c.getresponse().read()
+        c.sock.settimeout(timeout); c.sock.connect(DOCKER_SOCK)
+        headers, payload = {}, None
+        if body is not None:
+            payload = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        c.request(method, path, body=payload, headers=headers)
+        resp = c.getresponse()
+        return resp.status, resp.read()
     finally:
         c.close()
+
+def _docker(path):
+    # GET-only wrapper kept for the many read-only callers below; returns the raw
+    # body (they json.loads it). Shares the socket pattern via _docker_req.
+    return _docker_req("GET", path, timeout=4)[1]
 
 def containers():
     if time.time() - _ct_cache["at"] < 30 and _ct_cache["list"]:
@@ -1981,6 +1999,262 @@ def collect_update():
     with _UPDATE_LOCK:
         _UPDATE_CACHE.update({"at": now, "data": data})
     return data
+
+# ── Opt-in one-click self-update ──────────────────────────────────────────────
+# A container can't `docker compose up -d` its own container in-process — the
+# process dies mid-recreate. So we delegate the recreate to a DETACHED docker:cli
+# helper that runs the project's compose file and reports progress through the
+# shared ./data bind mount (update_state.json + update.log). The app, once it
+# restarts on the new image, just reads those files back for the status endpoint.
+SELF_UPDATE_IMAGE = "sikamikaniko123/homelab-monitor"   # the image this app ships as
+_SELF_UPDATE_STALE_SEC = 15 * 60   # a non-terminal job older than this is abandoned
+_SELF_UPDATE_DONE = ("done", "failed", "rolled_back")
+
+def _update_state_path():
+    return os.path.join(_data_dir(), "update_state.json")
+
+def _update_log_path():
+    return os.path.join(_data_dir(), "update.log")
+
+def _read_update_state():
+    try:
+        with open(_update_state_path(), "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+def _tail_lines(path, n=200):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return "".join(f.readlines()[-n:])
+    except Exception:
+        return ""
+
+def _self_container_name():
+    return os.environ.get("HOSTNAME") or "homelab-monitor"
+
+def _self_update_script(working_dir, project, config_files, service,
+                        target, target_image, previous_image, port):
+    """Build the shell the detached docker:cli helper runs. It writes
+    update_state.json atomically (temp + mv) and appends human lines to
+    update.log at each step, then health-gates the new container and rolls back
+    to previous_image on failure. All label-derived values are shell-quoted.
+
+    The forward pull/up pins MONITOR_IMAGE=<target_image> (the immutable
+    :x.y.z tag) so compose pulls that exact version instead of the moving
+    :latest; rollback pins MONITOR_IMAGE=<previous_image> (the prior digest)
+    so `up` genuinely restores the image we were running before."""
+    q = shlex.quote
+    fflags = " ".join("-f " + q(c) for c in config_files if c)
+    compose = "docker compose %s -p %s" % (fflags, q(project))
+    svc = q(service) if service else ""
+    state_json = q(os.path.join(working_dir, "data", "update_state.json"))
+    log = q(os.path.join(working_dir, "data", "update.log"))
+    # 127.0.0.1 (not "localhost"): the helper's BusyBox wget resolves "localhost"
+    # to IPv6 ::1 first, but the monitor's Flask binds IPv4 0.0.0.0 only — so a
+    # "localhost" gate gets connection-refused on [::1] and the update would
+    # always roll back. Force IPv4 to actually reach the monitor on the host.
+    health = "http://127.0.0.1:%d/api/health" % port
+    # MONITOR_IMAGE=<ref> prefix feeds compose's ${MONITOR_IMAGE:-…}
+    # interpolation. Forward = the versioned target tag; rollback = the
+    # exact previous image ref/digest. Shell-quoted so digests are safe.
+    fwd_env  = "MONITOR_IMAGE=%s " % q(target_image)
+    prev_env = "MONITOR_IMAGE=%s " % q(previous_image)
+    # set_state writes {state, target, previous_image, ...} merging optional
+    # error/new_image; mv makes the replace atomic-ish for the polling reader.
+    return r'''
+set -u
+WD=%(wd)s
+STATE=%(state)s
+LOG=%(log)s
+TARGET=%(target)s
+PREV=%(prev)s
+log(){ printf '%%s %%s\n' "$(date -u +%%H:%%M:%%S)" "$1" >> "$LOG" 2>/dev/null; }
+set_state(){ # $1=state  $2=extra-json (optional, no leading comma)
+  extra=""; [ -n "${2:-}" ] && extra=",$2"
+  printf '{"state":"%%s","target":"%%s","previous_image":"%%s","updated_at":%%s%%s}' \
+    "$1" "$TARGET" "$PREV" "$(date +%%s)" "$extra" > "$STATE.tmp" 2>/dev/null \
+    && mv "$STATE.tmp" "$STATE" 2>/dev/null; }
+cd "$WD" || { log "cannot cd to $WD"; set_state failed '"error":"cd failed"'; exit 1; }
+
+log "pulling new image (%(svc)s)…"
+if ! %(fwd_env)s%(compose)s pull %(svc)s >> "$LOG" 2>&1; then
+  log "pull failed"; set_state failed '"error":"docker compose pull failed"'; exit 1
+fi
+
+log "recreating container on the new image…"
+set_state restarting
+if ! %(fwd_env)s%(compose)s up -d --no-build %(svc)s >> "$LOG" 2>&1; then
+  log "up failed — rolling back to $PREV"
+  %(prev_env)s%(compose)s up -d --no-build %(svc)s >> "$LOG" 2>&1
+  set_state rolled_back '"error":"recreate failed; previous image restored"'; exit 1
+fi
+
+log "waiting for the new version to come up…"
+ok=0
+i=0
+while [ $i -lt 30 ]; do
+  cur=$(wget -qO- %(health)s 2>/dev/null | tr -d ' \n' | sed -n 's/.*"update":{[^}]*"current":"\([^"]*\)".*/\1/p')
+  if [ -n "$cur" ] && [ "$cur" = "$TARGET" ]; then ok=1; break; fi
+  i=$((i+1)); sleep 2
+done
+
+if [ $ok -eq 1 ]; then
+  log "healthy on v$TARGET — update complete"
+  set_state done '"new_image":"%(img)s:'"$TARGET"'"'
+else
+  log "health-gate failed (never reported v$TARGET) — rolling back to $PREV"
+  %(prev_env)s%(compose)s up -d --no-build %(svc)s >> "$LOG" 2>&1
+  set_state rolled_back '"error":"new version failed health-check; previous version restored"'
+fi
+''' % {"wd": q(working_dir), "state": state_json, "log": log,
+       "target": q(target), "prev": q(previous_image),
+       "compose": compose, "svc": svc, "health": health,
+       "fwd_env": fwd_env, "prev_env": prev_env,
+       "img": SELF_UPDATE_IMAGE}
+
+def start_self_update(force=False):
+    """Kick off the detached self-update helper. Returns (status_code, dict).
+    Degrades to error dicts (never raises) so the route can jsonify them."""
+    if not ALLOW_SELF_UPDATE:
+        return 400, {"ok": False, "error": "Self-update is disabled. Set ALLOW_SELF_UPDATE=1 to enable it."}
+
+    upd = collect_update()
+    if not force and not upd.get("available"):
+        return 400, {"ok": False, "error": "No update available."}
+    target = (upd.get("latest") or "").lstrip("vV")
+    if not target:
+        return 400, {"ok": False, "error": "Could not determine the target version to update to."}
+
+    # Singleton guard: a fresh non-terminal job blocks a second run.
+    st = _read_update_state()
+    if st and st.get("state") not in _SELF_UPDATE_DONE:
+        age = time.time() - (st.get("updated_at") or st.get("started_at") or 0)
+        if age < _SELF_UPDATE_STALE_SEC:
+            return 409, {"ok": False, "error": "An update is already in progress.", "state": st}
+
+    # Self-inspect to learn our image + compose labels.
+    name = _self_container_name()
+    try:
+        code, raw = _docker_req("GET", "/containers/%s/json" % urllib.parse.quote(name))
+    except Exception as e:
+        return 400, {"ok": False, "error": "Could not reach the Docker socket: %s" % e}
+    if code != 200:
+        return 400, {"ok": False, "error": "Could not inspect own container '%s' (HTTP %s). Is the docker socket mounted read-write?" % (name, code)}
+    try:
+        info = json.loads(raw)
+    except Exception:
+        return 400, {"ok": False, "error": "Unexpected response inspecting own container."}
+
+    cfg = info.get("Config") or {}
+    labels = cfg.get("Labels") or {}
+    # The repo-qualified ref we were deployed from. Prefer Config.Image (the
+    # "repo:tag" / "repo@digest" the container was created with) over the
+    # top-level Image, which on modern Docker is the bare local image ID
+    # ("sha256:<id>") — that has no repo to derive the versioned target tag from,
+    # so it would yield a bogus target like "sha256:0.16.0".
+    previous_image = cfg.get("Image") or info.get("Image") or ""   # the running image ref/digest
+    project    = labels.get("com.docker.compose.project")
+    cfg_files  = labels.get("com.docker.compose.project.config_files") or ""
+    working_dir = labels.get("com.docker.compose.project.working_dir")
+    service    = labels.get("com.docker.compose.service")
+    config_files = [c.strip() for c in cfg_files.split(",") if c.strip()]
+
+    # PREFLIGHT: refuse on a plain `docker run` deploy — without compose labels we
+    # have nothing to recreate from, so don't half-run.
+    if not (project and config_files and working_dir):
+        return 400, {"ok": False, "error": (
+            "This container wasn't started with docker compose (no compose labels found), "
+            "so the one-click update can't recreate it. Use the manual command instead.")}
+
+    # Derive the immutable target image ref from the image we're currently
+    # running: strip the tag/digest off the running ref to get the repo, then
+    # re-attach the versioned tag. Pulling :x.y.z (not the moving :latest) is
+    # what closes the "pull races a freshly-pushed :latest" window. A digest ref
+    # (repo@sha256:…) splits on '@'; a tag ref (repo:tag) splits on the last ':'
+    # that isn't part of a registry host:port (i.e. after the last '/').
+    repo = previous_image
+    if "@" in repo:
+        repo = repo.split("@", 1)[0]
+    else:
+        last_seg = repo.rsplit("/", 1)[-1]
+        if ":" in last_seg:
+            repo = repo.rsplit(":", 1)[0]
+    target_image = "%s:%s" % (repo, target) if repo else "%s:%s" % (SELF_UPDATE_IMAGE, target)
+
+    started_at = int(time.time())
+    state = {"state": "starting", "target": target, "target_image": target_image,
+             "previous_image": previous_image,
+             "started_at": started_at, "updated_at": started_at, "log": "update.log"}
+    try:
+        os.makedirs(_data_dir(), exist_ok=True)
+        with open(_update_state_path(), "w", encoding="utf-8") as f:
+            json.dump(state, f)
+        open(_update_log_path(), "w").close()   # truncate
+    except Exception as e:
+        return 400, {"ok": False, "error": "Cannot write to the data directory: %s" % e}
+
+    script = _self_update_script(working_dir, project, config_files, service,
+                                 target, target_image, previous_image, PORT)
+    create_body = {
+        "Image": SELF_UPDATE_HELPER_IMAGE,
+        "Cmd": ["sh", "-lc", script],
+        "HostConfig": {
+            "AutoRemove": True,
+            # Host networking so the helper's health-gate can reach the monitor at
+            # the host's localhost:9800. The monitor runs with network_mode: host,
+            # so on the default bridge the helper's "localhost" would be itself and
+            # the gate could never confirm the new version → it'd always roll back.
+            "NetworkMode": "host",
+            "Binds": [
+                "%s:/var/run/docker.sock" % DOCKER_SOCK,
+                # Mount the compose project dir at the same path inside the helper
+                # so `cd <working_dir>` works and ./data is the shared mount where
+                # update.log / update_state.json land (the app reads them back).
+                "%s:%s" % (working_dir, working_dir),
+            ],
+        },
+    }
+    # Ensure the helper image is present. On a fresh host docker:cli isn't pulled
+    # yet, so the create below would fail with "No such image". Split the ref into
+    # repo + tag the same way as the target image above: a digest splits on '@';
+    # a tag is the ':' in the *last* path segment (a ':' before the last '/' is a
+    # registry host:port, not a tag). Default tag is "latest" when none is given.
+    h_ref = SELF_UPDATE_HELPER_IMAGE
+    if "@" in h_ref:
+        h_img, h_tag = h_ref.split("@", 1)            # repo@sha256:… → pull by digest
+    else:
+        last_seg = h_ref.rsplit("/", 1)[-1]
+        if ":" in last_seg:
+            h_img, h_tag = h_ref.rsplit(":", 1)
+        else:
+            h_img, h_tag = h_ref, "latest"
+    try:
+        # The pull API streams a chunked JSON body and only finishes once the pull
+        # is done; _docker_req reads the body to completion, so create can't race
+        # it. It's a fast no-op when the image is already up to date.
+        code, raw = _docker_req("POST", "/images/create?fromImage=%s&tag=%s" % (
+            urllib.parse.quote(h_img), urllib.parse.quote(h_tag)),
+            timeout=600)
+        body_txt = raw.decode("utf-8", "replace")
+        if code not in (200, 201) or '"errorDetail"' in body_txt or '"error"' in body_txt:
+            return 400, {"ok": False, "error": "Could not pull the update helper image '%s:%s': %s" % (
+                h_img, h_tag, (body_txt[:200] if code not in (200, 201) else body_txt[-200:]))}
+    except Exception as e:
+        return 400, {"ok": False, "error": "Could not pull the update helper image '%s:%s': %s" % (h_img, h_tag, e)}
+
+    try:
+        code, raw = _docker_req("POST", "/containers/create", body=create_body)
+        if code not in (200, 201):
+            return 400, {"ok": False, "error": "Could not create the update helper (HTTP %s): %s" % (code, raw[:200].decode("utf-8", "replace"))}
+        cid = (json.loads(raw) or {}).get("Id")
+        code, raw = _docker_req("POST", "/containers/%s/start" % cid)
+        if code not in (204, 304):
+            return 400, {"ok": False, "error": "Could not start the update helper (HTTP %s)." % code}
+    except Exception as e:
+        return 400, {"ok": False, "error": "Failed to launch the update helper: %s" % e}
+
+    return 202, {"ok": True, "state": state}
 
 # ── Newer-OS-release check (endoflife.date) ───────────────────────────────────
 # The probe reports each host's pending *package* updates offline. Detecting that
@@ -5097,7 +5371,11 @@ def api_health():
                                     "containers": [], "summary": {"total": 0, "running": 0, "problems": 0}}
     systemd = HEALTH["systemd"] or {"available": False, "reason": "warming up…",
                                     "services": [], "summary": {}}
-    update  = HEALTH["update"]  or {"available": False, "current": VERSION}
+    update  = dict(HEALTH["update"] or {"available": False, "current": VERSION})
+    # Let the frontend decide whether to show the one-click "Update now" button.
+    # Set here (not baked into the cached collect_update payload) so toggling the
+    # env flag takes effect on restart without waiting for the update cache.
+    update["self_update_enabled"] = ALLOW_SELF_UPDATE
     return jsonify({"version": VERSION, "updated": HEALTH["at"], "now": now,
                     "docker": docker, "systemd": systemd, "update": update,
                     "processes": HEALTH["processes"],
@@ -5494,6 +5772,29 @@ def api_notify_test():
                              "If you see this, alerts are wired up correctly.")
     return jsonify({"ok": all(ok for _, ok, _ in results),
                     "results": [{"channel": c, "ok": ok, "error": err} for c, ok, err in results]})
+
+@app.route("/api/update/app", methods=["POST"])
+def api_update_app():
+    """Start the opt-in one-click self-update (detached docker:cli helper).
+    400 = disabled / no update / not a compose deploy; 409 = already running;
+    202 = job started. Gated by ALLOW_SELF_UPDATE — off by default."""
+    body = request.get_json(silent=True) or {}
+    force = bool(body.get("force"))
+    code, payload = start_self_update(force=force)
+    return jsonify(payload), code
+
+@app.route("/api/update/app/status")
+def api_update_app_status():
+    """Read back the self-update progress files from the data dir. Works even
+    right after the restart — it just reads update_state.json + a tail of
+    update.log. No state file yet → idle."""
+    st = _read_update_state()
+    if not st:
+        return jsonify({"state": "idle"})
+    st = dict(st)
+    st["log"] = _tail_lines(_update_log_path(), 200)
+    st["self_update_enabled"] = ALLOW_SELF_UPDATE
+    return jsonify(st)
 
 @app.route("/")
 def index():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   homelab-monitor:
     build: .
-    image: sikamikaniko123/homelab-monitor:latest
+    # MONITOR_IMAGE lets the self-update helper pin an exact image (the versioned tag for the upgrade, the previous digest for rollback); default is identical to before for a normal `docker compose up`.
+    image: ${MONITOR_IMAGE:-sikamikaniko123/homelab-monitor:latest}
     container_name: homelab-monitor
     restart: unless-stopped
     # host networking lets it reach any model server's API (Ollama/vLLM/TGI/…)
@@ -51,8 +52,12 @@ services:
       DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/run/dbus/system_bus_socket"
       # WATCH_CONTAINERS: "ollama,immich_machine_learning"  # extra containers to scan for OOM
       # WATCH_SERVICES: "tailscaled,sshd"   # always show these systemd units, even if vendor-shipped
+      # ALLOW_SELF_UPDATE: "1"              # opt-in one-click self-update button (off by default; pulls the new image, recreates & restarts this container)
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro   # container health, names & model APIs
+      # Read-write (not :ro): the opt-in self-update has to CREATE a detached
+      # docker:cli helper to recreate this container — a write API call. Plain
+      # monitoring only reads; leave :ro if you never set ALLOW_SELF_UPDATE.
+      - /var/run/docker.sock:/var/run/docker.sock      # container health, names & model APIs (+ self-update helper)
       - /:/rootfs:ro                                    # read-only host fs for disk usage
       - ./data:/data                                    # SQLite history persists here
       # systemd service health (optional): expose the host's D-Bus system socket

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -2248,6 +2248,7 @@ function openUpdateModal(up){
   // as before.
   const selfOn = !!up.self_update_enabled;
   document.getElementById('updselfbox').hidden = !selfOn;
+  document.getElementById('updmanualbox').hidden = selfOn;
   if(selfOn){ resetSelfUpdateUI(up.latest); }
 
   document.getElementById('updmodal').classList.add('show');

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1256,11 +1256,25 @@ GPU services attributed via <code>/proc/&lt;pid&gt;/cgroup</code> + the Docker A
     </div>
     <div class="bd">
       <div class="muted" id="updmeta"></div>
-      <div style="margin-top:12px">To update, run this on the host that's running the container:</div>
-      <pre class="cmd" id="updcmd">cd &lt;your-clone-dir&gt; &amp;&amp; git pull &amp;&amp; docker compose up -d --build</pre>
-      <div class="row">
-        <button class="btn" type="button" id="updcopy">📋 Copy command</button>
-        <a class="btn" id="updlink" href="#" target="_blank" rel="noopener">View on GitHub →</a>
+
+      <!-- One-click self-update (only shown when ALLOW_SELF_UPDATE is on) -->
+      <div id="updselfbox" hidden>
+        <div style="margin-top:12px">Update this container in place. It pulls the new image, recreates itself, and verifies it came back healthy — rolling back automatically if it doesn't.</div>
+        <div class="row" style="margin-top:10px">
+          <button class="btn" type="button" id="updnowbtn">⬆ Update now</button>
+        </div>
+        <div class="ins" id="updselfstatus" style="display:none"></div>
+        <pre class="cmd" id="updselflog" hidden style="max-height:220px;overflow:auto"></pre>
+      </div>
+
+      <!-- Manual fallback (always available) -->
+      <div id="updmanualbox">
+        <div style="margin-top:12px">To update, run this on the host that's running the container:</div>
+        <pre class="cmd" id="updcmd">cd &lt;your-clone-dir&gt; &amp;&amp; git pull &amp;&amp; docker compose up -d --build</pre>
+        <div class="row">
+          <button class="btn" type="button" id="updcopy">📋 Copy command</button>
+          <a class="btn" id="updlink" href="#" target="_blank" rel="noopener">View on GitHub →</a>
+        </div>
       </div>
       <div class="notes" id="updnotes" hidden></div>
     </div>
@@ -2228,9 +2242,97 @@ function openUpdateModal(up){
   } else {
     notes.hidden = true; notes.innerHTML = '';
   }
+  // One-click self-update is opt-in (ALLOW_SELF_UPDATE on the server). When it's
+  // on, offer the button; the manual command stays as a fallback below it. When
+  // it's off, the box stays hidden and only the manual command shows — exactly
+  // as before.
+  const selfOn = !!up.self_update_enabled;
+  document.getElementById('updselfbox').hidden = !selfOn;
+  if(selfOn){ resetSelfUpdateUI(up.latest); }
+
   document.getElementById('updmodal').classList.add('show');
 }
 function closeUpdateModal(){ document.getElementById('updmodal').classList.remove('show'); }
+
+// ── One-click self-update driver ──────────────────────────────────────────────
+let SELF_UPDATE_POLL = null;       // interval id while polling
+function selfUpdateStatus(level, text){   // reuses the .ins status pattern
+  const el = document.getElementById('updselfstatus');
+  el.className = 'ins ' + level; el.style.display = 'flex';
+  el.innerHTML = `<div class="ic">${ICON[level]||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
+}
+function resetSelfUpdateUI(latest){
+  if(SELF_UPDATE_POLL){ clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null; }
+  const btn = document.getElementById('updnowbtn');
+  btn.disabled = false; btn.textContent = '⬆ Update now';
+  btn.dataset.latest = latest || '';
+  document.getElementById('updselfstatus').style.display = 'none';
+  const log = document.getElementById('updselflog'); log.hidden = true; log.textContent = '';
+}
+async function startSelfUpdate(){
+  const btn = document.getElementById('updnowbtn');
+  const latest = btn.dataset.latest || '';
+  if(!confirm('Update to v'+latest+' now?\n\nThe monitor will pull the new image and restart itself. The dashboard will be briefly unavailable, then reload automatically. If the new version fails its health-check it rolls back to the current one.')) return;
+  btn.disabled = true; btn.textContent = 'Updating…';
+  document.getElementById('updselflog').hidden = false;
+  selfUpdateStatus('info', 'Starting the update…');
+  try{
+    const r = await fetch('/api/update/app', {method:'POST', headers:{'Content-Type':'application/json'}, body:'{}'});
+    const j = await r.json().catch(()=>({}));
+    if(!r.ok){
+      selfUpdateStatus('critical', (j && j.error) || ('Could not start the update (HTTP '+r.status+').'));
+      btn.disabled = false; btn.textContent = '⬆ Update now';
+      return;
+    }
+  }catch(e){
+    selfUpdateStatus('critical', 'Could not start the update: '+e);
+    btn.disabled = false; btn.textContent = '⬆ Update now';
+    return;
+  }
+  pollSelfUpdate();
+}
+function pollSelfUpdate(){
+  if(SELF_UPDATE_POLL) clearInterval(SELF_UPDATE_POLL);
+  const deadline = Date.now() + 3*60*1000;   // tolerate restart/connection-refused for ~3 min
+  const log = document.getElementById('updselflog');
+  SELF_UPDATE_POLL = setInterval(async () => {
+    let st = null;
+    try{
+      const r = await fetch('/api/update/app/status', {cache:'no-store'});
+      st = await r.json();
+    }catch(e){
+      // Expected while the container is mid-restart — keep retrying until the deadline.
+      if(Date.now() > deadline){
+        clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null;
+        selfUpdateStatus('warning', 'Lost contact with the monitor while it restarted. Reload the page to check its status.');
+      }
+      return;
+    }
+    if(st && typeof st.log === 'string'){ log.textContent = st.log; log.scrollTop = log.scrollHeight; }
+    const state = st && st.state;
+    if(state === 'done'){
+      clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null;
+      selfUpdateStatus('ok', 'Updated to v'+((st.target)||'')+'. Reloading…');
+      setTimeout(()=>location.reload(), 2500);
+    } else if(state === 'failed'){
+      clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null;
+      selfUpdateStatus('critical', (st.error||'Update failed.')+' The current version is still running.');
+      document.getElementById('updnowbtn').disabled = false;
+      document.getElementById('updnowbtn').textContent = '⬆ Update now';
+    } else if(state === 'rolled_back'){
+      clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null;
+      selfUpdateStatus('warning', 'The new version failed its health-check, so the previous version was restored. '+(st.error||''));
+      document.getElementById('updnowbtn').disabled = false;
+      document.getElementById('updnowbtn').textContent = '⬆ Update now';
+    } else {
+      selfUpdateStatus('info', state==='restarting' ? 'Restarting on the new version…' : 'Working…');
+    }
+    if(Date.now() > deadline && SELF_UPDATE_POLL){
+      clearInterval(SELF_UPDATE_POLL); SELF_UPDATE_POLL=null;
+      selfUpdateStatus('warning', 'Still working after 3 minutes — reload the page to check its status.');
+    }
+  }, 2000);
+}
 
 // ── OS-updates modal ──────────────────────────────────────────────────────────
 // Severity chips reused by the summary line and each host row, so a glance shows
@@ -4236,6 +4338,7 @@ document.getElementById('updcopy').onclick = async () => {
   b.textContent = ok ? '✓ Copied' : '⚠️ Copy failed — select and Ctrl+C';
   setTimeout(() => { b.textContent = t; }, 1800);
 };
+document.getElementById('updnowbtn').onclick = startSelfUpdate;
 showTab(TAB);
 loadData(); loadHealth(); loadFleet();
 setInterval(()=>{

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1,0 +1,171 @@
+"""Unit tests for the opt-in one-click self-update (feat/self-update).
+
+Everything that would touch real Docker (_docker_req) is stubbed, so these tests
+never create a container. We drive start_self_update() and the two routes through
+the Flask test client, overriding ALLOW_SELF_UPDATE / collect_update / _data_dir.
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+# A docker inspect payload with the compose labels start_self_update() needs.
+def _inspect_ok():
+    return (200, json.dumps({
+        "Image": "sikamikaniko123/homelab-monitor:0.16.0",
+        "Config": {"Labels": {
+            "com.docker.compose.project": "homelab",
+            "com.docker.compose.project.config_files": "/srv/homelab/docker-compose.yml",
+            "com.docker.compose.project.working_dir": "/srv/homelab",
+            "com.docker.compose.service": "homelab-monitor",
+        }},
+    }).encode())
+
+
+def _docker_stub(method, path, body=None, timeout=8):
+    """Stand-in for app._docker_req covering inspect/create/start."""
+    if method == "GET" and "/json" in path:
+        return _inspect_ok()
+    if path.startswith("/images/create"):
+        # Auto-pull of the helper image: emulate a successful streamed pull.
+        return (200, b'{"status":"Status: Image is up to date"}')
+    if path == "/containers/create":
+        return (201, b'{"Id":"deadbeef"}')
+    if path.endswith("/start"):
+        return (204, b"")
+    return (404, b"")
+
+
+class SelfUpdateBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.datadir = self._tmp.name
+        # Point the data dir (where state/log live) at a temp dir.
+        self._p_dir = patch.object(app, "_data_dir", return_value=self.datadir)
+        self._p_dir.start()
+        # Default: enabled + an update available, unless a test overrides it.
+        self._p_flag = patch.object(app, "ALLOW_SELF_UPDATE", True)
+        self._p_flag.start()
+        self._p_upd = patch.object(app, "collect_update",
+                                   return_value={"available": True, "current": "0.16.0", "latest": "0.17.0"})
+        self._p_upd.start()
+        self._p_req = patch.object(app, "_docker_req", side_effect=_docker_stub)
+        self._p_req.start()
+
+    def tearDown(self):
+        patch.stopall()
+        self._tmp.cleanup()
+
+    def _state_path(self):
+        return os.path.join(self.datadir, "update_state.json")
+
+    def _write_state(self, state, age_sec=0):
+        with open(self._state_path(), "w") as f:
+            json.dump({"state": state, "target": "0.17.0",
+                       "updated_at": int(time.time()) - age_sec}, f)
+
+
+class TestStartGating(SelfUpdateBase):
+    def test_disabled_returns_400(self):
+        with patch.object(app, "ALLOW_SELF_UPDATE", False):
+            code, payload = app.start_self_update()
+        self.assertEqual(code, 400)
+        self.assertFalse(payload["ok"])
+
+    def test_no_update_returns_400(self):
+        with patch.object(app, "collect_update",
+                          return_value={"available": False, "current": "0.17.0"}):
+            code, payload = app.start_self_update()
+        self.assertEqual(code, 400)
+        self.assertFalse(payload["ok"])
+
+    def test_fresh_job_returns_409(self):
+        self._write_state("restarting", age_sec=10)
+        code, payload = app.start_self_update()
+        self.assertEqual(code, 409)
+        self.assertFalse(payload["ok"])
+
+    def test_stale_job_is_allowed(self):
+        # Older than 15 min → treated as abandoned, a new run is permitted.
+        self._write_state("restarting", age_sec=20 * 60)
+        code, payload = app.start_self_update()
+        self.assertEqual(code, 202)
+        self.assertTrue(payload["ok"])
+
+    def test_terminal_job_does_not_block(self):
+        self._write_state("done", age_sec=10)
+        code, payload = app.start_self_update()
+        self.assertEqual(code, 202)
+        self.assertTrue(payload["ok"])
+
+    def test_missing_compose_labels_returns_400(self):
+        def _no_labels(method, path, body=None, timeout=8):
+            if method == "GET" and "/json" in path:
+                return (200, json.dumps({"Image": "img", "Config": {"Labels": {}}}).encode())
+            return _docker_stub(method, path, body, timeout)
+        with patch.object(app, "_docker_req", side_effect=_no_labels):
+            code, payload = app.start_self_update()
+        self.assertEqual(code, 400)
+        self.assertIn("compose", payload["error"].lower())
+
+    def test_success_writes_state_and_truncates_log(self):
+        code, payload = app.start_self_update()
+        self.assertEqual(code, 202)
+        st = json.load(open(self._state_path()))
+        self.assertEqual(st["state"], "starting")
+        self.assertEqual(st["target"], "0.17.0")
+        self.assertTrue(os.path.exists(os.path.join(self.datadir, "update.log")))
+
+
+class TestRoutes(SelfUpdateBase):
+    def setUp(self):
+        super().setUp()
+        self.client = app.app.test_client()
+
+    def test_post_disabled_400(self):
+        with patch.object(app, "ALLOW_SELF_UPDATE", False):
+            rv = self.client.post("/api/update/app", json={})
+        self.assertEqual(rv.status_code, 400)
+        self.assertFalse(rv.get_json()["ok"])
+
+    def test_post_no_update_400(self):
+        with patch.object(app, "collect_update",
+                          return_value={"available": False, "current": "0.17.0"}):
+            rv = self.client.post("/api/update/app", json={})
+        self.assertEqual(rv.status_code, 400)
+
+    def test_post_already_running_409(self):
+        self._write_state("restarting", age_sec=5)
+        rv = self.client.post("/api/update/app", json={})
+        self.assertEqual(rv.status_code, 409)
+
+    def test_post_starts_202(self):
+        rv = self.client.post("/api/update/app", json={})
+        self.assertEqual(rv.status_code, 202)
+        self.assertTrue(rv.get_json()["ok"])
+
+    def test_status_idle_when_no_file(self):
+        rv = self.client.get("/api/update/app/status")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.get_json()["state"], "idle")
+
+    def test_status_returns_state_file(self):
+        self._write_state("done", age_sec=1)
+        with open(os.path.join(self.datadir, "update.log"), "w") as f:
+            f.write("line1\nline2\n")
+        rv = self.client.get("/api/update/app/status")
+        body = rv.get_json()
+        self.assertEqual(body["state"], "done")
+        self.assertEqual(body["target"], "0.17.0")
+        self.assertIn("line2", body["log"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/configuration.md
+++ b/website/configuration.md
@@ -23,7 +23,46 @@ Set these under `environment:` in `docker-compose.yml`. All optional.
 | `WATCH_CONTAINERS` | *(empty)* | Comma-separated container names to always scan for OOM events, even if not GPU-attributed. |
 | `WATCH_SERVICES` | *(empty)* | Comma-separated systemd units to always surface in the Services tab. |
 | `CHECK_UPDATES` | `true` | Whether to poll GitHub releases for "update available" banner. |
+| `ALLOW_SELF_UPDATE` | *(off)* | Opt-in. Adds an **Update now** button to the update modal that pulls the new image, recreates this container, and restarts it (rolling back automatically if the new version fails its health-check). Off by default — see note below. |
+| `SELF_UPDATE_HELPER_IMAGE` | `docker:cli` | Image used for the short-lived detached helper that runs `docker compose` to recreate the container during a self-update. Override only if `docker:cli` isn't reachable in your registry. |
+| `MONITOR_IMAGE` | *(unset)* | Used **internally** by the self-update flow to pin an exact image — the versioned `:x.y.z` tag for the upgrade, the previous image ref/digest for a rollback. You normally never set this by hand; left unset, the shipped compose file falls back to the usual `sikamikaniko123/homelab-monitor:latest`. |
 | `SSH_DIR` | `/data/.ssh` | Where the multi-host SSH keypair lives. Persists across rebuilds. |
+
+### One-click self-update (`ALLOW_SELF_UPDATE`)
+
+This is the first and only action in the monitor that **writes** — everything
+else is read-only. It is therefore **off by default** and must be opted into:
+
+```yaml
+environment:
+  ALLOW_SELF_UPDATE: "1"
+volumes:
+  # Must be read-write (drop the :ro) — creating the update helper is a write
+  # API call. Leave it :ro if you don't enable self-update.
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
+When enabled and a newer release exists, the update modal shows an **Update now**
+button. On click (after a confirm) it pulls the new image, launches a detached
+`docker:cli` helper that recreates this container via your compose file, and the
+helper health-checks the result: if the new version doesn't report itself healthy
+within ~60s it rolls back to the image that was running. The dashboard streams the
+log live and reloads itself once the new version is up.
+
+Requirements / caveats:
+
+- The docker socket must be mounted **read-write** (not `:ro`).
+- The container must have been started with **docker compose** (the helper reads
+  the compose project labels to know what to recreate). A plain `docker run`
+  deploy is refused with a clear message — use the manual command instead.
+- The container **restarts**, so the dashboard is briefly unavailable.
+- For the upgrade to pull the **exact** target version (and for a rollback to
+  restore the **exact** previous image), your compose file's image line must use
+  the `image: ${MONITOR_IMAGE:-sikamikaniko123/homelab-monitor:latest}` form —
+  which the shipped `docker-compose.yml` now does. The helper sets `MONITOR_IMAGE`
+  to the immutable `:x.y.z` tag for the pull/up and to the previous image
+  ref/digest on rollback; with a hardcoded `:latest` image line, pinning and
+  rollback would silently degrade to re-pulling `:latest`.
 
 ## Alerts (configured in the UI)
 
@@ -61,7 +100,8 @@ the [repo](https://github.com/SikamikanikoBG/homelab-monitor/blob/main/docker-co
 ```yaml
 services:
   homelab-monitor:
-    image: sikamikaniko123/homelab-monitor:latest
+    # ${MONITOR_IMAGE:-…} lets the self-update flow pin/rollback an exact image
+    image: ${MONITOR_IMAGE:-sikamikaniko123/homelab-monitor:latest}
     container_name: homelab-monitor
     restart: unless-stopped
     network_mode: host          # for direct LAN access + model-server APIs

--- a/website/install.md
+++ b/website/install.md
@@ -30,6 +30,14 @@ Open **`http://<your-host-ip>:9800`** from any device on your LAN or VPN.
     ```
     Your SQLite history at `./data/gpu.db` survives — it's a bind mount.
 
+??? tip "Updating from the dashboard (opt-in)"
+    The commands above are the default way to update. If you'd rather press a
+    button, set `ALLOW_SELF_UPDATE: "1"` and mount the docker socket read-write
+    (drop the `:ro`). When a newer release exists, the update modal then shows an
+    **Update now** button that pulls the new image, recreates the container, and
+    rolls back automatically if the new version fails its health-check. It's off
+    by default — see [Configuration → One-click self-update](configuration.md#one-click-self-update-allow_self_update).
+
 ## Option B — from source
 
 Handy if you're tweaking the code or contributing:

--- a/website/mcp.md
+++ b/website/mcp.md
@@ -14,9 +14,13 @@ It's a thin, well-described wrapper over the monitor's existing **read-only** HT
 endpoints. No collectors are touched, and **nothing is mutated**.
 
 !!! info "Read-only by design"
-    There are no write tools. Any future write capability (run a probe, restart a
-    container, apply an OS update) must be opt-in, clearly labelled destructive, and
-    gated behind explicit config — same philosophy as the rest of the project.
+    There are no write tools in the MCP server. The monitor's **first and only**
+    write action is the opt-in one-click self-update — it lives in the dashboard,
+    is **off by default** (`ALLOW_SELF_UPDATE`), needs the docker socket mounted
+    read-write, and asks for confirmation before it recreates the container. It
+    sets the bar for any future write capability: opt-in, explicitly gated, and
+    clearly labelled — same philosophy as the rest of the project. It is **not**
+    exposed as an MCP tool.
 
 ## Tools
 


### PR DESCRIPTION
## What this changes

Adds an opt-in **"Update now"** button to the update modal. When clicked, the monitor pulls the latest release image, recreates itself, verifies it came back healthy, and rolls back to the previous image automatically if it doesn't. Live progress and logs are streamed in the UI so you can watch it happen without leaving the dashboard.

Closes #141

## How it works

A container can't recreate itself in-process (the process dies mid-swap), so a detached `docker:cli` helper container runs the project's own compose file:
- `MONITOR_IMAGE=<repo>:<version> docker compose pull` — pulls the immutable versioned tag, not the moving `:latest`
- `docker compose up -d --no-build` — recreates the service
- Health-gates on `GET /api/health` for ~60s; if the new container isn't healthy or reports the wrong version, it redeploys the **previous image digest** and reports `rolled_back`

Progress is written to `./data/update_state.json` + `./data/update.log` so the UI survives the restart and reconnects cleanly.

Off by default (`ALLOW_SELF_UPDATE=1` to enable). When disabled, the modal keeps the existing manual command. When enabled, the manual command is hidden (redundant).

## New surface

- `POST /api/update/app` — starts the update; 400 if disabled/no-update/not-a-compose-deploy, 409 if already running
- `GET /api/update/app/status` — returns state + log tail; readable across restarts since it just reads `./data`
- `update.self_update_enabled` added to `/api/health`
- `docker-compose.yml`: socket changed `:ro` → rw (needed to create the helper); `image` parameterised as `${MONITOR_IMAGE:-…:latest}` so rollback can pin the previous digest; commented `ALLOW_SELF_UPDATE` env line added

## How to test before merging

The setup below fakes the running version to 0.15.0 so the real v0.16.0 release shows as an available update, using a local registry as the pull target — no published image needed.

```bash
# Prerequisites: Docker, ports 9800 and 5000 free
git clone https://github.com/pehota/homelab-monitor.git -b feat/self-update
cd homelab-monitor
DEMO=/tmp/hlm-pr-test; mkdir -p $DEMO/data

# Build base image
docker build -t hlm-pr-base .

# Build two versioned images and push to a local registry
docker run -d -p 5000:5000 --name hlm-pr-registry registry:2
for v in 0.15.0 0.16.0; do
  printf "FROM hlm-pr-base\nRUN sed -i 's/VERSION      = \"0.17.0-next\"/VERSION      = \"$v\"/' /app/app.py\n" \
    | docker build -t localhost:5000/homelab-monitor:$v -f - .
  docker push localhost:5000/homelab-monitor:$v
done
docker pull docker:cli   # helper image used during update

# Deploy the "current" 0.15.0 version
cat > $DEMO/docker-compose.yml <<'YAML'
services:
  hlmtest:
    image: ${MONITOR_IMAGE:-localhost:5000/homelab-monitor:0.15.0}
    container_name: hlmtest
    network_mode: host
    environment:
      HOSTNAME: hlmtest
      PORT: "9800"
      ENABLE_MCP: "0"
      DB_PATH: /data/gpu.db
      SSH_DIR: /data/.ssh
      ALLOW_SELF_UPDATE: "1"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ./data:/data
YAML
cd $DEMO && docker compose -p hlmtest up -d
sleep 8 && curl -s localhost:9800/healthz   # should report 0.15.0
```

**Happy path** — open http://localhost:9800, click the version badge, hit **Update now**. Watch the log stream `pulling → recreating → healthy on v0.16.0`. The page reloads showing 0.16.0 with no update available.

**Pull-failure path** — redeploy 0.15.0, then trigger an update against a nonexistent tag:
```bash
cd $DEMO && MONITOR_IMAGE=localhost:5000/homelab-monitor:0.15.0 docker compose -p hlmtest up -d --force-recreate
rm -f $DEMO/data/update_state.json $DEMO/data/update.log
# Temporarily rename the 0.16.0 image so the pull fails
docker rmi localhost:5000/homelab-monitor:0.16.0
curl -s -X POST localhost:9800/api/update/app
sleep 5 && cat $DEMO/data/update_state.json  # should show state:failed
curl -s localhost:9800/healthz               # still 0.15.0 — old container untouched
```

**Cleanup:**
```bash
cd $DEMO && docker compose -p hlmtest down -v
docker rm -f hlm-pr-registry
docker rmi localhost:5000/homelab-monitor:0.15.0 localhost:5000/homelab-monitor:0.16.0 hlm-pr-base docker:cli registry:2 2>/dev/null || true
rm -rf $DEMO
```

## Checklist

- [x] **Base branch is `next`**
- [x] Branched off the latest `next`
- [x] Tested locally with `docker compose up -d --build` — including a full end-to-end self-update (pull → recreate → health-gate → `done`) and the pull-failure path (`failed`, old container untouched)
- [x] No version bump in this PR

## Notes for the reviewer

Four bugs were caught only by the live end-to-end test (static audit + stubbed unit tests all missed them): helper network mode (bridge → host so health-gate can reach the monitor), `previous_image` source (bare image ID → deploy ref), health-gate URL (`localhost` → `127.0.0.1`, Flask binds IPv4 only), and missing auto-pull of the `docker:cli` helper image on first use. All fixed and covered by `tests/test_self_update.py` (13 tests, Docker calls stubbed).

The one path not exercised by automated tests: an actual rollback from a genuinely unhealthy new image. The rollback shell logic was statically audited and the `MONITOR_IMAGE` pinning was proven to work by the e2e; a broken-image rollback test would need a local registry and a deliberately crashing image.