### PR TITLE
fix(fleet): stop online/offline flapping + reorder Overview tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -3170,35 +3170,74 @@ def _poll_and_adapt(name, u, host, port, fam):
         return cdata, None
     return None, cerr or err                  # too slow even at the ceiling / down
 
+def _host_online_window(name):
+    """How stale a host's last good sample may be before the UI calls it offline.
+    Generous and timeout-aware: a host that legitimately needs a long probe budget
+    (or that misses one slow cycle) must not flap to 'offline' between refreshes.
+    The flip only happens after a *sustained* gap — at least a few missed samples,
+    or twice the host's own learned probe budget, whichever is larger."""
+    timeout, _ = _host_poll_state(name)
+    return max(INTERVAL * 6, (timeout + INTERVAL) * 2)
+
+def _host_is_online(entry):
+    """Single source of truth for the fleet 'online' flag (used by both /api/fleet
+    and /api/host_data). True while we hold data whose last *successful* poll is
+    inside the host's staleness window. Hysteresis lives here, not in the caller,
+    so the table and the per-host view never disagree."""
+    if not entry or "data" not in entry or not entry.get("at"):
+        return False
+    window = entry.get("window") or (INTERVAL * 6)
+    return (int(time.time()) - int(entry["at"])) < window
+
+def _poll_one_host(h):
+    """Probe one eligible host and fold the result into HOST_DATA. Contains its own
+    exceptions so a single bad host can never sink the whole cycle. A *failed* poll
+    keeps the last good data and timestamp untouched — only the error is recorded —
+    so the online flag rides on last-success, not last-attempt."""
+    try:
+        check = h.get("last_check") or {}
+        if (check.get("summary") or {}).get("overall") not in ("ok", "warn"):
+            return
+        parsed = _parse_ssh_target(h["ssh_target"])
+        if not parsed:
+            return
+        u, host, port = parsed
+        fam = ((check.get("os") or {}).get("family")) or "linux"
+        data, err = _poll_and_adapt(h["name"], u, host, port, fam)
+        window = _host_online_window(h["name"])
+        with HOST_DATA_LOCK:
+            entry = HOST_DATA.get(h["name"], {})
+            entry["window"] = window
+            if data:
+                entry["data"]   = data
+                entry["at"]     = int(time.time())
+                entry["error"]  = None
+                entry["fails"]  = 0
+            else:
+                entry["error"]    = err or "unknown error"
+                entry["error_at"] = int(time.time())
+                entry["fails"]    = int(entry.get("fails", 0)) + 1
+            HOST_DATA[h["name"]] = entry
+    except Exception as e:
+        print(f"host poll error ({h.get('name')}):", e, flush=True)
+
 def host_poller():
