### PR TITLE
fix: restore :ro socket default; move self-update rw into an override file

### DIFF
--- a/docker-compose.self-update.yml
+++ b/docker-compose.self-update.yml
@@ -1,0 +1,16 @@
+# Opt-in self-update override — use alongside docker-compose.yml:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.self-update.yml up -d
+#
+# This upgrades the docker socket from :ro to read-write (needed to create the
+# detached docker:cli helper that recreates this container) and enables the
+# "Update now" button. The main compose keeps :ro so plain monitoring deployments
+# are unaffected.
+services:
+  homelab-monitor:
+    environment:
+      ALLOW_SELF_UPDATE: "1"
+    volumes:
+      # Override the :ro socket with read-write so the self-update helper can
+      # be created via the Docker API.
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,9 @@ services:
       DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/run/dbus/system_bus_socket"
       # WATCH_CONTAINERS: "ollama,immich_machine_learning"  # extra containers to scan for OOM
       # WATCH_SERVICES: "tailscaled,sshd"   # always show these systemd units, even if vendor-shipped
-      # ALLOW_SELF_UPDATE: "1"              # opt-in one-click self-update button (off by default; pulls the new image, recreates & restarts this container)
+      # ALLOW_SELF_UPDATE is set by docker-compose.self-update.yml — use that override to enable the one-click update button
     volumes:
-      # Read-write (not :ro): the opt-in self-update has to CREATE a detached
-      # docker:cli helper to recreate this container — a write API call. Plain
-      # monitoring only reads; leave :ro if you never set ALLOW_SELF_UPDATE.
-      - /var/run/docker.sock:/var/run/docker.sock      # container health, names & model APIs (+ self-update helper)
+      - /var/run/docker.sock:/var/run/docker.sock:ro   # container health, names & model APIs
       - /:/rootfs:ro                                    # read-only host fs for disk usage
       - ./data:/data                                    # SQLite history persists here
       # systemd service health (optional): expose the host's D-Bus system socket

--- a/website/configuration.md
+++ b/website/configuration.md
@@ -31,16 +31,17 @@ Set these under `environment:` in `docker-compose.yml`. All optional.
 ### One-click self-update (`ALLOW_SELF_UPDATE`)
 
 This is the first and only action in the monitor that **writes** — everything
-else is read-only. It is therefore **off by default** and must be opted into:
+else is read-only. It is therefore **off by default** and must be opted into
+using the bundled override file:
 
-```yaml
-environment:
-  ALLOW_SELF_UPDATE: "1"
-volumes:
-  # Must be read-write (drop the :ro) — creating the update helper is a write
-  # API call. Leave it :ro if you don't enable self-update.
-  - /var/run/docker.sock:/var/run/docker.sock
+```bash
+docker compose -f docker-compose.yml -f docker-compose.self-update.yml up -d
 ```
+
+`docker-compose.self-update.yml` sets `ALLOW_SELF_UPDATE: "1"` and upgrades the
+docker socket from `:ro` to read-write (needed to create the update helper). The
+main `docker-compose.yml` keeps `:ro` so plain monitoring deployments are
+unaffected.
 
 When enabled and a newer release exists, the update modal shows an **Update now**
 button. On click (after a confirm) it pulls the new image, launches a detached
@@ -51,7 +52,8 @@ log live and reloads itself once the new version is up.
 
 Requirements / caveats:
 
-- The docker socket must be mounted **read-write** (not `:ro`).
+- The docker socket must be mounted **read-write** (not `:ro`) — handled
+  automatically by the override file.
 - The container must have been started with **docker compose** (the helper reads
   the compose project labels to know what to recreate). A plain `docker run`
   deploy is refused with a clear message — use the manual command instead.

--- a/website/install.md
+++ b/website/install.md
@@ -32,11 +32,14 @@ Open **`http://<your-host-ip>:9800`** from any device on your LAN or VPN.
 
 ??? tip "Updating from the dashboard (opt-in)"
     The commands above are the default way to update. If you'd rather press a
-    button, set `ALLOW_SELF_UPDATE: "1"` and mount the docker socket read-write
-    (drop the `:ro`). When a newer release exists, the update modal then shows an
-    **Update now** button that pulls the new image, recreates the container, and
-    rolls back automatically if the new version fails its health-check. It's off
-    by default — see [Configuration → One-click self-update](configuration.md#one-click-self-update-allow_self_update).
+    button, use the bundled override file:
+    ```bash
+    docker compose -f docker-compose.yml -f docker-compose.self-update.yml up -d
+    ```
+    When a newer release exists, the update modal then shows an **Update now**
+    button that pulls the new image, recreates the container, and rolls back
+    automatically if the new version fails its health-check. It's off by default
+    — see [Configuration → One-click self-update](configuration.md#one-click-self-update-allow_self_update).
 
 ## Option B — from source
 


### PR DESCRIPTION
## What this changes

Follow-up to #142, addressing the reviewer's note: the main `docker-compose.yml` should keep the docker socket `:ro` by default, and only self-update users should opt into read-write.

Restores `:ro` in `docker-compose.yml` and ships a new `docker-compose.self-update.yml` override file. Self-update users enable it with:

```bash
docker compose -f docker-compose.yml -f docker-compose.self-update.yml up -d
```

Plain monitoring deployments are entirely unaffected — they keep the read-only socket.

## Checklist

- [x] **Base branch is `next`**
- [x] Branched off the latest `next`
- [x] `docker compose -f docker-compose.yml -f docker-compose.self-update.yml config` parses cleanly
- [x] No version bump in this PR