### PR TITLE
Add TLS certificate expiry tracking for uptime checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,6 +165,7 @@ _SAMPLE_MIGRATIONS = ("cpu REAL", "ram_used REAL", "ram_total REAL", "load1 REAL
 _HOST_MIGRATIONS = ("poll_timeout INTEGER", "poll_fails INTEGER DEFAULT 0", "poll_calibrated_at INTEGER")
 # Which API key pushed a run (for per-key attribution); added to the runs table.
 _RUNS_MIGRATIONS = ("key_id TEXT",)
+_UPTIME_MIGRATIONS = ("cert_days_remaining INTEGER", "cert_expires_at INTEGER")
 
 def _data_dir():
     return os.path.dirname(os.path.abspath(DB_PATH)) or "."
@@ -197,6 +198,11 @@ def _apply_schema_migrations(conn):
     for col in _RUNS_MIGRATIONS:
         try:
             conn.execute(f"ALTER TABLE runs ADD COLUMN {col}")
+        except sqlite3.OperationalError:
+            pass
+    for col in _UPTIME_MIGRATIONS:
+        try:
+            conn.execute(f"ALTER TABLE uptime_results ADD COLUMN {col}")
         except sqlite3.OperationalError:
             pass
     # Migrate a legacy single instance-wide api_key (the previous design) into the
@@ -4089,6 +4095,35 @@ def _http_probe_once(target, timeout, method):
             raise
     return last_code
 
+
+
+def _tls_cert_days(host, port, timeout):
+    """Return (days_remaining, expires_at_ts) or (None, None)."""
+    import ssl, datetime
+
+    try:
+        ctx = ssl.create_default_context()
+        with ctx.wrap_socket(
+            __import__("socket").create_connection((host, port), timeout=timeout),
+            server_hostname=host,
+        ) as ssock:
+            cert = ssock.getpeercert()
+            not_after = cert.get("notAfter", "")
+            if not not_after:
+                return None, None
+
+            exp = datetime.datetime.strptime(
+                not_after,
+                "%b %d %H:%M:%S %Y %Z"
+            ).replace(tzinfo=datetime.timezone.utc)
+
+            delta = exp - datetime.datetime.now(datetime.timezone.utc)
+            return max(0, delta.days), int(exp.timestamp())
+
+    except Exception:
+        return None, None
+
+
 def probe_http(target, timeout, expected=None):
     """GET the URL, following ≤ _UPTIME_MAX_REDIRECTS redirects. Returns
     (up, latency_ms, code, err). up = connected AND status matches expected (or any
@@ -4125,36 +4160,44 @@ def probe_tcp(target, timeout):
         latency = round((time.monotonic() - start) * 1000, 1)
         return False, latency, None, _redact_target(str(e))[:200]
 
+
 def run_uptime_check(check):
-    """Execute one check (dict) and persist its result. The probe is bounded by the
-    check's timeout; the only LOCK held is the brief DB write. Called from the
-    dedicated uptime worker thread. Returns the result dict."""
     ctype = check["type"]
     timeout = min(int(check.get("timeout_sec") or 10), _UPTIME_MAX_TIMEOUT)
+
     if ctype == "tcp":
         up, latency, code, err = probe_tcp(check["target"], timeout)
     else:
         up, latency, code, err = probe_http(check["target"], timeout, check.get("expected_status"))
-    ts = int(time.time())
-    if not _DB_MAINTENANCE:
-        try:
-            with LOCK:
-                DB.execute("INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err) "
-                           "VALUES(?,?,?,?,?,?)",
-                           (check["id"], ts, 1 if up else 0, latency, code, err))
-                # Per-check ring buffer: keep only the newest CAP rows. Trim by rowid
-                # (monotonic + unique) so it's exact even when many results share a
-                # second — a ts-based MIN() would under-trim on timestamp collisions.
-                DB.execute(
-                    "DELETE FROM uptime_results WHERE check_id=? AND rowid NOT IN "
-                    "(SELECT rowid FROM uptime_results WHERE check_id=? "
-                    "ORDER BY rowid DESC LIMIT ?)",
-                    (check["id"], check["id"], _UPTIME_RESULT_CAP))
-                DB.commit()
-        except Exception as e:
-            print("uptime persist error:", e, flush=True)
-    return {"ts": ts, "up": up, "latency_ms": latency, "code": code, "err": err}
 
+    ts = int(time.time())
+
+    cert_days = None
+    cert_expires_at = None
+
+    if ctype != "tcp" and check["target"].lower().startswith("https://"):
+        import urllib.parse
+        parsed = urllib.parse.urlparse(check["target"])
+        host = parsed.hostname
+        port = parsed.port or 443
+
+        cert_days, cert_expires_at = _tls_cert_days(host, port, min(timeout, 10))
+
+    DB.execute(
+        "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (check["id"], ts, 1 if up else 0, latency, code, err, cert_days, cert_expires_at)
+    )
+
+    DB.execute(
+        "DELETE FROM uptime_results WHERE check_id=? AND rowid NOT IN "
+        "(SELECT rowid FROM uptime_results WHERE check_id=? ORDER BY rowid DESC LIMIT ?)",
+        (check["id"], check["id"], _UPTIME_RESULT_CAP)
+    )
+
+    DB.commit()
+
+    return {"ts": ts, "up": up, "latency_ms": latency, "code": code, "err": err}
 def _uptime_state(check_id, now, window=86400, window2=604800):
     """Read-only summary for one check: current state (up/down/unknown), last latency,
     uptime% over `window` (24h) and `window2` (7d), last_checked, last_err, and a
@@ -4162,13 +4205,13 @@ def _uptime_state(check_id, now, window=86400, window2=604800):
     since, since2 = now - window, now - window2
     with LOCK:
         rows = DB.execute(
-            "SELECT ts,up,latency_ms,code,err FROM uptime_results WHERE check_id=? AND ts>=? "
+            "SELECT ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at FROM uptime_results WHERE check_id=? AND ts>=? "
             "ORDER BY ts", (check_id, since)).fetchall()
         agg2 = DB.execute(
             "SELECT COUNT(*), SUM(up) FROM uptime_results WHERE check_id=? AND ts>=?",
             (check_id, since2)).fetchone()
         last = DB.execute(
-            "SELECT ts,up,latency_ms,code,err FROM uptime_results WHERE check_id=? "
+            "SELECT ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at FROM uptime_results WHERE check_id=? "
             "ORDER BY ts DESC LIMIT 1", (check_id,)).fetchone()
     total = len(rows)
     up_n = sum(1 for r in rows if r[1])

--- a/app.py
+++ b/app.py
@@ -4182,9 +4182,22 @@ def _uptime_state(check_id, now, window=86400, window2=604800):
         last_checked, last_latency, last_code, last_err = last[0], last[2], last[3], last[4]
     # Heartbeat strip: most recent up-to-N results, oldest→newest, carrying {up, t}.
     strip = [{"up": bool(r[1]), "t": r[0]} for r in rows[-_UPTIME_STRIP_CELLS:]]
+    # Surface the most recent cert expiry data (index 5, 6 from the last row).
+    cert_days = last[5] if last and len(last) > 5 else None
+    cert_expires_at = last[6] if last and len(last) > 6 else None
+    cert_status = None
+    if cert_days is not None:
+        if cert_days <= 7:
+            cert_status = "red"
+        elif cert_days <= 21:
+            cert_status = "amber"
+        else:
+            cert_status = "ok"
     return {"state": state, "uptime": uptime, "uptime7": uptime7, "window_total": total,
             "last_latency_ms": last_latency, "last_checked": last_checked,
-            "last_code": last_code, "last_err": last_err, "strip": strip}
+            "last_code": last_code, "last_err": last_err, "strip": strip,
+            "cert_days_remaining": cert_days, "cert_expires_at": cert_expires_at,
+            "cert_status": cert_status}
 
 def uptime_overview(window=86400):
     """All checks + their current state. The user-facing private payload."""

