### PR TITLE
ci: add Claude review workflow to next

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,5 +73,9 @@ jobs:
             `confirmed: true`) for specific code issues.
             Only post GitHub comments — don't return review text as a message.
 
+          # Read/Grep/Glob let the reviewer open files in the checkout for
+          # cross-file context (the diff alone misses surrounding-code checks);
+          # the gh tools are for posting feedback. id-token:write above is used
+          # by the action to exchange OIDC for a GitHub App token — keep it.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,77 @@
+name: Claude Code Review
+
+# Automated AI code review on pull requests. Runs the official Claude Code
+# Action (https://github.com/anthropics/claude-code-action) against the PR
+# diff and posts findings back as inline + summary comments — a second pair
+# of eyes on every change before it lands on `next` / `main`.
+#
+# Auth: uses a Claude subscription OAuth token (CLAUDE_CODE_OAUTH_TOKEN),
+# generated locally with `claude setup-token` and stored as a repo secret.
+# This bills against the Claude plan rather than the metered Anthropic API.
+#
+# Triggers: PRs targeting `next` (the integration branch) or `main`, on open
+# and on every new push to the PR (synchronize). Forked-PR runs get no secret
+# access from GitHub by design, so the review simply no-ops there (guarded
+# below) instead of failing red.
+
+on:
+  pull_request:
+    branches: [next, main]
+    types: [opened, synchronize]
+
+# Least-privilege: read the code, write PR comments, and mint the OIDC token
+# the action uses. No contents:write — the reviewer never pushes.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+# One review per PR; a new push cancels an in-flight review of the old commit.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Skip when the secret is absent (e.g. PRs from forks) so those runs stay
+    # green instead of erroring on missing auth.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. The PR branch is already checked out in
+            the current working directory. This is a self-hosted homelab
+            monitoring app: a Python Flask backend (app.py), an SSH/Docker probe
+            (probe.py), and a single-page dashboard (static/dashboard.html).
+
+            Focus on, in priority order:
+            - Correctness bugs and regressions (probe parsing, SQLite access,
+              concurrency, error handling).
+            - Security: leaked secrets/credentials, SSH/command injection,
+              unsafe subprocess or shell usage, SSRF in outbound requests.
+            - Dashboard changes: reuse of existing component classes
+              (mc-panel, mc-sdot/mc-pill, .rb/.btn-mini, ICONS/sic() icons)
+              rather than new ad-hoc styles or raw-emoji icons.
+            - Performance and obvious simplifications.
+
+            Be concise and concrete. Skip nitpicks and style-only comments.
+            If the change looks clean, say so briefly rather than inventing
+            findings.
+
+            Use `gh pr comment` for a short top-level summary.
+            Use `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for specific code issues.
+            Only post GitHub comments — don't return review text as a message.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/README.md
+++ b/README.md
@@ -142,5 +142,3 @@ Issues and PRs are very welcome — especially new model-server probes, new moni
 ## License
 
 MIT — see [LICENSE](LICENSE).
-
-<!-- ci: throwaway change to verify the Claude review workflow posts; will be reverted -->

--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ Issues and PRs are very welcome — especially new model-server probes, new moni
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+<!-- ci: throwaway change to verify the Claude review workflow posts; will be reverted -->


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml` to the `next` integration branch (identical to the copy merged to `main` in #200).

Why both branches: the action validates the file against the **default branch (main)**, *and* GitHub only triggers a `pull_request` workflow if the file exists in the PR's **head branch**. Since everyone branches off `next`, `next` needs the file too — otherwise PRs into `next` never trigger a review.

This PR doubles as the live verification: its own branch now carries the file, so the `review` job should run for real and post a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)