### PR TITLE
ci: let Claude reviewer read checkout files

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,5 +73,9 @@ jobs:
             `confirmed: true`) for specific code issues.
             Only post GitHub comments — don't return review text as a message.
 
+          # Read/Grep/Glob let the reviewer open files in the checkout for
+          # cross-file context (the diff alone misses surrounding-code checks);
+          # the gh tools are for posting feedback. id-token:write above is used
+          # by the action to exchange OIDC for a GitHub App token — keep it.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Follow-up to #200. The reviewer's own first run (on #201) flagged that `--allowedTools` only permitted `gh pr diff/view/comment` + inline comments — so Claude could see the diff but **not read any file in the checkout**, despite the prompt asking it to review `app.py`/`probe.py`/`dashboard.html`. Adds `Read,Grep,Glob` so cross-file context works and the `checkout` step isn't wasted.

(The reviewer also suggested dropping `id-token: write`; rejected — the v1 action uses it to exchange OIDC for a GitHub App token, as the #200 run log confirms. Kept, with a comment explaining why.)

Must stay byte-identical to the copy on `next` (#201) for the action's default-branch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)