### PR TITLE
fix(alerts): name the machine in every notification — v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.17.2](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.2) — 2026-06-21 · _patch_
+_Silent patch — Docker image rebuilt, no release announcement (patches roll up into the next minor)._
+
+**Fixed**
+- **Alerts now name the machine.** Every notification — Discord, ntfy and Telegram — is prefixed with `[<machine>]`, so when you monitor many hosts you can tell at a glance *which* one a "Container unhealthy" / "Disk at 95%" / "GPU VRAM pressure" alert is about. The **Test** button shows the same label so you can confirm it. No configuration needed — the name comes from the host's reported hostname.
+
 ## [0.17.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.17.1) — 2026-06-21 · _patch_
 _Silent patch — Docker image rebuilt, no release announcement (patches roll up into the next minor)._
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.17.1"
+VERSION      = "0.17.2"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
@@ -3828,8 +3828,33 @@ def _post_to_telegram(token, chat_id, level, title, body):
             f"_HomeLab Monitor · {level}_")
     return _post_json(url, {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"})
 
-def dispatch_alert(s, level, title, detail):
-    """Send to whichever channels are configured. Returns list of (channel, ok, err)."""
+def _alert_host_label():
+    """Machine name to stamp on every alert so a notification says *where* the
+    problem is. Alerts are raised from the hub's own docker/systemd/disk/GPU
+    snapshots, so this is the hub host: prefer the probe-reported hostname (the
+    same name the dashboard's host tab shows), fall back to the OS hostname, and
+    finally to "" so a label-less environment degrades to the old behaviour."""
+    try:
+        name = ((LATEST or {}).get("host") or {}).get("hostname")
+        if name:
+            return str(name).strip()
+    except Exception:
+        pass
+    try:
+        return socket.gethostname()
+    except Exception:
+        return ""
+
+def dispatch_alert(s, level, title, detail, host=None):
+    """Send to whichever channels are configured. Returns list of (channel, ok, err).
+
+    `title` is prefixed with the machine name (`[host] …`) so every channel —
+    Discord, ntfy and Telegram alike — names which machine the alert is about.
+    Pass host="" to opt out (e.g. a generic message that isn't host-specific)."""
+    if host is None:
+        host = _alert_host_label()
+    if host:
+        title = f"[{host}] {title}"
     out = []
     if s.get("discord_webhook_url"):
         try: send_discord(s["discord_webhook_url"], level, title, detail); out.append(("discord", True, None))

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -85,6 +85,45 @@ class TestTelegramNotifier(unittest.TestCase):
         self.assertIn("network down", tg[0][2])
 
 
+class TestAlertHostLabel(unittest.TestCase):
+    """Every alert must name the machine it's about (many-hosts UX)."""
+
+    def test_label_prefers_probe_hostname(self):
+        with patch.object(app, "LATEST", {"host": {"hostname": "ardi"}}):
+            self.assertEqual(app._alert_host_label(), "ardi")
+
+    def test_label_falls_back_to_socket(self):
+        with patch.object(app, "LATEST", {}), \
+             patch("socket.gethostname", return_value="hubbox"):
+            self.assertEqual(app._alert_host_label(), "hubbox")
+
+    @patch("app._post_json")
+    def test_dispatch_prefixes_title_with_host(self, mock_post):
+        mock_post.return_value = (200, b"{}")
+        s = {**app.SETTING_DEFAULTS, "telegram_token": "tok", "telegram_chat_id": "99"}
+        with patch.object(app, "_alert_host_label", return_value="ardi"):
+            app.dispatch_alert(s, "warning", "Container immich unhealthy", "down")
+        _, payload = mock_post.call_args[0]
+        self.assertIn("[ardi]", payload["text"])
+        self.assertIn("Container immich unhealthy", payload["text"])
+
+    @patch("app._post_json")
+    def test_dispatch_explicit_host_overrides(self, mock_post):
+        mock_post.return_value = (200, b"{}")
+        s = {**app.SETTING_DEFAULTS, "telegram_token": "tok", "telegram_chat_id": "99"}
+        app.dispatch_alert(s, "info", "Title", "Body", host="webserver")
+        _, payload = mock_post.call_args[0]
+        self.assertIn("[webserver]", payload["text"])
+
+    @patch("app._post_json")
+    def test_dispatch_empty_host_opts_out(self, mock_post):
+        mock_post.return_value = (200, b"{}")
+        s = {**app.SETTING_DEFAULTS, "telegram_token": "tok", "telegram_chat_id": "99"}
+        app.dispatch_alert(s, "info", "Title", "Body", host="")
+        _, payload = mock_post.call_args[0]
+        self.assertNotIn("[", payload["text"].split("\n")[0])
+
+
 class TestOutboundUserAgent(unittest.TestCase):
     """Discord sits behind Cloudflare, which 403s the default Python-urllib
     agent (error 1010). Every outbound notifier POST must carry a real


### PR DESCRIPTION
## Problem
Alerts fire correctly (Discord / ntfy / Telegram), but the message never says **which machine** the problem is on. With many hosts monitored, "Container immich unhealthy" or "Disk at 95%" isn't actionable — you can't tell where to look.

## Fix
Every alert title is now prefixed with the machine name: `[ardi] 🔴 Container immich unhealthy`.

- Injected once at the single choke point — `dispatch_alert()` — so **all three channels**, the GPU-OOM path, and the **Test** button all get it uniformly.
- New `_alert_host_label()` resolves the hub's name from the probe-reported `hostname` (the same name the dashboard's host tab shows), falling back to `socket.gethostname()`. No configuration needed.
- Edge-trigger dedup keys in `_emit()` are **untouched** (host isn't part of the key), so flap-suppression behaves exactly as before.
- `dispatch_alert(..., host="")` opts a message out for the rare non-host-specific case.

Alerts today are raised from the hub's own docker/systemd/disk/GPU snapshots, so the label is the hub host. (Per-remote-host alerting is a separate, larger change for a future minor.)

## Tests
- Added `TestAlertHostLabel`: hostname preference, socket fallback, title prefixing, explicit-host override, empty-host opt-out.
- Full suite green: **143 passed**.

## Version
`0.17.2` — silent patch (CHANGELOG updated; rolls up into the next minor, no release announcement per the patch-channel policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)