### PR TITLE
fix(gpu): detect GPU when nvidia isn't Docker's default runtime (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release notes.
 **Changed**
 - Wired the new Alerts form labels to the locale files so translated dashboards automatically pick up the email/Slack/webhook copy.
 
+**Fixed**
+- **GPU went undetected on hosts where nvidia isn't Docker's default runtime** (stock Ubuntu/Debian/Mint, where GPU containers normally opt in per-container with `--gpus all`). The monitor exposed the card only through the `NVIDIA_*` env vars, which the toolkit honours only for the default runtime — so the card worked everywhere else but the dashboard reported "no GPU detected" (#203). Added a **`docker-compose.gpu.yml` override** that requests the nvidia runtime for just this container (no global-default change, still starts on GPU-less hosts), and corrected the Setup-tab remedy + compose comments to include the **`--force-recreate`** step a plain restart was silently skipping.
+
 ## [0.21.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.21.0) — 2026-06-23 · **See your power bill by the hour — and which GPU is burning it**
 *Three new questions answered at a glance: when is your lab most expensive, which GPU is doing the work (whoever made it), and is anything down?*
 

--- a/app.py
+++ b/app.py
@@ -2507,7 +2507,7 @@ def local_diagnostics():
                "cmd": "sudo nvidia-ctk runtime configure --runtime=docker --set-as-default\n"
                       "sudo systemctl restart docker\n"
                       "docker compose up -d --force-recreate   # recreate — restart keeps the old runtime\n"
-                      "# don't want nvidia as the global default? instead of the two lines above:\n"
+                      "# don't want nvidia as the global default? skip all three lines above and instead run:\n"
                       "#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d"})
     # Docker socket — powers Containers + Services + model APIs.
     try:

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.21.0"
+VERSION      = "0.21.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
@@ -2500,9 +2500,15 @@ def local_diagnostics():
     else:
         _diag(checks, "nvidia", "NVIDIA GPU", "info",
               "no GPU detected — GPU panels are hidden (everything else works)",
-              {"where": "on the host — only if it actually has an NVIDIA GPU",
+              {"where": "on the host — only if it actually has an NVIDIA GPU. "
+                        "GPU containers use the env vars below only when nvidia is "
+                        "Docker's DEFAULT runtime; the recreate step is what was "
+                        "missing if a previous attempt 'did nothing'.",
                "cmd": "sudo nvidia-ctk runtime configure --runtime=docker --set-as-default\n"
-                      "sudo systemctl restart docker"})
+                      "sudo systemctl restart docker\n"
+                      "docker compose up -d --force-recreate   # recreate — restart keeps the old runtime\n"
+                      "# don't want nvidia as the global default? instead of the two lines above:\n"
+                      "#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d"})
     # Docker socket — powers Containers + Services + model APIs.
     try:
         json.loads(_docker("/version"))

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,24 @@
+# GPU override — opt in WITHOUT changing Docker's global default runtime.
+#
+# Why this exists: the main docker-compose.yml exposes the GPU purely through
+# the NVIDIA_* env vars, which the NVIDIA Container Toolkit only honours when
+# nvidia is Docker's *default* runtime. On stock Ubuntu/Debian/Mint the default
+# is `runc`, so GPU containers usually opt in per-container with `--gpus all`.
+# This monitor doesn't — so on those hosts nvidia-smi never gets injected and the
+# dashboard reports "no GPU detected", even though the card works for everything
+# else. (Same trap as deploy/docker-compose.mc.yml on the project's own hub.)
+#
+# Layer this file on top to request the nvidia runtime for just this container,
+# leaving every other container on the host untouched:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+#
+# Requires the NVIDIA Container Toolkit installed on the host (`nvidia-ctk
+# runtime configure --runtime=docker` registers the runtime; you do NOT need
+# --set-as-default when you use this override). If the toolkit isn't installed,
+# `runtime: nvidia` is unknown and the stack won't start — which is exactly why
+# this lives in an opt-in override and not in the default compose.
+
+services:
+  homelab-monitor:
+    runtime: nvidia

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,21 @@ services:
       # container runtime inject nvidia-smi *when it's present*; on a host with no
       # GPU (or no nvidia runtime) they're simply inert and the dashboard runs
       # without the GPU panels. This is why there's no hard `deploy.devices`
-      # reservation below — that would refuse to start on a GPU-less host. If you
-      # have a GPU but the dashboard's Setup tab says it isn't detected, run:
-      #   sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
-      #   sudo systemctl restart docker
+      # reservation below — that would refuse to start on a GPU-less host.
+      #
+      # IMPORTANT: these env vars only take effect when nvidia is Docker's
+      # *default* runtime. On stock Ubuntu/Debian/Mint the default is `runc`, so
+      # GPU containers normally opt in per-container with `--gpus all` — this one
+      # doesn't, so on those hosts the GPU goes undetected until you do ONE of:
+      #
+      #   A) Don't change the global default — bring it up with the GPU override:
+      #        docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+      #
+      #   B) Make nvidia the default runtime, then RECREATE this container
+      #      (a plain restart keeps the old runtime, so the change "does nothing"):
+      #        sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+      #        sudo systemctl restart docker
+      #        docker compose up -d --force-recreate
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: utility   # injects nvidia-smi into the container
       PORT: "9800"                          # dashboard served on 0.0.0.0:9800 (LAN/VPN reachable)


### PR DESCRIPTION
## What & why

Fixes #203 — GPU undetected on a fresh install where everything else works and the card runs fine for other containers.

**Root cause:** the published `docker-compose.yml` exposes the GPU **only** through the `NVIDIA_*` env vars. The NVIDIA Container Toolkit honours those only when nvidia is Docker's **default** runtime. On stock Ubuntu/Debian/Mint the default is `runc` and GPU containers opt in per-container with `--gpus all` — this monitor doesn't, so on those hosts `nvidia-smi` is never injected → `read_gpu()` returns `{}` → "no GPU detected". (The project already documents this trap in `deploy/docker-compose.mc.yml`; it just never reached the published compose or the Setup-tab remedy.)

The reporter's own fix attempt failed because the remedy text omitted recreating the container — a changed default runtime only applies to **newly created** containers, so `docker compose restart` kept the old binding and the fix "did nothing".

## Changes
- **`docker-compose.gpu.yml`** (new): opt-in override that requests `runtime: nvidia` for just this container. No global-default change, leaves other containers untouched, and stays out of the base compose so GPU-less hosts (no nvidia runtime registered) still start.
  ```
  docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
  ```
- **Setup-tab remedy (`app.py`)** and **compose comments**: now spell out the two supported paths and include the missing `--force-recreate` step.
- Version `0.21.0` → `0.21.1`; `CHANGELOG.md` note under `[Unreleased]`.

## Not changed
- No `runtime: nvidia` in the base compose (errors `unknown runtime: nvidia` on hosts without the toolkit — exactly why it lives in an override).
- The reported **>1GB RAM** is unproven and untouched here; following up with the reporter for `docker stats` data before treating it as a leak.

## Test
`python -c "import ast; ast.parse(open('app.py').read())"` ✓ · `docker compose -f docker-compose.yml -f docker-compose.gpu.yml config` merges cleanly ✓