--- a/app.py
+++ b/app.py
@@ -4099,16 +4099,18 @@ def _http_probe_once(target, timeout, method):
 
 def _tls_cert_days(host, port, timeout):
     """Return (days_remaining, expires_at_ts) or (None, None)."""
-    import ssl, datetime
+    import ssl, datetime, socket
 
     try:
-        ctx = ssl.create_default_context()
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
         with ctx.wrap_socket(
-            __import__("socket").create_connection((host, port), timeout=timeout),
+            socket.create_connection((host, port), timeout=timeout),
             server_hostname=host,
         ) as ssock:
             cert = ssock.getpeercert()
-            not_after = cert.get("notAfter", "")
+            not_after = cert.get("notAfter", "") if cert else ""
             if not not_after:
                 return None, None
 
@@ -4183,19 +4185,26 @@ def run_uptime_check(check):
 
         cert_days, cert_expires_at = _tls_cert_days(host, port, min(timeout, 10))
 
-    DB.execute(
-        "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
-        "VALUES(?,?,?,?,?,?,?,?)",
-        (check["id"], ts, 1 if up else 0, latency, code, err, cert_days, cert_expires_at)
-    )
+    if _DB_MAINTENANCE:
+        return {"ts": ts, "up": up, "latency_ms": latency, "code": code, "err": err}
 
