### PR TITLE
feat(gpu): AMD & Intel GPU support (Windows perf counters + amdgpu sysfs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.19.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.19.0) — 2026-06-23 · **AMD & Intel GPUs join the party**
+*The GPU panel is no longer NVIDIA-only — AMD and Intel cards now show up too, with no vendor tools to install.*
+
+**Added**
+- **AMD GPU support on Linux — no ROCm required.** Both the hub's own collector and every monitored Linux host now read AMD cards through the in-kernel `amdgpu` sysfs interface (`gpu_busy_percent`, `mem_info_vram_total`/`used`, and hwmon temperature/power) — so an AMD box shows the GPU panel (name, utilisation, VRAM, temp, power) with zero configuration. (#1)
+- **AMD & Intel GPU support on Windows hosts.** The Windows probe now falls back to Windows' built-in GPU performance counters + WMI when `nvidia-smi` is absent, surfacing AMD and Intel GPUs — including **integrated** graphics — with name, utilisation and VRAM.
+
+**Changed**
+- The GPU back-end is now vendor-aware: NVIDIA continues through `nvidia-smi`, and the AMD/Intel paths are consulted **only** when `nvidia-smi` reports nothing — so NVIDIA and GPU-less hosts behave exactly as before. Per-card clock/throttle enrichment and per-process VRAM attribution remain NVIDIA-only for now (AMD per-process attribution is tracked as a follow-up).
+
 ## [0.18.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.18.0) — 2026-06-22 · **Is my lab up? — Uptime monitoring built in**
 *Point it at any URL or port and it watches them for you — heartbeat, uptime %, and alerts that page once (not on every dropped packet) and tell you when it's back.*
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ History lives in `./data/gpu.db` (a bind mount), so it survives restarts and upg
 
 ## Under the hood
 
