### PR TITLE
feat(costs): busy-hours power/cost heatmap on the Costs tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ loosely based on [Keep a Changelog](https://keepachangelog.com/), and the
 project follows semantic-ish versioning. Each entry links to its full GitHub
 release notes.
 
+## [0.20.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.20.0) — 2026-06-23 · **Busy hours — see when your lab burns power**
+*A 7×24 day-of-week × hour heatmap on the Costs tab shows the rhythm of your lab at a glance — when it's busy, when it's idle, and (with a tariff set) when it's expensive.*
+
+**Added**
+- **Busy-hours heatmap on the Costs tab.** Every history sample is bucketed by its **local weekday and hour** and averaged, giving a 7×24 grid of typical total draw (GPU + CPU + DRAM). Colour scales by **cost-per-hour** once you've set a tariff, or by **power** otherwise — so it's useful even before you add a price. Callouts surface the **busiest** and **quietest** slots and, when priced, the spread between your busiest and quietest quarter of hours. Served from a new pure-Python `/api/cost/heatmap` endpoint (own 30-day window, aggregated outside the DB lock), reusing the same tariff machinery as the rest of the Costs page so the €/kWh maths never diverges. The grid is a real `<table>` with per-cell `aria-label`s, sparse cells are dimmed by sample count (honest about coverage), and it fills in after about a day of history.
+
 ## [0.19.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.19.0) — 2026-06-23 · **AMD & Intel GPUs join the party**
 *The GPU panel is no longer NVIDIA-only — AMD and Intel cards now show up too, with no vendor tools to install.*
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.19.0"
+VERSION      = "0.20.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
@@ -5306,6 +5306,143 @@ def api_costs():
         "tariff": {"mode": ctx["mode"], "price_day": ctx["day"], "price_night": ctx["night"],
                    "night_start": ctx["night_start"], "night_end": ctx["night_end"]},
         "machines": [machine], "components": series, "breakdown": breakdown[:40],
+    })
+
+@app.route("/api/cost/heatmap")
+def api_cost_heatmap():
+    """Busy-vs-quiet rhythm of the lab as a 7×24 grid (local day-of-week × hour).
+
+    Each historical `samples` row is the machine's total draw (GPU+CPU+DRAM) for
+    one INTERVAL tick. We bucket every tick by its LOCAL weekday/hour and average
+    the watts in each cell, then derive a cost-rate (€/h) for that cell at the
+    tariff's price for that hour band — reusing the same `_cost_ctx`/`_price_at`
+    machinery as the Costs page, so the €/kWh math never diverges. Sparse cells
+    carry their own sample count so the UI can be honest about coverage.
+
+    Pure-Python aggregation, read outside any held lock, always 200. When cost is
+    disabled (no tariff) we still return the power grid and `enabled:false` so the
+    card can render watts and prompt for a price.
+    """
+    ctx = _cost_ctx()
+    cur = ctx["currency"]
+    # window: last N days, sane default 30, capped at a year so a huge DB can't stall
+    try:
+        days = int(request.args.get("days", "30"))
+    except (TypeError, ValueError):
+        days = 30
+    days = max(1, min(days, 365))
+    now = int(time.time())
+    since = now - days * 86400
+
+    # 7×24 accumulators: summed watts and tick count per local day/hour cell
+    sum_w = [[0.0] * 24 for _ in range(7)]
+    cnt   = [[0]   * 24 for _ in range(7)]
+    span_min = span_max = None
+    try:
+        with LOCK:
+            c = DB.cursor()
+            rows = c.execute(
+                f"SELECT ts, {_TOTAL_W_EXPR} w FROM samples WHERE ts>=? ORDER BY ts",
+                (since,)).fetchall()
+        # aggregate OUTSIDE the lock — pure Python, no DB calls below
+        for ts, w in rows:
+            lt = time.localtime(ts)
+            # Python weekday(): Mon=0..Sun=6 — matches our locale day labels
+            d = lt.tm_wday
+            h = lt.tm_hour
+            sum_w[d][h] += (w or 0)
+            cnt[d][h] += 1
+            if span_min is None or ts < span_min:
+                span_min = ts
+            if span_max is None or ts > span_max:
+                span_max = ts
+    except Exception:
+        rows = []
+
+    # build the grids; price each cell at the tariff for a representative ts in it
+    rep_ts = span_max or now
+    rep_lt = time.localtime(rep_ts)
+    # anchor to local midnight of the most recent observed day so is_night() lands
+    # in the right band per (day,hour); the date component is irrelevant to the band
+    anchor = int(time.mktime((rep_lt.tm_year, rep_lt.tm_mon, rep_lt.tm_mday,
+                              0, 0, 0, 0, 0, -1)))
+    avg_w  = [[None] * 24 for _ in range(7)]
+    cost_h = [[None] * 24 for _ in range(7)]   # cost per HOUR at this cell's mean draw
+    max_w = max_cost = 0.0
+    busiest = quietest = None                  # by avg watts
+    total_ticks = 0
+    for d in range(7):
+        for h in range(24):
+            n = cnt[d][h]
+            total_ticks += n
+            if n == 0:
+                continue
+            aw = sum_w[d][h] / n
+            avg_w[d][h] = round(aw)
+            # price for this hour band: a ts at hour h on the anchor day
+            cell_ts = anchor + h * 3600
+            price = _price_at(ctx, cell_ts)
+            ch = aw / 1000.0 * price           # W -> kW * €/kWh = €/h
+            cost_h[d][h] = round(ch, 4)
+            max_w = max(max_w, aw)
+            max_cost = max(max_cost, ch)
+            if busiest is None or aw > busiest["avg_w"]:
+                busiest = {"day": d, "hour": h, "avg_w": round(aw),
+                           "cost_h": round(ch, 4), "samples": n}
+            if quietest is None or aw < quietest["avg_w"]:
+                quietest = {"day": d, "hour": h, "avg_w": round(aw),
+                            "cost_h": round(ch, 4), "samples": n}
+
+    # busy vs quiet bands: top/bottom quartile of populated cells by avg watts
+    populated = [(avg_w[d][h], cost_h[d][h])
+                 for d in range(7) for h in range(24) if avg_w[d][h] is not None]
+    bands = None
+    if len(populated) >= 4:
+        ordered = sorted(populated, key=lambda x: x[0])
+        q = max(1, len(ordered) // 4)
+        quiet_band = ordered[:q]
+        busy_band = ordered[-q:]
+        def band_stats(b):
+            return {"avg_w": round(sum(x[0] for x in b) / len(b)),
+                    "avg_cost_h": round(sum((x[1] or 0) for x in b) / len(b), 4),
+                    "cells": len(b)}
+        bands = {"busy": band_stats(busy_band), "quiet": band_stats(quiet_band)}
+
+    # per-day rollups (busiest / quietest day by mean watts across populated hours)
+    day_avg = [None] * 7
+    for d in range(7):
+        vals = [avg_w[d][h] for h in range(24) if avg_w[d][h] is not None]
+        if vals:
+            day_avg[d] = round(sum(vals) / len(vals))
+
+    coverage = round(total_ticks / max(1, days * 24 * 3600 / INTERVAL), 4)
+    # "ready" once we have at least a day's worth of ticks spread across cells
+    populated_cells = len(populated)
+    ready = total_ticks >= (86400 / INTERVAL) and populated_cells >= 6
+
+    return jsonify({
+        "ok": True,
+        "enabled": ctx["day"] > 0,
+        "currency": cur,
+        "days": days,
+        "interval_sec": INTERVAL,
+        "ready": ready,
+        "rows": 7, "cols": 24,
+        "avg_w": avg_w,
+        "cost_h": cost_h,
+        "samples": cnt,
+        "day_avg_w": day_avg,
+        "max_w": round(max_w),
+        "max_cost_h": round(max_cost, 4),
+        "busiest": busiest,
+        "quietest": quietest,
+        "bands": bands,
+        "total_ticks": total_ticks,
+        "populated_cells": populated_cells,
+        "coverage": coverage,
+        "span": {"min": span_min, "max": span_max},
+        "tariff": {"mode": ctx["mode"], "price_day": ctx["day"], "price_night": ctx["night"],
+                   "night_start": ctx["night_start"], "night_end": ctx["night_end"]},
     })
 
 @app.route("/api/costs/entity")

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -9,12 +9,14 @@
 :root{--mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,Consolas,monospace}
 :root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
 --crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;
+--heat-lo:#1f6f3c;--heat-mid:#d29922;--heat-hi:#f85149;
 --canvas:#0a0e14;--inset:#0d1117;--hover:#161b22;--sel:#1c232e;--sb:#0b0f15;
 --okbg:#3fb95018;--warnbg:#d2992218;--critbg:#f8514918;
 --mc-bloom:rgba(210,153,34,.28);--mc-bloom2:rgba(88,166,255,.15);--mc-glass:rgba(20,26,34,.62);--mc-glass2:rgba(13,17,23,.5);
 --mc-stroke:rgba(255,255,255,.09);--mc-shadow:0 18px 44px -22px rgba(0,0,0,.9);--mc-glow:rgba(227,179,65,.55);--mc-glowsoft:rgba(227,179,65,.22);--mc-grid:rgba(255,255,255,.022)}
 [data-theme="light"]{--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;--free:#eaeef2;
 --crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;
+--heat-lo:#2da44e;--heat-mid:#bf8700;--heat-hi:#cf222e;
 --canvas:#f6f8fa;--inset:#f6f8fa;--hover:#eef1f4;--sel:#e7ebf0;--sb:#f6f8fa;
 --okbg:#1a7f3714;--warnbg:#9a670014;--critbg:#cf222e14;
 --mc-bloom:rgba(210,153,34,.16);--mc-bloom2:rgba(9,105,218,.08);--mc-glass:rgba(255,255,255,.74);--mc-glass2:rgba(246,248,250,.7);
@@ -283,6 +285,25 @@ th{color:var(--mut);font-weight:600;font-size:12px}.dot{display:inline-block;wid
 .gpucard{border:1px solid var(--bd);border-radius:9px;padding:11px 13px;margin-bottom:10px;background:rgba(127,127,127,.04)}
 .gpucard:last-child{margin-bottom:0}
 .gpucard-h{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:7px;font-size:14px}
+/* ── Busy-hours power/cost heatmap (7×24) — Costs tab ── */
+.heat-callouts{display:flex;flex-wrap:wrap;gap:9px;margin:2px 0 14px}
+.heat-callout{flex:1 1 220px;border:1px solid var(--bd);border-radius:10px;padding:10px 12px;background:var(--inset)}
+.heat-callout .l{font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--mut);display:flex;align-items:center;gap:6px}
+.heat-callout .v{font-size:15px;font-weight:600;margin-top:3px;color:var(--tx)}
+.heat-callout .s{font-size:12px;color:var(--mut);margin-top:1px}
+.heat-callout.busy{border-color:var(--crit)}.heat-callout.busy .l{color:var(--crit)}
+.heat-callout.quiet{border-color:var(--ok)}.heat-callout.quiet .l{color:var(--ok)}
+.heat-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.heat-grid{border-collapse:separate;border-spacing:2px;font-size:11px;width:100%;min-width:560px}
+.heat-grid th{color:var(--mut);font-weight:500;text-transform:none;letter-spacing:0;font-size:10px;padding:0;text-align:center}
+.heat-grid th.hr{font-variant-numeric:tabular-nums}
+.heat-grid td.day{color:var(--mut);font-weight:600;text-align:right;padding-right:6px;white-space:nowrap;font-size:11px}
+.heat-grid td.cell{width:20px;height:18px;border-radius:3px;background:var(--free);transition:transform .08s ease;cursor:default}
+.heat-grid td.cell:hover{outline:2px solid var(--tx);outline-offset:-1px}
+@media(prefers-reduced-motion:no-preference){.heat-grid td.cell:hover{transform:scale(1.18)}}
+.heat-legend{display:flex;align-items:center;gap:8px;margin-top:11px;font-size:11px;color:var(--mut)}
+.heat-legend .bar{flex:0 0 160px;height:10px;border-radius:5px;background:linear-gradient(90deg,var(--heat-lo),var(--heat-mid),var(--heat-hi))}
+.vh{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .gpucard-stats{margin-left:auto;color:var(--mut);font-size:12px;font-variant-numeric:tabular-nums}
 .gpucard-row{display:flex;align-items:center;gap:9px;margin-top:5px;font-size:13px}
 .gpucard-lbl{flex:none;width:42px;color:var(--mut)}
@@ -1639,6 +1660,23 @@ body.mc-customizing .mc-board .mc-widget{ border-radius:12px }
       <p class="cap" id="costs-comp-cap" data-i18n="costs.comp_cap">GPU power is measured (nvidia-smi); CPU/DRAM are measured via RAPL when readable. "Other" appears only if you set a baseline in Settings — wall power is never guessed.</p>
     </div>
   </div>
+  <div class="card" id="heatmap-card" hidden>
+    <h2>🗓️ Busy hours — when your lab burns power
+      <span class="muted" id="heat-mode-chip" style="font-size:12px;font-weight:400;text-transform:none" hidden></span></h2>
+    <div id="heat-collecting" class="topproc-empty" hidden data-i18n="heat.collecting">Collecting data — the busy-hours map fills in as history accumulates (about a day of samples).</div>
+    <div id="heat-body" hidden>
+      <div class="heat-callouts" id="heat-callouts"></div>
+      <div class="heat-wrap">
+        <table class="heat-grid" id="heat-table" aria-describedby="heat-cap">
+          <caption class="vh" id="heat-cap" data-i18n="heat.a11y_caption">Average power draw by day of week and hour of day. Higher is busier and more expensive.</caption>
+          <thead><tr id="heat-head"></tr></thead>
+          <tbody id="heat-rows"></tbody>
+        </table>
+      </div>
+      <div class="heat-legend" id="heat-legend"></div>
+      <p class="cap" id="heat-cap-foot" data-i18n="heat.cap">Each cell is the average total draw (GPU + CPU + DRAM) for that local day-of-week and hour, over the chosen window. Colour scales by cost-rate when a tariff is set, otherwise by power. Sparse cells are dimmed — hover for the exact figures.</p>
+    </div>
+  </div>
   <div class="card" id="costs-breakdown-card" hidden>
     <h2 data-i18n="costs.breakdown_title">🧾 Breakdown by process / container / model</h2>
     <table><thead><tr>
@@ -2921,10 +2959,83 @@ async function renderCost(){
 
 // ── Costs page: per-machine → per-component → per-process, with drilldown ──────
 let COSTS_SORT={key:'energy_kwh',dir:-1}, COSTS_DATA=null, COSTS_AT=0;
+// ── Busy-hours heatmap: 7×24 day-of-week × hour grid coloured by cost-rate ─────
+// Reads /api/cost/heatmap (own window, default 30d). Colour scales by cost/hour when
+// a tariff is set, else by avg W. Always a <table> so screen readers / no-CSS get
+// the numbers; sparse cells are dimmed by sample count, never faked. Self-throttles
+// so renderCosts() can call it freely on every refresh.
+let HEAT_AT=0;
+function heatColor(t){            // t in [0,1] -> blend --heat-lo → --heat-mid → --heat-hi
+  const hex=v=>{const x=getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+    return [parseInt(x.slice(1,3),16),parseInt(x.slice(3,5),16),parseInt(x.slice(5,7),16)];};
+  const lo=hex('--heat-lo'), mid=hex('--heat-mid'), hi=hex('--heat-hi');
+  const lerp=(a,b,f)=>Math.round(a+(b-a)*f);
+  let c1,c2,f; if(t<0.5){c1=lo;c2=mid;f=t/0.5;} else {c1=mid;c2=hi;f=(t-0.5)/0.5;}
+  return `rgb(${lerp(c1[0],c2[0],f)},${lerp(c1[1],c2[1],f)},${lerp(c1[2],c2[2],f)})`;
+}
+async function renderHeatmap(force){
+  const card=document.getElementById('heatmap-card'); if(!card) return;
+  if(CURRENT_HOST!=='local'){ card.hidden=true; return; }
+  if(!force && Date.now()-HEAT_AT<20000 && card.dataset.loaded) return;
+  HEAT_AT=Date.now();
+  let j; try{ j=await(await fetch('/api/cost/heatmap?days=30')).json(); }catch(e){ card.hidden=true; return; }
+  if(!j||!j.ok){ card.hidden=true; return; }
+  card.hidden=false; card.dataset.loaded='1';
+  const collecting=document.getElementById('heat-collecting'), body=document.getElementById('heat-body');
+  const modeEl=document.getElementById('heat-mode-chip');
+  const byCost=!!j.enabled, cur=j.currency||'$';
+  if(modeEl){ modeEl.hidden=false;
+    modeEl.textContent = byCost ? I18N.t('heat.by_cost','· shaded by cost / hour') : I18N.t('heat.by_power','· shaded by power'); }
+  if(!j.ready){ collecting.hidden=false; body.hidden=true; return; }
+  collecting.hidden=true; body.hidden=false;
+  const days=(I18N.t('heat.days','Mon|Tue|Wed|Thu|Fri|Sat|Sun')).split('|');
+  const W=v=>v+' W', money=v=>cur+(+v).toFixed(v<1?3:2);
+  const maxV = byCost ? (j.max_cost_h||1) : (j.max_w||1);
+  // header: hour ticks (every 3h to stay legible; the cell aria-labels keep full info)
+  const head=document.getElementById('heat-head');
+  head.innerHTML='<th scope="col"><span class="vh">'+I18N.t('heat.day_col','Day')+'</span></th>'+
+    Array.from({length:24},(_,h)=>`<th scope="col" class="hr">${h%3===0?String(h).padStart(2,'0'):''}</th>`).join('');
+  const rows=document.getElementById('heat-rows');
+  rows.innerHTML=j.avg_w.map((row,d)=>{
+    const cells=row.map((aw,h)=>{
+      const n=j.samples[d][h];
+      if(aw==null||!n) return `<td class="cell" aria-label="${esc(days[d])} ${String(h).padStart(2,'0')}:00 — ${I18N.t('heat.no_data','no data')}"></td>`;
+      const ch=j.cost_h[d][h], v=byCost?ch:aw;
+      const t=Math.max(0,Math.min(1,(v||0)/maxV));
+      // dim cells with thin coverage so sparse data reads as less certain
+      const op=Math.min(1,0.35+0.65*Math.min(1,n/Math.max(1,j.total_ticks/Math.max(1,j.populated_cells)/2)));
+      const tip=`${days[d]} ${String(h).padStart(2,'0')}:00 · ${W(aw)}${byCost?' · '+money(ch)+'/h':''} · ${I18N.tf('heat.n_samples','{n} samples',{n})}`;
+      return `<td class="cell" title="${esc(tip)}" aria-label="${esc(tip)}" style="background:${heatColor(t)};opacity:${op.toFixed(2)}"></td>`;
+    }).join('');
+    return `<tr><td class="day" scope="row">${esc(days[d])}</td>${cells}</tr>`;
+  }).join('');
+  // legend
+  const leg=document.getElementById('heat-legend');
+  leg.innerHTML=`<span>${byCost?I18N.t('heat.cheap','cheaper'):I18N.t('heat.quiet_l','quieter')}</span>`+
+    `<span class="bar"></span><span>${byCost?I18N.tf('heat.up_to','up to {v}/h',{v:money(maxV)}):I18N.tf('heat.up_to_w','up to {v} W',{v:Math.round(maxV)})}</span>`;
+  // callouts: busiest vs quietest slot, and busy-vs-quiet bands (when priced)
+  const co=document.getElementById('heat-callouts'); co.innerHTML='';
+  const fmtSlot=s=>`${days[s.day]} ${String(s.hour).padStart(2,'0')}:00`;
+  if(j.busiest){ const b=j.busiest;
+    co.insertAdjacentHTML('beforeend',`<div class="heat-callout busy"><div class="l">🔺 ${I18N.t('heat.busiest','Busiest slot')}</div>`+
+      `<div class="v">${esc(fmtSlot(b))}</div><div class="s">${W(b.avg_w)}${byCost?' ≈ '+money(b.cost_h)+'/h':''}</div></div>`);
+  }
+  if(j.quietest){ const q=j.quietest;
+    co.insertAdjacentHTML('beforeend',`<div class="heat-callout quiet"><div class="l">🔻 ${I18N.t('heat.quietest','Quietest slot')}</div>`+
+      `<div class="v">${esc(fmtSlot(q))}</div><div class="s">${W(q.avg_w)}${byCost?' ≈ '+money(q.cost_h)+'/h':''}</div></div>`);
+  }
+  if(j.bands && byCost){
+    co.insertAdjacentHTML('beforeend',`<div class="heat-callout"><div class="l">⚖️ ${I18N.t('heat.bands','Busy vs quiet bands')}</div>`+
+      `<div class="v">${money(j.bands.busy.avg_cost_h)}/h ${I18N.t('heat.vs','vs')} ${money(j.bands.quiet.avg_cost_h)}/h</div>`+
+      `<div class="s">${I18N.t('heat.bands_sub','busiest quarter vs quietest quarter of hours')}</div></div>`);
+  }
+}
+
 async function renderCosts(force){
   const card=document.getElementById('costs-card'); if(!card) return;
   if(CURRENT_HOST!=='local'){ renderLocalOnlyNotice('costs'); return; }
   clearLocalOnlyNotice('costs');
+  renderHeatmap(force);   // busy-hours heatmap renders even with no tariff (power-only)
   if(!force && Date.now()-COSTS_AT < 20000) return;   // throttle live refresh
   COSTS_AT=Date.now();
   let j; try{ j=await(await fetch('/api/costs?range='+encodeURIComponent(R))).json(); }catch(e){ card.hidden=true; return; }


### PR DESCRIPTION
## What

Ports the **"Busy hours — when your lab burns power"** heatmap from the `next_ai` prototype onto `next`, **re-styled to look native** (not a paste-over).

A 7×24 grid (local weekday × hour) on the **Costs tab** showing the rhythm of the lab — when it draws power, when it's idle, and (with a tariff set) when it's expensive.

### Backend
- New `GET /api/cost/heatmap` (pure-Python): buckets every `samples` row by **local weekday/hour**, averages total draw (GPU + CPU + DRAM), and prices each cell via the existing `_cost_ctx`/`_price_at` machinery — so the €/kWh maths never diverges from the rest of the Costs page. Aggregated **outside the DB lock**, always 200, returns the power grid with `enabled:false` when no tariff is set.

### Frontend — adapted to next's idiom
- **Card header** uses next's plain `<h2>` + muted inline sub-span (exactly like the existing Costs header) — dropped next_ai's `.card-h`/`.ch-space`/`.chip` wrapper that doesn't exist on `next`.
- **Styling** is built on next's existing tokens (`--bd/--inset/--mut/--tx/--crit/--ok/--free`); the only new tokens are a `--heat-lo/mid/hi` ramp added to **both** the dark and light themes, matching next's GitHub-style palette.
- Real `<table>` with per-cell `aria-label`s + a `vh` caption; sparse cells dimmed by sample count (honest about coverage); busiest/quietest callouts, and a busy-vs-quiet band stat when priced.
- `renderHeatmap()` hangs off the existing `renderCosts()` and self-throttles (20s); reuses `esc`/`I18N.t`/`I18N.tf`.

## Verification
- `python -m py_compile app.py` ✅
- Image **builds + boots** (CI parity) ✅
- `/api/cost/heatmap` exercised against seeded history: `ready:true`, 52 populated cells, **busiest = hour 15 / quietest = hour 3** — matching the seeded midday-peak pattern, confirming the local day/hour bucketing.
- Page serves with the card + renderer present.

Bumps `0.19.0 → 0.20.0`.

> Note: visual styling validated against next's tokens/structure; a final eyeball on a populated AMD/GPU instance is worth doing once `:next` ships. The grid only fills in after ~a day of history (shows a "collecting" state until then).