-    DB.execute(
-        "DELETE FROM uptime_results WHERE check_id=? AND rowid NOT IN "
-        "(SELECT rowid FROM uptime_results WHERE check_id=? ORDER BY rowid DESC LIMIT ?)",
-        (check["id"], check["id"], _UPTIME_RESULT_CAP)
-    )
+    try:
+        with LOCK:
+            DB.execute(
+                "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
+                "VALUES(?,?,?,?,?,?,?,?)",
+                (check["id"], ts, 1 if up else 0, latency, code, err, cert_days, cert_expires_at)
+            )
 
-    DB.commit()
+            DB.execute(
+                "DELETE FROM uptime_results WHERE check_id=? AND rowid NOT IN "
+                "(SELECT rowid FROM uptime_results WHERE check_id=? ORDER BY rowid DESC LIMIT ?)",
+                (check["id"], check["id"], _UPTIME_RESULT_CAP)
+            )
+
+            DB.commit()
+    except Exception as e:
+        print("run_uptime_check DB error:", e, flush=True)
 
     return {"ts": ts, "up": up, "latency_ms": latency, "code": code, "err": err}
 def _uptime_state(check_id, now, window=86400, window2=604800):
@@ -4749,6 +4758,19 @@ def notify_uptime(s):
                       f"{tgt} — {round(lat)} ms (warns above {lw} ms).", rules=rules)
             else:
                 _clear(slow_key)
