### PR TITLE
docs(readme): add Discord button + Community section to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🛰️ HomeLab Monitor
 
 [![GitHub stars](https://img.shields.io/github/stars/SikamikanikoBG/homelab-monitor?style=social)](https://github.com/SikamikanikoBG/homelab-monitor/stargazers)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/yFEf3N2mb9)
 [![version](https://img.shields.io/github/v/release/SikamikanikoBG/homelab-monitor?color=blue&label=version)](CHANGELOG.md)
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![docker](https://img.shields.io/badge/deploy-docker--compose-2496ED?logo=docker&logoColor=white)
@@ -123,6 +124,14 @@ If HomeLab Monitor saves you a browser tab or two, a ⭐ on GitHub genuinely hel
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=SikamikanikoBG/homelab-monitor&type=date&legend=top-left" />
  </picture>
 </a>
+
+## 💬 Community
+
+Building this is more fun together. **[Join the HomeLab Monitor Discord](https://discord.gg/yFEf3N2mb9)** — say hi, show off your rig, swap ideas, ask for help, or just hang out. It's where the roadmap chatter, “should we build X?” questions, and quick help happen — and where new contributors get a warm welcome.
+
+[![Join the Discord](https://img.shields.io/badge/Discord-join%20the%20chat-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/yFEf3N2mb9)
+
+Bring a friend, post an idea, open an issue — let's grow a friendly, healthy homelab community. 💛
 
 ## Contributing
 


### PR DESCRIPTION
## What
Brings the **Discord entry points** that already live on `next` to the released README on `main`, so visitors landing on the default branch (and the Docker Hub README, which is generated from `main`) get an obvious way to join the server.

## Changes (+9 lines, README only)
- **Top Discord badge** in the badge row, right after the GitHub-stars badge.
- **`## 💬 Community` section** (between *Support the project* and *Contributing*) with the intro line, the big "Join the Discord" badge, and the closing line.

Both use the **permanent invite** `discord.gg/yFEf3N2mb9` (the one PR #146 fixed on `next`).

## Notes
- README-only, no logic. The `🛰️` heading on `main` is intentionally left as-is (the radar-logo swap is a separate `next` change, out of scope here).
- Once merged, the GitHub repo homepage and the Docker Hub README (next push to `main`) show the Join-the-Discord button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)