### PR TITLE
fix(notify): set User-Agent on outbound posts — Discord webhook 403

### DIFF
--- a/app.py
+++ b/app.py
@@ -3743,15 +3743,22 @@ _COLORS = {"info": 0x58A6FF, "warning": 0xD29922, "critical": 0xF85149}
 _NTFY_P = {"info": 3, "warning": 4, "critical": 5}
 _NTFY_T = {"info": "information_source", "warning": "warning", "critical": "rotating_light"}
 
+# Discord's API sits behind Cloudflare, which rejects the default
+# "Python-urllib/x.y" agent with 403 (error code 1010). A real User-Agent is
+# also mandated by Discord's API rules, so every outbound POST carries one.
+NOTIFY_USER_AGENT = f"homelab-monitor/{VERSION} (+https://github.com/SikamikanikoBG/homelab-monitor)"
+
 def _post_json(url, payload, timeout=5):
     req = urllib.request.Request(url, data=json.dumps(payload).encode("utf-8"),
-                                 headers={"Content-Type": "application/json"})
+                                 headers={"Content-Type": "application/json",
+                                          "User-Agent": NOTIFY_USER_AGENT})
     with urllib.request.urlopen(req, timeout=timeout) as r:
         return r.status, r.read()
 
 def _post_text(url, text, headers=None, timeout=5):
-    req = urllib.request.Request(url, data=text.encode("utf-8"),
-                                 headers=headers or {"Content-Type": "text/plain"})
+    hdr = dict(headers or {"Content-Type": "text/plain"})
+    hdr.setdefault("User-Agent", NOTIFY_USER_AGENT)
+    req = urllib.request.Request(url, data=text.encode("utf-8"), headers=hdr)
     with urllib.request.urlopen(req, timeout=timeout) as r:
         return r.status, r.read()
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -85,5 +85,46 @@ class TestTelegramNotifier(unittest.TestCase):
         self.assertIn("network down", tg[0][2])
 
 
+class TestOutboundUserAgent(unittest.TestCase):
+    """Discord sits behind Cloudflare, which 403s the default Python-urllib
+    agent (error 1010). Every outbound notifier POST must carry a real
+    User-Agent header. Regression guard for the webhook-test 403."""
+
+    def _capture(self, fn):
+        captured = {}
+
+        class _Resp:
+            status = 204
+            def read(self): return b""
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+
+        def _fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            return _Resp()
+
+        with patch("urllib.request.urlopen", _fake_urlopen):
+            fn()
+        return captured["req"]
+
+    def test_post_json_sets_user_agent(self):
+        req = self._capture(lambda: app._post_json("https://discord.com/api/webhooks/1/x", {"a": 1}))
+        self.assertEqual(req.get_header("User-agent"), app.NOTIFY_USER_AGENT)
+
+    def test_post_text_sets_user_agent(self):
+        req = self._capture(lambda: app._post_text("https://ntfy.sh/topic", "hi"))
+        self.assertEqual(req.get_header("User-agent"), app.NOTIFY_USER_AGENT)
+
+    def test_post_text_preserves_caller_headers_and_adds_ua(self):
+        req = self._capture(lambda: app._post_text(
+            "https://ntfy.sh/topic", "hi", headers={"Title": "T", "Priority": "5"}))
+        self.assertEqual(req.get_header("Title"), "T")
+        self.assertEqual(req.get_header("User-agent"), app.NOTIFY_USER_AGENT)
+
+    def test_user_agent_is_non_default(self):
+        self.assertIn("homelab-monitor", app.NOTIFY_USER_AGENT)
+        self.assertNotIn("Python-urllib", app.NOTIFY_USER_AGENT)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
Saving a valid Discord webhook in alert settings and clicking **Test** returns **403** in the dashboard. The webhook itself is fine.

## Root cause
Discord's webhook API is fronted by Cloudflare, which rejects the default `Python-urllib/x.y` User-Agent with **HTTP 403 (error code 1010 — banned browser signature)**. `_post_json` / `_post_text` sent no `User-Agent`, so every Discord send failed. A real User-Agent is also mandated by Discord's API rules.

## Fix
Both notifier helpers now send `User-Agent: homelab-monitor/<VERSION>` — the same agent the app already uses for its other outbound HTTP calls. `_post_text` preserves any caller-supplied headers (ntfy Title/Priority/Tags) and only adds the UA if absent.

## Verification
- Reproduced against a live webhook: default urllib → `403 error code: 1010`; with User-Agent → `204`.
- Live-ran the fixed `send_discord` path end-to-end → `204`, message delivered.
- Added regression tests asserting both helpers set a non-default User-Agent and that `_post_text` preserves caller headers.
- Full suite: **130 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)