### PR TITLE
feat(mcp): Costs & Experiments over MCP (16 tools) — cut v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,33 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
-## [Unreleased] — `next`
+## [0.17.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.0) — 2026-06-18 · **Ask Your Homelab**
+*Costs and experiments are now MCP tools — so Claude (or any AI) can tell you what last night cost. Plus: the dashboard speaks your language, and can update itself.*
 
-### Added
-- **Community: we're on Discord.** A "Join the Discord" button in the dashboard sidebar (a small social bar, ready to grow as more channels go live) and a Community section + badge in the README. Come chat, share ideas, and help shape the roadmap: <https://discord.gg/tpKWKEdSQN>
+> 0.16 turned HomeLab Monitor into the **AI Lab Cockpit** — GPU, models and the power bill on one page. 0.17 makes that cockpit **conversational and personal**: your AI can now read the costs and the experiment runs straight over MCP, the whole UI can speak another language, and the dashboard can upgrade itself in one click. Still pure Python + Flask, no new dependencies.
 
-### Changed
-- **New logo — radar, not satellite.** A designed radar mark is now *the* logo everywhere instead of a generic line-icon: dashboard sidebar brand + page header, favicon, README title, and the docs site. Two variants of the same artwork — a **transparent** radar for the dark in-app / docs UI (so it pops), and a **tiled** app-icon for the favicon and README. Radar fits what the tool actually does — sweep the fleet, surface the blips. The old satellite glyph is gone; section headings keep their own topical icons (e.g. "All hosts" now uses the monitor glyph) so the radar reads only as the brand.
+**Ask your AI what it costs (MCP)**
+- The built-in **read-only MCP server** gains four tools so an agent can finally see the money side of the lab: `get_costs` (machine draw + cost, with a ranked per-process / container / service / model breakdown), `get_entity_cost` (drill into one line item), and `get_experiments` / `get_experiment` (tracked runs priced by the **real GPU energy they burned** — loss curve and watts on the same timeline). **16 tools total**, still **nothing mutated**. Ask *"what did my homelab cost last night, and which model is the most expensive thing on the GPU?"* and let it pick the tools.
 