-The hub stitches `nvidia-smi`, the Docker API, model-server APIs (Ollama, vLLM, llama.cpp, A1111, …), systemd D-Bus, and `/proc` + `/sys` into one sampled view, persisted to SQLite and downsampled on read so a six-month range loads as fast as the last hour. Single page, vendored Chart.js, no build step.
+The hub stitches `nvidia-smi` (plus AMD GPUs via the in-kernel `amdgpu` sysfs interface, and AMD/Intel on Windows hosts via the built-in GPU perf counters), the Docker API, model-server APIs (Ollama, vLLM, llama.cpp, A1111, …), systemd D-Bus, and `/proc` + `/sys` into one sampled view, persisted to SQLite and downsampled on read so a six-month range loads as fast as the last hour. Single page, vendored Chart.js, no build step.
 
 - **30+ recognised model servers** → [Model servers](https://sikamikanikobg.github.io/homelab-monitor/model-servers/)
 - **`/metrics` Prometheus endpoint + Grafana dashboard** → [Prometheus & Grafana](https://sikamikanikobg.github.io/homelab-monitor/prometheus/)

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.18.0"
+VERSION      = "0.19.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
@@ -4499,6 +4499,77 @@ def _gpu_num(x):
     except ValueError:
         return 0.0
 
+# ── AMD GPU back-end (issue #1) ───────────────────────────────────────────────
+# NVIDIA goes through nvidia-smi (above); AMD has no universally-present CLI, so we
+# read the kernel's amdgpu sysfs directly — available on any host with the in-tree
+# `amdgpu` driver, ROCm NOT required. The hub reads the host's sysfs through the
+# read-only HOST_ROOT mount via _hp(); the remote Linux probe (probe.py) reads /sys
+# in place. Strictly additive: consulted only when nvidia-smi reports no card, so
+# NVIDIA and GPU-less hosts behave exactly as before.
+def _amd_read_int(path):
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+def _amd_hwmon(dev, fname):
+    """Read a hwmon scalar (e.g. temp1_input in millidegrees C, power1_average in
+    microwatts) from the card's hwmon node. None if absent/unreadable."""
+    try:
+        for h in sorted(os.listdir(os.path.join(dev, "hwmon"))):
+            v = _amd_read_int(os.path.join(dev, "hwmon", h, fname))
+            if v is not None:
+                return v
+    except OSError:
+        pass
+    return None
+
+def amd_gpus(drm_root=None):
+    """Per-card AMD snapshot from amdgpu sysfs, matching the dict shape sample_once()
+    builds for NVIDIA cards (idx/name/util/mem_used/mem_total/power/temp; MB, %, W,
+    °C). Empty list when no AMD GPU is present. `drm_root` is injectable for tests;
+    in production it points at the host's /sys/class/drm through HOST_ROOT."""
+    if drm_root is None:
+        drm_root = _hp("/sys/class/drm")
+    try:
+        entries = sorted(os.listdir(drm_root))
+    except OSError:
+        return []
+    gpus = []
+    for nm in entries:
+        m = re.fullmatch(r"card(\d+)", nm or "")
+        if not m:
+            continue
+        dev = os.path.join(drm_root, nm, "device")
+        try:
+            with open(os.path.join(dev, "vendor")) as f:
+                if f.read().strip().lower() != "0x1002":   # 0x1002 = AMD/ATI
+                    continue
+        except OSError:
+            continue
+        total  = _amd_read_int(os.path.join(dev, "mem_info_vram_total"))   # bytes
+        used   = _amd_read_int(os.path.join(dev, "mem_info_vram_used"))    # bytes
+        busy   = _amd_read_int(os.path.join(dev, "gpu_busy_percent"))      # %
+        temp_m = _amd_hwmon(dev, "temp1_input")     # millidegrees C
+        powr_u = _amd_hwmon(dev, "power1_average")  # microwatts
+        name = None
+        try:
+            with open(os.path.join(dev, "product_name")) as f:   # newer kernels only
+                name = f.read().strip() or None
+        except OSError:
+            pass
+        gpus.append({
+            "idx": int(m.group(1)),
+            "name": name or "AMD GPU %s" % m.group(1),
+            "util": float(busy) if busy is not None else 0.0,
+            "mem_used":  round(used / 1048576.0) if used is not None else 0.0,
+            "mem_total": round(total / 1048576.0) if total is not None else 0.0,
+            "power": round(powr_u / 1e6, 1) if powr_u is not None else 0.0,
+            "temp":  round(temp_m / 1000.0, 1) if temp_m is not None else 0.0,
+        })
+    return gpus
+
 # Extra per-card telemetry the AI/DS crowd actually debugs with: memory-bandwidth
 # utilisation (mem-bound vs compute-bound), core/memory clocks, power limit (for
 # headroom), performance state, memory-junction temp, and the *throttle reasons*
@@ -4699,27 +4770,40 @@ def sample_once():
             u, mu, mt, pw, tp = (_gpu_num(x) for x in p[2:7])
             gpus.append({"idx": int(_gpu_num(p[0])), "name": p[1] or f"GPU {p[0]}",
                          "util": u, "mem_used": mu, "mem_total": mt, "power": pw, "temp": tp})
+        amd = False
         if not gpus:
-            raise ValueError("nvidia-smi returned no GPU rows")
+            # No NVIDIA card (or no nvidia-smi) — fall back to the AMD amdgpu sysfs
+            # back-end (issue #1). Additive: an NVIDIA host never reaches this.
+            gpus = amd_gpus()
+            amd = bool(gpus)
+            if not gpus:
+                raise ValueError("no NVIDIA or AMD GPU detected")
         gpu_avail = True
         # Aggregate across cards for the existing single-GPU views: VRAM + power are
-        # the pool, utilisation is averaged, temperature is the hottest card.
+        # the pool, utilisation is averaged, temperature is the hottest card. AMD
+        # cards expose the same keys, so this aggregation is vendor-agnostic.
         mem_used  = sum(g["mem_used"] for g in gpus)
         mem_total = sum(g["mem_total"] for g in gpus)
         power     = sum(g["power"] for g in gpus)
         util      = round(sum(g["util"] for g in gpus) / len(gpus))
         temp      = max(g["temp"] for g in gpus)
-        _enrich_gpus(gpus)                 # mem-bw util, clocks, power limit, throttle reasons (best-effort)
-        gpu_extra = _gpu_extra(gpus)
-        for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
-            if line.strip():
-                pid, mem = (p.strip() for p in line.split(","))
-                svc = service_for_pid(pid, nm)
-                procs[svc] = procs.get(svc, 0) + _gpu_num(mem)
-                try:
-                    gpu_pids[int(pid)] = gpu_pids.get(int(pid), 0) + _gpu_num(mem)
-                except ValueError:
-                    pass
+        if amd:
+            # Per-card enrichment (clocks/throttle) and per-process VRAM attribution
+            # are nvidia-smi-specific; AMD shows the core panel (util/VRAM/temp/power)
+            # without them. Per-process AMD attribution is a follow-up (issue #1).
+            gpu_extra = {}
+        else:
+            _enrich_gpus(gpus)                 # mem-bw util, clocks, power limit, throttle reasons (best-effort)
+            gpu_extra = _gpu_extra(gpus)
+            for line in smi(["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"]).splitlines():
+                if line.strip():
+                    pid, mem = (p.strip() for p in line.split(","))
+                    svc = service_for_pid(pid, nm)
+                    procs[svc] = procs.get(svc, 0) + _gpu_num(mem)
+                    try:
+                        gpu_pids[int(pid)] = gpu_pids.get(int(pid), 0) + _gpu_num(mem)
+                    except ValueError:
+                        pass
     except Exception as e:
         # Log only on the ok→fail edge so a permanently GPU-less host doesn't spam.
         if LATEST.get("gpu_avail"):

--- a/probe.ps1
+++ b/probe.ps1
@@ -61,23 +61,97 @@ function Read-Temp {
     return @{}
 }
 
-# ── GPU via nvidia-smi (identical query to probe.py) ──────────────────────────
+# ── GPU: nvidia-smi first, then a vendor-agnostic Windows fallback ─────────────
+# NVIDIA cards report through nvidia-smi (same query probe.py uses). When that's
+# absent we fall back to Windows' built-in GPU perf counters + WMI, which cover
+# AMD and Intel GPUs (incl. integrated) with no vendor tool installed. The
+# returned shape is identical either way, so the hub renders all three the same.
+# Temperature/power aren't exposed by Windows for AMD/Intel without a vendor
+# library, so they come back as 0 (the UI already tolerates missing fields).
 function Read-Gpu {
     try {
-        if (-not (Get-Command nvidia-smi -ErrorAction SilentlyContinue)) { return @{} }
-        $raw = & nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu,temperature.gpu,name --format=csv,noheader,nounits 2>$null
-        $lines = @($raw | Where-Object { $_ -and $_.Trim() })
-        if ($lines.Count -eq 0) { return @{} }
-        $p = $lines[0].Split(',') | ForEach-Object { $_.Trim() }
-        if ($p.Count -lt 5) { return @{} }
-        function I($v) { try { return [int][double]$v } catch { return 0 } }
+        if (Get-Command nvidia-smi -ErrorAction SilentlyContinue) {
+            $raw = & nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu,temperature.gpu,name --format=csv,noheader,nounits 2>$null
+            $lines = @($raw | Where-Object { $_ -and $_.Trim() })
+            if ($lines.Count -ge 1) {
+                $p = $lines[0].Split(',') | ForEach-Object { $_.Trim() }
+                if ($p.Count -ge 5) {
+                    function I($v) { try { return [int][double]$v } catch { return 0 } }
+                    return @{ gpu = [ordered]@{
+                        count     = $lines.Count
+                        name      = $p[4]
+                        mem_used  = (I $p[0])
+                        mem_total = (I $p[1])
+                        util      = (I $p[2])
+                        temp      = (I $p[3])
+                        vendor    = 'nvidia'
+                    } }
+                }
+            }
+        }
+    } catch {}
+    # ── Fallback: AMD / Intel (and NVIDIA if nvidia-smi is missing) via Windows ──
+    try {
+        # Only surface a real, recognised display GPU — skip Basic Display, virtual,
+        # RDP and USB display adapters so headless servers don't show a phantom card.
+        $cards = @(Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match 'NVIDIA|GeForce|Quadro|Tesla|RTX|GTX|AMD|Radeon|Intel|Arc|Iris|UHD|HD Graphics' })
+        if ($cards.Count -eq 0) { return @{} }
+        $card = $cards | Sort-Object { [int64]($_.AdapterRAM) } -Descending | Select-Object -First 1
+        $name = $card.Name
+
+        # Utilisation: sum the engines within each engine type, take the busiest
+        # type (this is what Task Manager shows as overall GPU %). 0 if unreadable.
+        $util = 0
+        try {
+            $s = (Get-Counter '\GPU Engine(*)\Utilization Percentage' -ErrorAction Stop).CounterSamples
+            $perType = $s | Group-Object { ($_.InstanceName -replace '.*(engtype_[a-z0-9]+).*', '$1') } |
+                ForEach-Object { ($_.Group | Measure-Object CookedValue -Sum).Sum }
+            if ($perType) {
+                $util = [int][math]::Round(($perType | Measure-Object -Maximum).Maximum)
+                if ($util -lt 0) { $util = 0 } elseif ($util -gt 100) { $util = 100 }
+            }
+        } catch {}
+
+        # VRAM used: dedicated GPU memory in use (MB). Shared memory is host RAM and
+        # is already counted in the memory panel, so we don't fold it into "VRAM".
+        $mem_used = 0
+        try {
+            $d = (Get-Counter '\GPU Adapter Memory(*)\Dedicated Usage' -ErrorAction Stop).CounterSamples
+            $mem_used = [int][math]::Round((($d | Measure-Object CookedValue -Sum).Sum) / 1MB)
+        } catch {}
+
+        # VRAM total: the adapter's dedicated memory size from the driver registry
+        # (qwMemorySize is accurate where Win32_VideoController.AdapterRAM caps at 4 GB).
+        $mem_total = 0
+        try {
+            $reg = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -ErrorAction SilentlyContinue |
+                Where-Object { $_.DriverDesc -and $_.'HardwareInformation.qwMemorySize' -and ($_.DriverDesc -eq $name) } |
+                Select-Object -First 1
+            if (-not $reg) {
+                $reg = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*' -ErrorAction SilentlyContinue |
+                    Where-Object { $_.'HardwareInformation.qwMemorySize' } |
+                    Sort-Object { [int64]$_.'HardwareInformation.qwMemorySize' } -Descending | Select-Object -First 1
+            }
+            if ($reg) { $mem_total = [int]([int64]$reg.'HardwareInformation.qwMemorySize' / 1MB) }
+        } catch {}
+        if ($mem_total -eq 0 -and $card.AdapterRAM) {
+            try { $mem_total = [int]([int64]$card.AdapterRAM / 1MB) } catch {}
+        }
+
+        $vendor = if ($name -match 'NVIDIA|GeForce|Quadro|Tesla|RTX|GTX') { 'nvidia' }
+                  elseif ($name -match 'AMD|Radeon') { 'amd' }
+                  elseif ($name -match 'Intel|Arc|Iris|UHD|HD Graphics') { 'intel' }
+                  else { 'unknown' }
+
         return @{ gpu = [ordered]@{
-            count     = $lines.Count
-            name      = $p[4]
-            mem_used  = (I $p[0])
-            mem_total = (I $p[1])
-            util      = (I $p[2])
-            temp      = (I $p[3])
+            count     = $cards.Count
+            name      = $name
+            mem_used  = $mem_used
+            mem_total = $mem_total
+            util      = $util
+            temp      = 0
+            vendor    = $vendor
         } }
     } catch { return @{} }
 }

--- a/probe.py
+++ b/probe.py
@@ -370,10 +370,8 @@ def _smi_int(v):
         return 0
 
 
-def read_gpu():
-    """First NVIDIA GPU's snapshot via nvidia-smi. Returns {} if no driver or
-    no GPU. We treat the first GPU as the 'representative' for the table; the
-    detailed per-GPU view lives in the future GPU tab."""
+def _nvidia_gpu():
+    """First NVIDIA GPU's snapshot via nvidia-smi, or {} if no driver / no GPU."""
     try:
         r = subprocess.run(
             ["nvidia-smi",
@@ -399,6 +397,71 @@ def read_gpu():
         }}
     except Exception:
         return {}
+
+
+def _amd_gpu_sysfs(drm_root="/sys/class/drm"):
+    """First AMD GPU's snapshot from the in-kernel amdgpu sysfs interface — present
+    on any host with the open `amdgpu` driver, no ROCm tools required. Same shape
+    as _nvidia_gpu(); {} when no AMD card is present or sysfs is unreadable.
+    `drm_root` is injectable for tests."""
+    def _int(path):
+        try:
+            with open(path) as f:
+                return int(f.read().strip())
+        except (OSError, ValueError):
+            return None
+    try:
+        entries = sorted(os.listdir(drm_root))
+    except OSError:
+        return {}
+    cards = []
+    for nm in entries:
+        m = re.fullmatch(r"card(\d+)", nm or "")
+        if not m:
+            continue
+        dev = os.path.join(drm_root, nm, "device")
+        try:
+            with open(os.path.join(dev, "vendor")) as f:
+                if f.read().strip().lower() != "0x1002":   # PCI vendor id 0x1002 = AMD/ATI
+                    continue
+        except OSError:
+            continue
+        total = _int(os.path.join(dev, "mem_info_vram_total"))   # bytes
+        used  = _int(os.path.join(dev, "mem_info_vram_used"))    # bytes
+        busy  = _int(os.path.join(dev, "gpu_busy_percent"))      # %
+        temp = 0
+        try:
+            hwroot = os.path.join(dev, "hwmon")
+            for h in sorted(os.listdir(hwroot)):
+                t = _int(os.path.join(hwroot, h, "temp1_input"))  # millidegrees C
+                if t is not None:
+                    temp = int(round(t / 1000.0))
+                    break
+        except OSError:
+            pass
+        name = None
+        try:
+            with open(os.path.join(dev, "product_name")) as f:   # newer kernels only
+                name = f.read().strip() or None
+        except OSError:
+            pass
+        cards.append({
+            "name":      name or "AMD GPU %s" % m.group(1),
+            "mem_used":  int(round(used / 1048576.0)) if used is not None else 0,
+            "mem_total": int(round(total / 1048576.0)) if total is not None else 0,
+            "util":      busy if busy is not None else 0,
+            "temp":      temp,
+        })
+    if not cards:
+        return {}
+    return {"gpu": dict(cards[0], count=len(cards))}
+
+
+def read_gpu():
+    """First GPU's snapshot for the All-hosts table. NVIDIA via nvidia-smi; when
+    that's unavailable, AMD via the amdgpu sysfs interface (no ROCm needed). {} on
+    a host with neither — the GPU panel is simply hidden."""
+    return _nvidia_gpu() or _amd_gpu_sysfs()
 
 
 # ── System / Hardware / Network / Security inventory ──────────────────────────

--- a/tests/test_amd_gpu.py
+++ b/tests/test_amd_gpu.py
@@ -1,0 +1,102 @@
+"""Unit tests for the AMD GPU back-end (issue #1) — the amdgpu sysfs readers used
+by the hub's local collector (app.amd_gpus) and the remote Linux probe
+(probe._amd_gpu_sysfs). We build a fake /sys/class/drm tree so the parsing is
+verified without an AMD GPU present."""
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+import probe
+
+
+def _write(path, value):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(str(value))
+
+
+def _amd_card(drm, idx, *, total, used, busy, temp_mc=None, power_uw=None,
+              name=None, vendor="0x1002"):
+    """Lay down a single fake card<idx>/device/ node under <drm>."""
+    dev = os.path.join(drm, "card%d" % idx, "device")
+    _write(os.path.join(dev, "vendor"), vendor + "\n")
+    _write(os.path.join(dev, "mem_info_vram_total"), total)
+    _write(os.path.join(dev, "mem_info_vram_used"), used)
+    _write(os.path.join(dev, "gpu_busy_percent"), busy)
+    if temp_mc is not None:
+        _write(os.path.join(dev, "hwmon", "hwmon3", "temp1_input"), temp_mc)
+    if power_uw is not None:
+        _write(os.path.join(dev, "hwmon", "hwmon3", "power1_average"), power_uw)
+    if name is not None:
+        _write(os.path.join(dev, "product_name"), name)
+    return dev
+
+
+class TestAmdSysfs(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.drm = os.path.join(self.tmp, "drm")
+        os.makedirs(self.drm)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_app_collector_reads_card(self):
+        # 8 GiB total, 1 GiB used, 37% busy, 54.3°C, 42 W.
+        _amd_card(self.drm, 0, total=8 * 1024**3, used=1 * 1024**3, busy=37,
+                  temp_mc=54300, power_uw=42_000_000, name="AMD Radeon RX 7900 XTX")
+        gpus = app.amd_gpus(drm_root=self.drm)
+        self.assertEqual(len(gpus), 1)
+        g = gpus[0]
+        self.assertEqual(g["idx"], 0)
+        self.assertEqual(g["name"], "AMD Radeon RX 7900 XTX")
+        self.assertEqual(g["util"], 37.0)
+        self.assertEqual(g["mem_total"], 8192)
+        self.assertEqual(g["mem_used"], 1024)
+        self.assertEqual(g["temp"], 54.3)
+        self.assertEqual(g["power"], 42.0)
+
+    def test_probe_representative_matches(self):
+        _amd_card(self.drm, 0, total=16 * 1024**3, used=2 * 1024**3, busy=10,
+                  temp_mc=40000, name="AMD Instinct MI210")
+        out = probe._amd_gpu_sysfs(drm_root=self.drm)
+        self.assertIn("gpu", out)
+        self.assertEqual(out["gpu"]["count"], 1)
+        self.assertEqual(out["gpu"]["name"], "AMD Instinct MI210")
+        self.assertEqual(out["gpu"]["mem_total"], 16384)
+        self.assertEqual(out["gpu"]["mem_used"], 2048)
+        self.assertEqual(out["gpu"]["util"], 10)
+        self.assertEqual(out["gpu"]["temp"], 40)
+
+    def test_non_amd_vendor_is_skipped(self):
+        # An NVIDIA card (0x10de) in the same tree must be ignored by the AMD reader.
+        _amd_card(self.drm, 0, total=8 * 1024**3, used=0, busy=0, vendor="0x10de")
+        self.assertEqual(app.amd_gpus(drm_root=self.drm), [])
+        self.assertEqual(probe._amd_gpu_sysfs(drm_root=self.drm), {})
+
+    def test_missing_optional_fields_degrade_to_zero(self):
+        # No hwmon (temp/power) and no product_name → still a valid card, zeros + fallback name.
+        _amd_card(self.drm, 1, total=4 * 1024**3, used=512 * 1024**2, busy=0)
+        gpus = app.amd_gpus(drm_root=self.drm)
+        self.assertEqual(len(gpus), 1)
+        self.assertEqual(gpus[0]["name"], "AMD GPU 1")
+        self.assertEqual(gpus[0]["temp"], 0)
+        self.assertEqual(gpus[0]["power"], 0.0)
+        self.assertEqual(gpus[0]["mem_used"], 512)
+
+    def test_no_gpu_returns_empty(self):
+        self.assertEqual(app.amd_gpus(drm_root=self.drm), [])
+        self.assertEqual(probe._amd_gpu_sysfs(drm_root=self.drm), {})
+
+    def test_unreadable_root_is_safe(self):
+        missing = os.path.join(self.tmp, "does-not-exist")
+        self.assertEqual(app.amd_gpus(drm_root=missing), [])
+        self.assertEqual(probe._amd_gpu_sysfs(drm_root=missing), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds **AMD & Intel GPU support** so the GPU panel is no longer NVIDIA-only. The new paths are a strictly-additive fallback — consulted **only when `nvidia-smi` reports nothing** — so NVIDIA and GPU-less hosts behave exactly as before.

### Windows hosts (`probe.ps1`) — ✅ hardware-validated
When `nvidia-smi` is absent, `Read-Gpu` reads the GPU from Windows' built-in **GPU performance counters** (`\GPU Engine(*)\Utilization Percentage`, `\GPU Adapter Memory(*)\Dedicated Usage`) + **WMI** (adapter name, dedicated VRAM via the driver registry `qwMemorySize`). Covers **AMD and Intel**, including integrated graphics, with no vendor tools installed.

Validated live on an **AMD Radeon integrated GPU** (Windows 11), surfaced through the existing "monitor a Windows host over SSH" flow:
```
gpu: {name: "AMD Radeon (TM) Graphics", mem_used: 454, mem_total: 512, util: 4, vendor: "amd"}
```

### Linux hosts (`probe.py` + `app.py`) — ⚠️ parser-tested, not yet AMD-HW-validated
Reads AMD cards via the in-kernel **`amdgpu` sysfs** interface — no ROCm required:
`gpu_busy_percent`, `mem_info_vram_total`/`used`, and `hwmon/*/temp1_input` + `power1_average`. Wired into:
- `probe.py read_gpu()` — monitored remote Linux hosts (reads `/sys` in place).
- `app.py sample_once()` — the hub's own collector (reads the host's `/sys` through the `HOST_ROOT` mount).

I don't have an AMD **Linux** GPU to test on, so this path is covered by unit tests against a fake `/sys/class/drm` tree (`tests/test_amd_gpu.py`) but **needs a confirm on real AMD-on-Linux hardware**. The mechanism is the well-documented amdgpu sysfs, and it's additive + gated, so the risk to existing users is nil.

## Scope / limitations
- Per-card clock/throttle enrichment and **per-process VRAM attribution remain NVIDIA-only**. AMD shows the core panel (util / VRAM / temp / power); per-process AMD attribution is a follow-up.

## Tests / CI
- `python -m py_compile app.py probe.py` ✅
- New `tests/test_amd_gpu.py` (6 cases) ✅, existing `test_gputelemetry` + `test_multigpu` still green ✅

Bumps `0.18.0 → 0.19.0`. Addresses #1.