-    """Loop: probe every registered host whose last Test was healthy. A per-host
-    adaptive timeout (issue #99) isolates slow remotes — they self-calibrate to a
+    """Loop: probe every registered host whose last Test was healthy. Hosts are
+    polled *concurrently* so one slow/timing-out remote can't delay the others and
+    age their rows out to a false 'offline' (the flapping bug). A per-host adaptive
+    timeout (issue #99) still isolates slow remotes — they self-calibrate to a
     working budget instead of going permanently dark, while fast hosts stay at the
     15s default. Errors are kept on the cache row so the UI can show a last error."""
     # Stagger the first run a touch so we don't fire before the app is fully up.
     time.sleep(2)
     while True:
         try:
-            for h in list_hosts():
-                check = h.get("last_check") or {}
-                if (check.get("summary") or {}).get("overall") not in ("ok", "warn"):
-                    continue
-                parsed = _parse_ssh_target(h["ssh_target"])
-                if not parsed:
-                    continue
-                u, host, port = parsed
-                fam = ((check.get("os") or {}).get("family")) or "linux"
-                data, err = _poll_and_adapt(h["name"], u, host, port, fam)
-                with HOST_DATA_LOCK:
-                    entry = HOST_DATA.get(h["name"], {})
-                    if data:
-                        entry["data"]  = data
-                        entry["at"]    = int(time.time())
-                        entry["error"] = None
-                    else:
-                        entry["error"]      = err or "unknown error"
-                        entry["error_at"]   = int(time.time())
-                    HOST_DATA[h["name"]] = entry
+            hosts = list_hosts()
+            if hosts:
+                # Each host gets its own thread for the cycle, so the wall-clock
+                # period is the slowest single probe, not the sum of all of them.
+                with ThreadPoolExecutor(max_workers=min(8, len(hosts))) as ex:
+                    list(ex.map(_poll_one_host, hosts))
         except Exception as e:
             print("host_poller error:", e, flush=True)
         time.sleep(INTERVAL)
@@ -5524,10 +5563,11 @@ def api_host_data(name):
                         "error": (entry or {}).get("error") or "no data yet",
                         "at": (entry or {}).get("at"),
                         "host": None})
-    age = int(time.time()) - int(entry["at"])
+    age     = int(time.time()) - int(entry["at"])
+    online  = _host_is_online(entry)
     return jsonify({"name": name, "host": enrich_os_upgrade(entry["data"].get("host", {})),
-                    "at": entry["at"], "online": age < INTERVAL * 3,
-                    "stale_for": age if age >= INTERVAL * 3 else 0,
+                    "at": entry["at"], "online": online,
+                    "stale_for": 0 if online else age,
                     "error": entry.get("error")})
 
 # ── On-demand disk-usage scan (WizTree-style folder treemap) ──────────────────
@@ -5647,7 +5687,7 @@ def api_fleet():
             entry = HOST_DATA.get(h["name"]) or {}
             data  = entry.get("data") or {}
             at    = entry.get("at")
-            online = bool(data) and at and (int(time.time()) - at) < INTERVAL * 3
+            online = _host_is_online(entry)
             rows.append({
                 "name": h["name"],
                 "label": h["name"],

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -831,31 +831,8 @@ h2 .hic{ opacity:.9 }
 
 <!-- ───────── Overview = All hosts (fleet table) ───────── -->
 <section data-tab="overview">
-  <div class="card" id="ai-band" hidden>
-    <h2 style="display:flex;align-items:center;gap:8px">🧠 AI workload <span class="muted" id="ai-band-sub" style="font-size:12px;font-weight:400;text-transform:none"></span></h2>
-    <div id="ai-band-throttle" class="ins crit" style="display:none;margin:8px 0"></div>
-    <div class="grid" id="ai-band-kpis"></div>
-    <p class="cap" id="ai-band-cap"></p>
-  </div>
-  <div class="card" id="diagcard" hidden>
-    <h2 data-i18n="diag.title">🩺 Setup &amp; requirements</h2>
-    <div class="fleet-meta" data-i18n="diag.fleet_meta">What the monitor can see on this hub, and how to enable anything that's missing. The dashboard keeps running even when optional pieces aren't mounted — no GPU required.</div>
-    <div style="overflow-x:auto">
-      <table class="sectbl" style="margin-top:10px"><thead><tr><th data-i18n="col.requirement">Requirement</th><th data-i18n="col.status">Status</th><th data-i18n="col.detail">Detail</th></tr></thead><tbody id="diagbody"></tbody></table>
-    </div>
-  </div>
-  <div class="card" id="mcpcard">
-    <h2 data-i18n="mcp.title">AI agent (MCP)</h2>
-    <div class="fleet-meta" data-i18n-html="mcp.card_desc">A read-only <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity, right down to what each model and container costs to run. <span id="mcpstatus"></span></div>
-    <div id="mcpconn" style="margin-top:10px" hidden>
-      <div class="muted" data-i18n="mcp.connect_hint">Connect with the Claude CLI (then ask it about your fleet):</div>
-      <pre class="cmd" id="mcpcmd">claude mcp add --transport http homelab …</pre>
-      <div class="row">
-        <button class="btn" type="button" id="mcpcopy" data-i18n="btn.copy_command">📋 Copy command</button>
-        <a class="btn" id="mcpdocs" href="https://sikamikanikobg.github.io/homelab-monitor/mcp/" target="_blank" rel="noopener" data-i18n="mcp.docs">MCP docs →</a>
-      </div>
-    </div>
-  </div>
+  <!-- Order (rev): data table first, then the AI/GPU band, then MCP, then Setup
+       last — the day-to-day fleet view leads; one-time setup sinks to the bottom. -->
   <div class="card">
     <h2 data-i18n="fleet.title">🖥 All hosts</h2>
     <div class="fleet-meta" id="fleet_meta">Every registered host at a glance. Click a row to focus that host in the other tabs.</div>
@@ -869,6 +846,31 @@ h2 .hic{ opacity:.9 }
         </thead>
         <tbody><tr><td colspan="11" class="muted" style="padding:14px" data-i18n="fleet.loading">Loading fleet…</td></tr></tbody>
       </table>
+    </div>
+  </div>
+  <div class="card" id="ai-band" hidden>
+    <h2 style="display:flex;align-items:center;gap:8px">🧠 AI workload <span class="muted" id="ai-band-sub" style="font-size:12px;font-weight:400;text-transform:none"></span></h2>
+    <div id="ai-band-throttle" class="ins crit" style="display:none;margin:8px 0"></div>
+    <div class="grid" id="ai-band-kpis"></div>
+    <p class="cap" id="ai-band-cap"></p>
+  </div>
+  <div class="card" id="mcpcard">
+    <h2 data-i18n="mcp.title">AI agent (MCP)</h2>
+    <div class="fleet-meta" data-i18n-html="mcp.card_desc">A read-only <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">MCP</a> server is built in, so Claude — or any MCP client — can connect and explore this homelab with full dashboard parity, right down to what each model and container costs to run. <span id="mcpstatus"></span></div>
+    <div id="mcpconn" style="margin-top:10px" hidden>
+      <div class="muted" data-i18n="mcp.connect_hint">Connect with the Claude CLI (then ask it about your fleet):</div>
+      <pre class="cmd" id="mcpcmd">claude mcp add --transport http homelab …</pre>
+      <div class="row">
+        <button class="btn" type="button" id="mcpcopy" data-i18n="btn.copy_command">📋 Copy command</button>
+        <a class="btn" id="mcpdocs" href="https://sikamikanikobg.github.io/homelab-monitor/mcp/" target="_blank" rel="noopener" data-i18n="mcp.docs">MCP docs →</a>
+      </div>
+    </div>
+  </div>
+  <div class="card" id="diagcard" hidden>
+    <h2 data-i18n="diag.title">🩺 Setup &amp; requirements</h2>
+    <div class="fleet-meta" data-i18n="diag.fleet_meta">What the monitor can see on this hub, and how to enable anything that's missing. The dashboard keeps running even when optional pieces aren't mounted — no GPU required.</div>
+    <div style="overflow-x:auto">
+      <table class="sectbl" style="margin-top:10px"><thead><tr><th data-i18n="col.requirement">Requirement</th><th data-i18n="col.status">Status</th><th data-i18n="col.detail">Detail</th></tr></thead><tbody id="diagbody"></tbody></table>
     </div>
   </div>
 </section>

--- a/tests/test_fleet_online.py
+++ b/tests/test_fleet_online.py
@@ -1,0 +1,64 @@
+"""The fleet 'online' flag must not flap. A healthy host that misses one slow or
+timed-out poll cycle (or that legitimately needs a long probe budget) should stay
+'online' until a *sustained* gap of missed samples — never blink offline between
+refreshes. Regression guard for the overview summary flapping bug."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+class TestHostOnlineWindow(unittest.TestCase):
+    def test_window_is_generous_for_fast_host(self):
+        # A fast host (default budget) still gets several missed cycles of grace.
+        with patch.object(app, "_host_poll_state", return_value=(app.HOST_POLL_TIMEOUT, 0)):
+            w = app._host_online_window("fast")
+        self.assertGreaterEqual(w, app.INTERVAL * 6)
+
+    def test_window_scales_with_learned_timeout(self):
+        # A host that learned a long budget gets a proportionally longer window,
+        # so its own slow probe cycles never read as offline.
+        with patch.object(app, "_host_poll_state", return_value=(90, 0)):
+            w = app._host_online_window("slow")
+        self.assertGreaterEqual(w, (90 + app.INTERVAL) * 2)
+
+
+class TestHostIsOnline(unittest.TestCase):
+    def _entry(self, age_sec, window=None, data=True):
+        e = {"at": int(app.time.time()) - age_sec}
+        if data:
+            e["data"] = {"host": {}}
+        if window is not None:
+            e["window"] = window
+        return e
+
+    def test_no_entry_is_offline(self):
+        self.assertFalse(app._host_is_online(None))
+        self.assertFalse(app._host_is_online({}))
+
+    def test_entry_without_data_is_offline(self):
+        self.assertFalse(app._host_is_online(self._entry(1, data=False)))
+
+    def test_fresh_sample_is_online(self):
+        self.assertTrue(app._host_is_online(self._entry(2, window=60)))
+
+    def test_one_missed_cycle_stays_online(self):
+        # A single slow/timed-out cycle (~INTERVAL*2 old) must NOT flip to offline —
+        # this is exactly the flap the old INTERVAL*3 (30s) cutoff caused.
+        self.assertTrue(app._host_is_online(self._entry(app.INTERVAL * 3 + 1, window=60)))
+
+    def test_sustained_gap_is_offline(self):
+        self.assertFalse(app._host_is_online(self._entry(120, window=60)))
+
+    def test_missing_window_falls_back_to_generous_default(self):
+        # Old cache rows written before this field existed still get hysteresis.
+        e = self._entry(app.INTERVAL * 3 + 1)
+        e.pop("window", None)
+        self.assertTrue(app._host_is_online(e))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two changes to the Overview, both reported from `ardi:9800`.

## 1. Fix the online/offline flapping (the real bug)
**Symptom:** hosts that are actually up intermittently showed **offline** in the summary table, then **online** again on the next refresh — mixed signals that make the app feel unreliable.

**Root cause (two, compounding):**
1. **Serialized polling.** `host_poller()` probed hosts one-by-one. A single slow or timing-out remote (SSH budget up to 15s, learned up to 90s via #99) delayed the refresh of *every other* host, so a healthy host's last-success timestamp aged past the online cutoff before the loop came back to it.
2. **Tight cutoff.** online = `last_success < INTERVAL*3` (30s) — easily exceeded once a cycle ran long, so healthy rows blinked offline.

**Fix:**
- **Concurrent polling** (`ThreadPoolExecutor`, ≤8 workers). The cycle wall-clock is now the slowest *single* probe, not the sum — every host refreshes each `INTERVAL` regardless of slow peers.
- **Centralized, hysteretic online flag** — `_host_is_online()` (used by both `/api/fleet` and `/api/host_data`, so they can't disagree) behind a generous, timeout-aware staleness window: `max(INTERVAL*6, (learned_timeout+INTERVAL)*2)`. A single slow/missed cycle can no longer flip a healthy host offline; the flip now requires a *sustained* gap. A failed poll keeps the last good data/timestamp untouched.
- New `tests/test_fleet_online.py` proves the window sizing and the no-flap-on-one-missed-cycle behaviour.

The adaptive per-host timeout (#99) is unchanged and still self-calibrates slow remotes.

## 2. Reorder the Overview tab
New order: **All-hosts table → AI workload (GPU throttling band) → AI agent (MCP) → Setup & requirements (last)**. The day-to-day fleet view now leads; one-time setup sinks to the bottom. Pure markup reorder — every card is referenced by id in JS, behaviour unchanged.

## Verification
- Full suite **138 passed** (incl. 7 new online-flag tests).
- Smoke: `/api/fleet` and `/api/host_data/local` return 200 with correct `online` flags; all three new helpers present.
- HTML: Overview section well-formed, card order confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)