+            cert_key = f"uptime:cert:{cid}"
+            cert_days = st.get("cert_days_remaining")
+            if cert_days is not None:
+                if cert_days <= 7:
+                    _emit(s, cert_key, "critical", f"🔒 {c['label']} TLS cert expiring",
+                          f"{tgt} — cert expires in {cert_days}d.", rules=rules)
+                elif cert_days <= 21:
+                    _emit(s, cert_key, "warning", f"🔒 {c['label']} TLS cert expiring soon",
+                          f"{tgt} — cert expires in {cert_days}d.", rules=rules)
+                else:
+                    _clear(cert_key)
+            else:
+                _clear(cert_key)
 
 # ── Sampling ────────────────────────────────────────────────────────────────
 def smi(args):

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1069,6 +1069,7 @@ body.mc-customizing .mc-whide:hover{ color:var(--crit); border-color:var(--crit)
 .mc-pill-ok{ background:var(--okbg); color:var(--ok); border-color:var(--ok) }
 .mc-pill-warn{ background:var(--warnbg); color:var(--warn); border-color:var(--warn); cursor:help }
 .mc-pill-crit{ background:var(--critbg); color:var(--crit); border-color:var(--crit) }
+.cert-ok{ color:var(--ok) } .cert-amber{ color:var(--warn) } .cert-red{ color:var(--crit) }
 .mc-svc-line{ display:flex; align-items:baseline; gap:8px; margin-bottom:7px }
 .mc-failed-note{ font-size:10px; color:var(--mut); position:relative; cursor:help; display:inline-flex; align-items:center; gap:5px }
 .mc-tip{ position:absolute; bottom:130%; left:0; width:255px; background:var(--card); border:1px solid var(--bd); border-radius:9px;
@@ -3829,6 +3830,9 @@ function upCard(c){
   const up=c.uptime!=null?c.uptime+'%':'—';
   const up7=c.uptime7!=null?c.uptime7+'%':'—';
   const lat=c.last_latency_ms!=null?Math.round(c.last_latency_ms)+' ms':'—';
+  const certPill=(c.cert_days_remaining!=null)
+    ? `<span>${esc(I18N.t('uptime.cert','Cert'))} <b class="cert-${esc(c.cert_status||'ok')}">${esc(I18N.tf('uptime.cert_days','{d}d',{d:c.cert_days_remaining}))}</b></span>`
+    : '';
   const tgt=c.type==='http'?c.target:(I18N.t('uptime.tcp_prefix','TCP')+' '+c.target);
   const dotcls=st==='up'?'mc-on':st==='down'?'mc-offdot':'';
   const pill=st==='up'?`<span class="mc-pill mc-pill-ok">${esc(upStateLabel(st))}</span>`
@@ -3858,6 +3862,7 @@ function upCard(c){
       <span>${esc(I18N.t('uptime.uptime7','7d'))} <b>${up7}</b></span>
       <span>${esc(I18N.t('uptime.latency','Latency'))} <b>${lat}</b></span>
       <span>${esc(I18N.t('uptime.checked','Checked'))} <b>${esc(c.last_checked?relTime(c.last_checked):'—')}</b></span>
+      ${certPill}
     </div>
     ${err}
     ${bell}

--- a/tests/test_uptime.py
+++ b/tests/test_uptime.py
@@ -492,3 +492,86 @@ class TestApi(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestTlsCertExpiry(unittest.TestCase):
+    """Tests for _tls_cert_days and cert_status surfacing in _uptime_state."""
+
+    def test_cert_days_returns_days_and_expiry(self):
+        """_tls_cert_days parses a real-looking cert notAfter and returns correct days."""
+        import datetime, ssl
+        mock_cert = {"notAfter": "Dec 31 23:59:59 2099 GMT"}
+        mock_ssock = MagicMock()
+        mock_ssock.__enter__ = MagicMock(return_value=mock_ssock)
+        mock_ssock.__exit__ = MagicMock(return_value=False)
+        mock_ssock.getpeercert.return_value = mock_cert
+        with patch("ssl.create_default_context") as mock_ctx,              patch("socket.create_connection", return_value=MagicMock()):
+            mock_ctx.return_value.wrap_socket.return_value = mock_ssock
+            days, expires_at = app._tls_cert_days("example.com", 443, 5)
+        self.assertIsNotNone(days)
+        self.assertGreater(days, 365 * 70)  # far future cert
+        self.assertIsNotNone(expires_at)
+
+    def test_cert_days_returns_none_on_error(self):
+        """_tls_cert_days returns (None, None) on connection error."""
+        with patch("socket.create_connection", side_effect=OSError("refused")):
+            days, expires_at = app._tls_cert_days("bad.host", 443, 1)
+        self.assertIsNone(days)
+        self.assertIsNone(expires_at)
+
+    def test_cert_status_red_when_le_7_days(self):
+        """cert_status is 'red' when cert_days_remaining <= 7."""
+        _clean_db()
+        cid, _ = app.create_uptime_check(
+            {"label": "tls-test", "type": "http", "target": "https://expiring.example.com"})
+        ts = int(time.time())
+        with app.LOCK:
+            app.DB.execute(
+                "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
+                "VALUES(?,?,?,?,?,?,?,?)",
+                (cid, ts, 1, 10.0, 200, None, 5, ts + 5 * 86400))
+            app.DB.commit()
+        state = app._uptime_state(cid, ts + 1)
+        self.assertEqual(state["cert_status"], "red")
+        self.assertEqual(state["cert_days_remaining"], 5)
+
+    def test_cert_status_amber_when_le_21_days(self):
+        """cert_status is 'amber' when cert_days_remaining <= 21."""
+        _clean_db()
+        cid, _ = app.create_uptime_check(
+            {"label": "tls-amber", "type": "http", "target": "https://soon.example.com"})
+        ts = int(time.time())
+        with app.LOCK:
+            app.DB.execute(
+                "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
+                "VALUES(?,?,?,?,?,?,?,?)",
+                (cid, ts, 1, 10.0, 200, None, 15, ts + 15 * 86400))
+            app.DB.commit()
+        state = app._uptime_state(cid, ts + 1)
+        self.assertEqual(state["cert_status"], "amber")
+
+    def test_cert_status_ok_when_gt_21_days(self):
+        """cert_status is 'ok' when cert_days_remaining > 21."""
+        _clean_db()
+        cid, _ = app.create_uptime_check(
+            {"label": "tls-ok", "type": "http", "target": "https://healthy.example.com"})
+        ts = int(time.time())
+        with app.LOCK:
+            app.DB.execute(
+                "INSERT INTO uptime_results(check_id,ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at) "
+                "VALUES(?,?,?,?,?,?,?,?)",
+                (cid, ts, 1, 10.0, 200, None, 60, ts + 60 * 86400))
+            app.DB.commit()
+        state = app._uptime_state(cid, ts + 1)
+        self.assertEqual(state["cert_status"], "ok")
+
+    def test_cert_status_none_for_tcp_check(self):
+        """cert_status is None when no cert data exists (TCP check or no results yet)."""
+        _clean_db()
+        cid, _ = app.create_uptime_check(
+            {"label": "tcp-check", "type": "tcp", "target": "host:443"})
+        ts = int(time.time())
+        _insert_results(cid, [(ts, 1)])
+        state = app._uptime_state(cid, ts + 1)
+        self.assertIsNone(state["cert_status"])
+        self.assertIsNone(state["cert_days_remaining"])
+

--- a/tests/test_uptime.py
+++ b/tests/test_uptime.py
@@ -519,6 +519,33 @@ class TestTlsCertExpiry(unittest.TestCase):
         self.assertIsNone(days)
         self.assertIsNone(expires_at)
 
+    def test_cert_days_reads_expired_cert_unverified(self):
+        """_tls_cert_days must still return a date for an expired/self-signed cert.
+
+        A verifying SSLContext raises during the handshake on these certs,
+        before getpeercert() ever runs, which silently breaks the expiry
+        monitor at the exact moment it matters. This confirms the context
+        is built with check_hostname=False / verify_mode=CERT_NONE so the
+        unverified read succeeds and yields a negative days_remaining."""
+        import ssl
+        mock_cert = {"notAfter": "Jan 01 00:00:00 2000 GMT"}  # long-expired
+        mock_ssock = MagicMock()
+        mock_ssock.__enter__ = MagicMock(return_value=mock_ssock)
+        mock_ssock.__exit__ = MagicMock(return_value=False)
+        mock_ssock.getpeercert.return_value = mock_cert
+        mock_ctx_instance = MagicMock()
+        mock_ctx_instance.wrap_socket.return_value = mock_ssock
+        with patch("ssl.SSLContext", return_value=mock_ctx_instance) as mock_ctx_cls,              patch("socket.create_connection", return_value=MagicMock()):
+            days, expires_at = app._tls_cert_days("expired.example.com", 443, 5)
+        # The expiry read must succeed unconditionally — this is the exact
+        # case (expired cert) that a verifying context would have raised on.
+        self.assertIsNotNone(days)
+        self.assertIsNotNone(expires_at)
+        self.assertEqual(days, 0)  # max(0, negative_delta) per the function's floor
+        # Confirm the context is unverified, not the verifying default.
+        self.assertEqual(mock_ctx_instance.check_hostname, False)
+        self.assertEqual(mock_ctx_instance.verify_mode, ssl.CERT_NONE)
+
     def test_cert_status_red_when_le_7_days(self):
         """cert_status is 'red' when cert_days_remaining <= 7."""
         _clean_db()

--- a/tests/test_uptime.py
+++ b/tests/test_uptime.py
@@ -504,8 +504,9 @@ class TestTlsCertExpiry(unittest.TestCase):
         mock_ssock.__enter__ = MagicMock(return_value=mock_ssock)
         mock_ssock.__exit__ = MagicMock(return_value=False)
         mock_ssock.getpeercert.return_value = mock_cert
-        with patch("ssl.create_default_context") as mock_ctx,              patch("socket.create_connection", return_value=MagicMock()):
-            mock_ctx.return_value.wrap_socket.return_value = mock_ssock
+        mock_ctx_instance = MagicMock()
+        mock_ctx_instance.wrap_socket.return_value = mock_ssock
+        with patch("ssl.SSLContext", return_value=mock_ctx_instance),              patch("socket.create_connection", return_value=MagicMock()):
             days, expires_at = app._tls_cert_days("example.com", 443, 5)
         self.assertIsNotNone(days)
         self.assertGreater(days, 365 * 70)  # far future cert


### PR DESCRIPTION
Adds TLS certificate expiry tracking to uptime checks using stdlib ssl. Stores remaining days + expiry timestamp and exposes them in uptime results and alerts (7d critical, 21d warning).