### PR TITLE
chore(release): silent patch channel — v0.17.1 + gate Discord announcer to minor+

### DIFF
--- a/.github/workflows/discord-announce.yml
+++ b/.github/workflows/discord-announce.yml
@@ -1,12 +1,14 @@
 name: Announce release on Discord
 
-# On every published, non-prerelease release, post the changelog as a rich
-# embed to the project Discord #announcements channel via webhook.
+# On a published, NON-prerelease, MINOR-or-greater release, post the changelog
+# as a rich embed to the project Discord #announcements channel via webhook.
 #
-# Unlike the selfh.st announcer (minor+ only, feeding a human-curated weekly),
-# this posts EVERY non-prerelease release: #announcements IS the changelog, and
-# people who join a project's Discord want every release note. If it ever feels
-# noisy, copy the patch-skip gate from selfhst-newsletter.yml into the gate step.
+# Patch releases (vX.Y.Z, Z>0) and prereleases are skipped on purpose: patches
+# ship daily and silently (Docker rebuild only, no announcement) — announcing
+# every one would spam the channel. Bigger versions (vX.Y.0) are the moments
+# worth communicating, and they roll up all the patches since. This mirrors the
+# selfh.st announcer's gate so both channels speak only on minor+ versions.
+# Re-post a specific tag by hand via the "Run workflow" button (workflow_dispatch).
 #
 #   secrets.DISCORD_ANNOUNCE_WEBHOOK   Discord webhook URL for #announcements
 
@@ -46,17 +48,22 @@ jobs:
             core.setOutput('prerelease', String(r.prerelease));
             core.setOutput('body', r.body || '');
 
-      - name: Skip prereleases
+      - name: Gate (skip prereleases and patch releases)
         id: gate
         env:
           PRERELEASE: ${{ steps.rel.outputs.prerelease }}
           TAG: ${{ steps.rel.outputs.tag }}
         run: |
+          ver="${TAG#v}"
+          IFS='.' read -r major minor patch _ <<< "$ver"
           if [ "$PRERELEASE" = "true" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"; echo "::notice::$TAG is a prerelease — skipping"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"; echo "::notice::$TAG is a prerelease — skipping"; exit 0
           fi
+          if [ "${patch:-0}" != "0" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"; echo "::notice::$TAG is a patch release — skipping (patches ship silently)"; exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::$TAG qualifies — announcing on Discord"
 
       - name: Post to Discord
         if: steps.gate.outputs.skip == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.17.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.1) — 2026-06-21 · _patch_
+_Silent patch — Docker image rebuilt, no release announcement (patches roll up into the next minor)._
+
+**Fixed**
+- **Discord notifications no longer fail with 403.** Discord's webhook API sits behind Cloudflare, which rejects the default `Python-urllib` agent (error 1010). Outbound notifier POSTs now send a real `User-Agent`, so the alert-settings **Test** button works.
+- **Fleet "online/offline" no longer flaps.** The overview summary occasionally showed healthy hosts as offline, then online again next refresh. Hosts are now polled **concurrently** (one slow remote can't age the others out) and the online flag uses a generous, timeout-aware staleness window — a single slow or missed poll cycle can't flip a host offline.
+
+**Changed**
+- **Overview tab reordered** — fleet data table first, then the AI/GPU workload band, then MCP, with **Setup & requirements** moved to the bottom.
+- **CI/CD**: the Discord release announcer now skips patch releases, matching the selfh.st gate — both speak only on minor+ versions.
+
 ## [0.17.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.0) — 2026-06-18 · **Ask Your Homelab — over MCP**
 *Costs and experiments are now MCP tools, so Claude (or any AI) can tell you what last night cost. Bonus: it speaks Chinese now, and updates itself.*
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.17.0"
+VERSION      = "0.17.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))


### PR DESCRIPTION
Establishes the **silent patch** policy and ships **v0.17.1**.

## Policy
- **Patches (vX.Y.Z, Z>0)** ship daily and silently: a `v*` tag rebuilds the Docker image (`release.yml`), but **no GitHub Release** is cut — so neither outward announcer fires (both trigger on `release: published`).
- **Minor+ (vX.Y.0)** are the communication events and roll up the patches since.

## Changes
- **`discord-announce.yml`**: add the patch-skip gate that `selfhst-newsletter.yml` already has. Now **both** comm channels speak only on minor+ — even if a Release is ever published for a patch, it's skipped on both.
- **VERSION → 0.17.1** to track the recent fixes.
- **CHANGELOG**: compact 0.17.1 patch entry (links to the tag, no Release notes).

## What this patch rolls up
- Discord webhook 403 fix (#180)
- Fleet online/offline flapping fix + Overview reorder (#181)

## Verification
- Both announce workflows: valid YAML, patch-skip gate present in both.
- Full suite: **138 passed**; no test pins the version.

After merge: `next` → `main`, then tag `v0.17.1` (Docker rebuild only, no Release, no comms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)