-### Fixed
-- The brand logo 404'd in the container — `static/logo.svg` wasn't copied into the image. The Dockerfile now copies the whole `static/` dir instead of listing files one by one, so a new static asset can never be silently left out again.
+**Make it yours — in your language**
+- A full **internationalisation framework**: every tab, modal, toast and helper string is translatable, served from `/locales` and shipped in the image. **Simplified Chinese (zh-CN)** is the first complete translation (96% coverage). Closes #148.
+
+**A dashboard that maintains itself**
+- **One-click self-update** from the dashboard — opt-in, **off by default** (`ALLOW_SELF_UPDATE`), confirmation-gated, and the monitor's *first and only* write action. It is **not** exposed over MCP. Closes #142.
+- **Toast notifications** — every action confirms itself with a quick, dismissible toast instead of a silent state change. Closes #139.
+
+**Brand & community**
+- **New logo — radar, not satellite.** A designed radar mark is now *the* brand everywhere — sidebar, header, favicon, README and the docs site — in a transparent variant for the dark UI and a tiled app-icon for the favicon. Radar fits what the tool does: sweep the fleet, surface the blips.
+- **Community** — a "Join the Discord" button and a permanent invite in the sidebar, a "Buy me a coffee" support button, and a live Docker-pulls badge in the README. Come help shape the roadmap: <https://discord.gg/tpKWKEdSQN>
+
+**Fixed**
+- Network › Throughput legend filter no longer resets on every auto-refresh (#155).
+- Clearer **Topology / Machine** card labels on System › Hardware (#154).
+- The offline "What's new" changelog now renders italics, blockquotes and the bold subtitle (#173).
+- Bulgaria (BG) tariffs switched from BGN to EUR (#145).
+- The brand logo no longer 404s in the container — the Dockerfile copies the whole `static/` dir instead of listing files one by one.
+
+The unfinished personalisation items from the "Make it yours" epic (#147) — reorderable tabs (#33), the AI Models Hall of Fame (#23) and per-service notification rules (#24) — carry forward to the next cycle.
 
 ## [0.16.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.16.0) — 2026-06-14 · **The AI Lab Cockpit**
 *Your GPU, your models, and your power bill — finally on the same page.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ release notes.
 
 The unfinished personalisation items from the "Make it yours" epic (#147) — reorderable tabs (#33), the AI Models Hall of Fame (#23) and per-service notification rules (#24) — carry forward to the next cycle.
 
+**Thanks to**
+This release leaned hard on the community — it wouldn't be what it is without them.
+- **@pehota** — one-click self-update (off by default), a socket-safety fix, and migrated Bulgaria's tariffs to EUR
+- **@krishnapandey1504** — built the unified toast notification system
+- **@DevCrox** — wired the dashboard's status messages onto the new toast system
+- **@laishettikarthik-tech** — fixed the network throughput legend filter resetting on refresh
+- **@koteshyelamati** — clearer Topology / Machine card labels
+
+Five external contributors on one release. 🙏
+
 ## [0.16.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.16.0) — 2026-06-14 · **The AI Lab Cockpit**
 *Your GPU, your models, and your power bill — finally on the same page.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
-## [0.17.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.0) — 2026-06-18 · **Ask Your Homelab**
-*Costs and experiments are now MCP tools — so Claude (or any AI) can tell you what last night cost. Plus: the dashboard speaks your language, and can update itself.*
+## [0.17.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.0) — 2026-06-18 · **Ask Your Homelab — over MCP**
+*Costs and experiments are now MCP tools, so Claude (or any AI) can tell you what last night cost. Bonus: it speaks Chinese now, and updates itself.*
 
 > 0.16 turned HomeLab Monitor into the **AI Lab Cockpit** — GPU, models and the power bill on one page. 0.17 makes that cockpit **conversational and personal**: your AI can now read the costs and the experiment runs straight over MCP, the whole UI can speak another language, and the dashboard can upgrade itself in one click. Still pure Python + Flask, no new dependencies.
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.17.0-next"
+VERSION      = "0.17.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))

--- a/locales/en.json
+++ b/locales/en.json
@@ -506,7 +506,7 @@
   "logdrawer.copy_all_t": "Copy all logs",
   "logdrawer.close_t": "Close (Esc)",
   "diag.fleet_meta": "What the monitor can see on this hub, and how to enable anything that's missing. The dashboard keeps running even when optional pieces aren't mounted — no GPU required.",
-  "mcp.card_desc": "A read-only <a href=\"https://modelcontextprotocol.io\" target=\"_blank\" rel=\"noopener\">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity. <span id=\"mcpstatus\"></span>",
+  "mcp.card_desc": "A read-only <a href=\"https://modelcontextprotocol.io\" target=\"_blank\" rel=\"noopener\">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity, right down to what each model and container costs to run. <span id=\"mcpstatus\"></span>",
   "mcp.connect_hint": "Connect with the Claude CLI (then ask it about your fleet):",
   "mcp.docs": "MCP docs →",
   "gpu.vram_alloc": "VRAM allocation",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -531,7 +531,7 @@
   "logdrawer.copy_all_t": "复制所有日志",
   "logdrawer.close_t": "关闭 (Esc)",
   "diag.fleet_meta": "监控在此 hub 上能看到什么，以及如何启用缺失的部分。即使可选组件未挂载，仪表盘仍可运行 — 无需 GPU。",
-  "mcp.card_desc": "内置了一个只读的 <a href=\"https://modelcontextprotocol.io\" target=\"_blank\" rel=\"noopener\">MCP</a> 服务，因此 Claude — 或任何 MCP 客户端 — 都能连接并以完整的仪表盘视图探索这个家庭实验室。<span id=\"mcpstatus\"></span>",
+  "mcp.card_desc": "内置了一个只读的 <a href=\"https://modelcontextprotocol.io\" target=\"_blank\" rel=\"noopener\">MCP</a> 服务，因此 Claude — 或任何 MCP 客户端 — 都能连接并以完整的仪表盘视图探索这个家庭实验室，乃至每个模型和容器的运行成本。<span id=\"mcpstatus\"></span>",
   "mcp.connect_hint": "使用 Claude CLI 连接（然后向它询问你的主机群）：",
   "mcp.docs": "MCP 文档 →",
   "gpu.vram_alloc": "VRAM 分配",

--- a/mcp/homelab_client.py
+++ b/mcp/homelab_client.py
@@ -335,6 +335,104 @@ def get_history(range="6h"):
     }
 
 
+# ── costs & experiments (the AI Lab Cockpit, over MCP) ───────────────────────
+
+def get_costs(range="7d"):
+    """Power-cost summary for the hub (the Costs tab): what the machine drew and
+    what it cost over `range`, plus the ranked list of which processes, containers,
+    services and models cost the most.
+
+    Returns `currency` and `tariff` (flat, or a day/night split), the `machine`
+    totals (`now_w` live draw, `energy_kwh`, and `cost` windows for today/7d/30d
+    plus `cost_range` for the selected window), and `breakdown` — the top energy
+    consumers, each with `kind`, `name`, `energy_kwh`, `cost` and `avg_w`.
+    `enabled` is False when no tariff is configured (energy is still reported,
+    cost reads 0). Answers "what did my homelab cost, and what's the biggest line
+    item?". The per-bucket stacked-area chart is omitted to keep this compact.
+    """
+    d = _get("/api/costs?range=" + urllib.parse.quote(str(range)))
+    machines = d.get("machines") or []
+    m = machines[0] if machines else {}
+    return {
+        "range": d.get("range", range),
+        "enabled": d.get("enabled"),
+        "currency": d.get("currency"),
+        "rapl_available": d.get("rapl_available"),
+        "tariff": d.get("tariff"),
+        "machine": {
+            "now_w": m.get("now_w"),
+            "energy_kwh": m.get("energy_kwh"),
+            "cost": m.get("cost"),
+            "cost_range": m.get("cost_range"),
+            "measured": m.get("measured"),
+            "estimated": m.get("estimated"),
+        },
+        "breakdown": d.get("breakdown") or [],
+    }
+
+
+def get_entity_cost(name, kind="", range="7d"):
+    """Cost drill-down for one process / container / service / model by `name`
+    (the Costs tab's click-through). Pass the `kind`/`name` pair from
+    `get_costs`' breakdown; `kind` is optional but disambiguates same-named rows.
+
+    Returns `energy_kwh` and `cost` over `range`, the `avg_w`/`peak_w` it drew,
+    and `resources` (e.g. peak GPU VRAM). Answers "what did *this* model/container
+    cost me?". The per-bucket cost-curve series is omitted to keep this compact.
+    """
+    q = "?name=" + urllib.parse.quote(str(name)) + "&range=" + urllib.parse.quote(str(range))
+    if kind:
+        q += "&kind=" + urllib.parse.quote(str(kind))
+    d = _get("/api/costs/entity" + q)
+    return {
+        "name": d.get("name", name),
+        "kind": d.get("kind", kind),
+        "range": d.get("range", range),
+        "currency": d.get("currency"),
+        "energy_kwh": d.get("energy_kwh"),
+        "cost": d.get("cost"),
+        "avg_w": d.get("avg_w"),
+        "peak_w": d.get("peak_w"),
+        "resources": d.get("resources"),
+    }
+
+
+def get_experiments(range="7d", status=""):
+    """Tracked training/eval runs (the Experiments tab), each priced with the real
+    GPU energy it burned. Optionally filter by `status` (running / finished /
+    failed / killed).
+
+    Returns one row per run: `id`, `name`, `source` (sdk/mlflow/…), `status`,
+    `started_at`/`ended_at`/`duration`, `host`, `params`, `tags`,
+    `metrics_latest` (the last value logged per metric — e.g. loss/accuracy), and
+    the energy it cost: `energy_kwh`, `cost`, `avg_w`, `peak_util`. Answers "which
+    runs ran, how did they do, and what did each one cost?".
+    """
+    q = "?range=" + urllib.parse.quote(str(range))
+    if status:
+        q += "&status=" + urllib.parse.quote(str(status))
+    d = _get("/api/runs" + q)
+    runs = d.get("runs") or []
+    return {
+        "range": d.get("range", range),
+        "currency": d.get("currency"),
+        "tariff_mode": d.get("tariff_mode"),
+        "count": len(runs),
+        "runs": runs,
+    }
+
+
+def get_experiment(run_id):
+    """Full detail for one tracked run by `run_id` (from `get_experiments`).
+
+    Returns its logged-metric series (`metrics`: per-key steps/ts/values — the
+    loss curve), the GPU `resource` time-series (`power_w`/`util_pct` over the
+    run), and the priced energy it burned (`energy_kwh`, `cost`, `avg_w`,
+    `peak_util`). An unknown id surfaces as an HTTP 404 error.
+    """
+    return _get("/api/runs/" + urllib.parse.quote(str(run_id)))
+
+
 def scan_disk(path="/", rescan=False, max_wait=60):
     """WizTree-style nested folder-size treemap for a host path (the Disks tab).
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -55,8 +55,11 @@ INSTRUCTIONS = (
     "tools: `get_containers` and `get_services` (full Docker/systemd lists), "
     "`get_memory` (per-service/per-process RAM breakdown), `get_gpu` (utilisation, "
     "per-model VRAM, and who's driving it), `get_ai_models` (loaded models), "
-    "`get_history` (charted time-series), `get_events`/`get_alerts` (OOM kills / "
-    "threshold crossings), and `scan_disk(path)` (WizTree-style folder treemap). "
+    "`get_history` (charted time-series), `get_costs`/`get_entity_cost` (power "
+    "turned into money, per machine and per process/container/service/model), "
+    "`get_experiments`/`get_experiment` (tracked runs priced by the GPU energy they "
+    "burned), `get_events`/`get_alerts` (OOM kills / threshold crossings), and "
+    "`scan_disk(path)` (WizTree-style folder treemap). "
     "Resources expose Prometheus `/metrics`, `/healthz` and the CHANGELOG. This "
     "server never mutates the fleet."
 )
@@ -177,6 +180,50 @@ def get_ai_models(range: str = "6h") -> dict:
     "24h", "7d"). Answers "why is the GPU pinned, and which service is calling it?".
     """
     return hc.get_ai_models(range)
+
+
+@mcp.tool()
+@_track
+def get_costs(range: str = "7d") -> dict:
+    """Power-cost summary for the hub (Costs tab): what the machine drew and what it
+    cost over `range`, with the live `tariff`, the `machine` totals (now/energy/cost
+    for today, 7d, 30d and the range) and a ranked `breakdown` of which processes,
+    containers, services and models cost the most. Answers "what did my homelab cost,
+    and what's the biggest line item?".
+    """
+    return hc.get_costs(range)
+
+
+@mcp.tool()
+@_track
+def get_entity_cost(name: str, kind: str = "", range: str = "7d") -> dict:
+    """Cost drill-down for one process/container/service/model by `name` (use a
+    `kind`/`name` pair from `get_costs`' breakdown; `kind` is optional). Returns its
+    `energy_kwh`, `cost`, `avg_w`/`peak_w` and resource use over `range`. Answers
+    "what did *this* model or container cost me?".
+    """
+    return hc.get_entity_cost(name, kind, range)
+
+
+@mcp.tool()
+@_track
+def get_experiments(range: str = "7d", status: str = "") -> dict:
+    """Tracked training/eval runs (Experiments tab), each priced with the real GPU
+    energy it burned. Optionally filter by `status` (running/finished/failed/killed).
+    Each row carries its params, latest metrics (loss/accuracy…), duration and cost.
+    Answers "which runs ran, how did they do, and what did each one cost?".
+    """
+    return hc.get_experiments(range, status)
+
+
+@mcp.tool()
+@_track
+def get_experiment(run_id: str) -> dict:
+    """Full detail for one tracked run by `run_id` (from `get_experiments`): its
+    logged-metric series (the loss curve), the GPU power/util time-series over the
+    run, and the priced energy it burned. An unknown id returns an HTTP 404 error.
+    """
+    return hc.get_experiment(run_id)
 
 
 @mcp.tool()

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -98,6 +98,62 @@ DATA = {
     "insights": ["GPU VRAM peaked at 8.2 GB driven by open-webui"],
 }
 
+COSTS = {
+    "enabled": True, "range": "7d", "bucket_sec": 600, "currency": "BGN",
+    "rapl_available": True,
+    "tariff": {"mode": "dual", "price_day": 0.28, "price_night": 0.14,
+               "night_start": "23:00", "night_end": "06:00"},
+    "machines": [{
+        "name": "local",
+        "now_w": {"gpu": 210, "cpu": 45, "dram": 8, "total": 263},
+        "energy_kwh": {"gpu": 12.4, "cpu": 3.1, "dram": 0.6, "total": 16.1},
+        "cost": {"today": 0.92, "d7": 4.21, "d30": 18.7},
+        "cost_range": 4.21,
+        "measured": ["gpu", "cpu", "dram"], "estimated": [],
+    }],
+    # the stacked-area chart the client deliberately drops
+    "components": {"labels": [1000, 1600], "gpu": [200, 210], "cpu": [40, 45], "dram": [7, 8]},
+    "breakdown": [
+        {"kind": "model", "name": "llama3:70b", "energy_kwh": 8.2, "cost": 2.1, "avg_w": 180},
+        {"kind": "container", "name": "immich_ml", "energy_kwh": 1.4, "cost": 0.35, "avg_w": 30},
+    ],
+}
+
+COSTS_ENTITY = {
+    "name": "llama3:70b", "kind": "model", "range": "7d", "bucket_sec": 600,
+    "currency": "BGN", "energy_kwh": 8.2, "cost": 2.1, "avg_w": 180, "peak_w": 320,
+    # the per-bucket cost curve the client deliberately drops
+    "series": {"labels": [1000, 1600], "watts": [170, 190], "cost_cum": [0.4, 0.9]},
+    "resources": {"gpu_vram_peak_mb": 8200},
+}
+
+RUNS = {
+    "range": "7d", "currency": "BGN", "tariff_mode": "dual",
+    "runs": [
+        {"id": "r1", "name": "qwen-sft", "source": "sdk", "status": "finished",
+         "started_at": 1000, "ended_at": 4600, "duration": 3600, "host": "ardi",
+         "params": {"lr": 0.0002, "epochs": 3}, "tags": ["sft"], "notes": "",
+         "key_id": 1, "key_name": "laptop",
+         "metrics_latest": {"loss": 0.42, "accuracy": 0.91},
+         "energy_kwh": 1.8, "cost": 0.46, "avg_w": 180, "peak_util": 99},
+        {"id": "r2", "name": "eval-sweep", "source": "mlflow", "status": "running",
+         "started_at": 4000, "ended_at": None, "duration": 600, "host": "ardi",
+         "params": {}, "tags": [], "notes": "", "key_id": 1, "key_name": "laptop",
+         "metrics_latest": {"loss": 0.55}, "energy_kwh": 0.3, "cost": 0.08,
+         "avg_w": 160, "peak_util": 95},
+    ],
+}
+
+RUN_ONE = {
+    "id": "r1", "name": "qwen-sft", "source": "sdk", "status": "finished",
+    "started_at": 1000, "ended_at": 4600, "duration": 3600, "host": "ardi",
+    "params": {"lr": 0.0002, "epochs": 3}, "tags": ["sft"], "notes": "",
+    "metrics": {"loss": {"steps": [0, 1, 2], "ts": [1000, 2800, 4600], "values": [1.2, 0.7, 0.42]}},
+    "resource": {"labels": [1000, 4600], "power_w": [170, 190], "util_pct": [98, 99], "bucket_sec": 600},
+    "energy_kwh": 1.8, "cost": 0.46, "avg_w": 180, "peak_util": 99,
+    "currency": "BGN", "tariff_mode": "dual",
+}
+
 DISK_DONE = {
     "path": "/", "state": "done", "total": 355218889101, "free": 82583969792,
     "entries": [{"name": "var", "path": "/var", "bytes": 172911017873,
@@ -115,6 +171,9 @@ ROUTES = {
     "/api/host_data/ghost": HOST_GHOST,
     "/api/health": HEALTH,
     "/api/data": DATA,
+    "/api/costs": COSTS,
+    "/api/costs/entity": COSTS_ENTITY,
+    "/api/runs": RUNS,
     "/healthz": HEALTHZ,
 }
 
@@ -143,6 +202,15 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(body)
+            return
+        if path.startswith("/api/runs/"):
+            rid = path.rsplit("/", 1)[-1]
+            if rid == "r1":
+                self._json(RUN_ONE)
+            else:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b'{"error":"unknown run"}')
             return
         if path in ROUTES:
             body = json.dumps(ROUTES[path]).encode()
@@ -260,6 +328,40 @@ def run():
         check("blame" in r["events"][0], "blame preserved")
         check(len(r["insights"]) == 1, "insights surfaced")
         check(hc.get_alerts()["events"] == r["events"], "get_alerts aliases get_events")
+
+        print("get_costs")
+        r = hc.get_costs("7d")
+        check(r["enabled"] is True and r["currency"] == "BGN", "cost summary basics")
+        check(r["machine"]["cost"]["today"] == 0.92, "machine cost windows (today/7d/30d)")
+        check(r["machine"]["energy_kwh"]["total"] == 16.1, "machine energy total")
+        check(r["machine"]["cost_range"] == 4.21, "cost over the selected range")
+        check(r["tariff"]["mode"] == "dual", "tariff passed through")
+        check(r["breakdown"][0]["name"] == "llama3:70b", "ranked breakdown, biggest first")
+        check("components" not in r, "per-bucket stacked chart trimmed out")
+
+        print("get_entity_cost")
+        r = hc.get_entity_cost("llama3:70b", "model", "7d")
+        check(r["cost"] == 2.1 and r["energy_kwh"] == 8.2, "entity cost + energy")
+        check(r["peak_w"] == 320, "entity peak watts")
+        check(r["resources"]["gpu_vram_peak_mb"] == 8200, "entity resource use")
+        check("series" not in r, "entity cost curve trimmed out")
+
+        print("get_experiments")
+        r = hc.get_experiments("7d")
+        check(r["count"] == 2, "counts runs")
+        check(r["runs"][0]["metrics_latest"]["loss"] == 0.42, "latest metrics surfaced")
+        check(r["runs"][0]["cost"] == 0.46, "run priced by GPU energy")
+
+        print("get_experiment")
+        r = hc.get_experiment("r1")
+        check(r["id"] == "r1" and r["status"] == "finished", "single run detail")
+        check(r["metrics"]["loss"]["values"][-1] == 0.42, "loss-curve series")
+        check(r["resource"]["util_pct"] == [98, 99], "gpu series over the run")
+        try:
+            hc.get_experiment("nope")
+            check(False, "unknown run id raises MonitorError")
+        except hc.MonitorError as e:
+            check("404" in str(e), "unknown run id raises MonitorError (404)")
 
         print("resources")
         check("gpu_util" in hc.get_metrics(), "metrics text")

--- a/server.json
+++ b/server.json
@@ -38,12 +38,13 @@
   ],
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
-      "summary": "HomeLab Monitor is a self-hosted dashboard for AI/homelab rigs. It ships a read-only MCP server (v0.14.0+) inside the same Docker image, serving 12 tools over streamable-HTTP — explore your fleet's hosts, containers, GPU usage, services, and alerts without touching the OS. MIT, no cloud dependency.",
+      "summary": "HomeLab Monitor is a self-hosted dashboard for AI/homelab rigs. It ships a read-only MCP server (v0.14.0+) inside the same Docker image, serving 16 tools over streamable-HTTP — explore your fleet's hosts, containers, GPU usage, services, power costs, tracked experiments and alerts without touching the OS. MIT, no cloud dependency.",
       "connect_http": "claude mcp add --transport http homelab http://YOUR-HUB:9810/mcp",
       "connect_stdio": "docker run -i --rm -e HOMELAB_MONITOR_URL=http://YOUR-HUB:9800 -e MCP_TRANSPORT=stdio sikamikaniko123/homelab-monitor python /app/mcp_server.py",
       "tools": [
         "list_hosts", "get_host", "get_snapshot", "get_containers", "get_services",
-        "get_memory", "get_gpu", "get_ai_models", "get_history", "get_events",
+        "get_memory", "get_gpu", "get_ai_models", "get_history", "get_costs",
+        "get_entity_cost", "get_experiments", "get_experiment", "get_events",
         "get_alerts", "scan_disk"
       ],
       "categories": ["monitoring", "homelab", "self-hosted", "gpu", "observability"],

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -846,7 +846,7 @@ h2 .hic{ opacity:.9 }
   </div>
   <div class="card" id="mcpcard">
     <h2 data-i18n="mcp.title">AI agent (MCP)</h2>
-    <div class="fleet-meta" data-i18n-html="mcp.card_desc">A read-only <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity. <span id="mcpstatus"></span></div>
+    <div class="fleet-meta" data-i18n-html="mcp.card_desc">A read-only <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity, right down to what each model and container costs to run. <span id="mcpstatus"></span></div>
     <div id="mcpconn" style="margin-top:10px" hidden>
       <div class="muted" data-i18n="mcp.connect_hint">Connect with the Claude CLI (then ask it about your fleet):</div>
       <pre class="cmd" id="mcpcmd">claude mcp add --transport http homelab …</pre>

--- a/website/mcp.md
+++ b/website/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP server — connect Claude, ChatGPT & any AI agent to your homelab
-description: Connect Claude, ChatGPT or any MCP client to your homelab. HomeLab Monitor ships a read-only Model Context Protocol server with 12 tools — one line to connect.
+description: Connect Claude, ChatGPT or any MCP client to your homelab. HomeLab Monitor ships a read-only Model Context Protocol server with 16 tools — one line to connect.
 ---
 
 # MCP server — connect Claude, ChatGPT & any AI agent
@@ -38,6 +38,10 @@ Everything the dashboard shows is reachable through these tools. The usual path 
 | `get_gpu(range)` | GPU util / VRAM / power / temp, per-model VRAM, caller attribution | `/api/data` |
 | `get_ai_models(range)` | Which models are loaded, their VRAM, and *who is driving them* | `/api/data` |
 | `get_history(range)` | Charted time-series (GPU + host) for trends | `/api/data` |
+| `get_costs(range)` | What the machine drew and cost, + a ranked per-process/container/service/model breakdown | `/api/costs` |
+| `get_entity_cost(name, kind, range)` | Cost drill-down for one process/container/service/model | `/api/costs/entity` |
+| `get_experiments(range, status)` | Tracked runs, each priced by the real GPU energy it burned | `/api/runs` |
+| `get_experiment(run_id)` | One run's loss-curve metrics, GPU power/util series and priced energy | `/api/runs/<id>` |
 | `get_events(range)` / `get_alerts(range)` | Recent OOM kills / threshold crossings + insights | `/api/data` |
 | `scan_disk(path, rescan)` | WizTree-style nested folder-size treemap | `/api/disk_scan` |
 
@@ -101,6 +105,8 @@ Once connected, ask your agent natural questions and let it pick the tools:
 - *"Which host has a reboot pending **and** an OS upgrade available — what's the safe order to apply it?"*
 - *"Why is the GPU pinned right now, and which service is calling the model server?"*
 - *"Any OOM kills in the last 24h? What got blamed?"*
+- *"What did my homelab cost last night, and which model is the most expensive thing on the GPU?"*
+- *"How much energy did my last training run burn, and what did it cost?"*
 
 !!! warning "Keep it on your LAN/VPN"
     Like the dashboard, the MCP server gives broad visibility into your hosts.


### PR DESCRIPTION
## 0.17.0 — **Ask Your Homelab — over MCP**
*Costs and experiments are now MCP tools, so Claude (or any AI) can tell you what last night cost. Bonus: it speaks Chinese now, and updates itself.*

### What this PR adds
The built-in **read-only** MCP server stopped at GPU/containers/services — it couldn't see the "AI Lab Cockpit" cost/experiments side that 0.16 shipped. This adds four tools so an agent can finally answer *"what did my homelab cost last night?"*:

| Tool | Wraps |
|------|-------|
| `get_costs(range)` — machine draw + cost, ranked per-process/container/service/model breakdown | `/api/costs` |
| `get_entity_cost(name, kind, range)` — drill into one line item | `/api/costs/entity` |
| `get_experiments(range, status)` — tracked runs priced by the real GPU energy burned | `/api/runs` |
| `get_experiment(run_id)` — one run's loss curve + GPU power/util + priced energy | `/api/runs/<id>` |

**16 tools total, still nothing mutated.** Thin wrappers over existing endpoints, same `_track` + trim-and-shape pattern as the other tools.

### Also in this release
- **i18n + Simplified Chinese (zh-CN, 96%)** — full translatable UI (#148)
- **One-click self-update** — opt-in, off by default, the monitor's first write action (#142)
- **Toast notifications** (#139), **radar rebrand**, Discord/Buy-me-a-coffee/Docker-pulls badge
- Fixes: network legend (#155), Topology/Machine labels (#154), what's-new rendering (#173), BG tariffs → EUR (#145)

### Verification
- **60/60 MCP client unit tests green** (14 new, stub-server) — `python mcp/tests/test_client.py`
- All 3 Python modules compile; `server.json` + both locales valid JSON; i18n `--check` passes (zh-CN 96%)

### Notes / follow-ups
- `VERSION` bumped to `0.17.0`; CHANGELOG headline voice-approved by Jarvis.
- `server.json` `version`/OCI pin left at `0.14.3` — registry republish once the `:0.17.0` image is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
