### PR TITLE
feat(brief): Daily Brief — opt-in once-a-day HTML health digest (#170)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4311,20 +4311,17 @@ def _post_to_telegram(token, chat_id, level, title, body):
             f"_HomeLab Monitor · {level}_")
     return _post_json(url, {"chat_id": chat_id, "text": text, "parse_mode": "Markdown"})
 
-def _send_email(host, port, use_tls, username, password, from_addr, to_addr, level, title, detail):
-    """Send alert via SMTP. Raises on error."""
-    msg = email.message.EmailMessage()
-    msg["Subject"] = title
-    msg["From"] = from_addr
-    msg["To"] = to_addr
-    msg.set_content(f"{detail}\n\nHomeLab Monitor · {level}")
-
-    port_num = int(port)
+def _smtp_send(msg, host, port, use_tls, username, password):
+    """Connect, optionally STARTTLS + authenticate, send, and always close. Shared by
+    the alert and daily-brief email paths so any fix (timeouts, TLS, error handling)
+    lives in one place. The connection is built inside the try with a None-guarded
+    quit() so a constructor failure can never reach an unbound name."""
+    port = int(port)
     ctx = None
     try:
-        ctx = (smtplib.SMTP_SSL(host, port_num, timeout=10) if (use_tls and port_num == 465)
-               else smtplib.SMTP(host, port_num, timeout=10))
-        if use_tls and port_num != 465:
+        ctx = (smtplib.SMTP_SSL(host, port, timeout=10) if (use_tls and port == 465)
+               else smtplib.SMTP(host, port, timeout=10))
+        if use_tls and port != 465:
             ctx.starttls()
         if username and password:
             ctx.login(username, password)
@@ -4332,6 +4329,15 @@ def _send_email(host, port, use_tls, username, password, from_addr, to_addr, lev
     finally:
         if ctx is not None:
             ctx.quit()
+
+def _send_email(host, port, use_tls, username, password, from_addr, to_addr, level, title, detail):
+    """Send alert via SMTP. Raises on error."""
+    msg = email.message.EmailMessage()
+    msg["Subject"] = title
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(f"{detail}\n\nHomeLab Monitor · {level}")
+    _smtp_send(msg, host, port, use_tls, username, password)
 
 def send_slack(webhook, level, title, detail):
     payload = {"text": f"[{level}] {title}\n\n{detail}"}
@@ -6992,15 +6998,19 @@ def _brief_fleet():
     return {"hosts": out, "up": sum(1 for x in out if x["up"]), "total": len(out)}
 
 def _brief_checks():
-    """Uptime rollup: counts, any down, and certs expiring within 21 days. The cert
-    list is empty until per-check TLS expiry (#163) lands — the section just hides it."""
-    summ = uptime_summary()
-    downs, certs = [], []
-    for c in uptime_overview().get("checks", []):
-        if not c.get("enabled"):
-            continue
-        if c.get("state") == "down":
-            downs.append(c.get("label", "?"))
+    """Uptime rollup: counts, any down, and certs expiring within 21 days. Derived
+    from a SINGLE uptime_overview() read so the counts and the per-check lists can't
+    diverge across two snapshots. The cert list stays empty until per-check TLS
+    expiry (#163) lands — the section just hides it."""
+    checks = [c for c in uptime_overview().get("checks", []) if c.get("enabled")]
+    up = sum(1 for c in checks if c.get("state") == "up")
+    down = sum(1 for c in checks if c.get("state") == "down")
+    summ = {"total": len(checks), "up": up, "down": down,
+            "unknown": len(checks) - up - down,
+            "worst_down": next((c.get("label") for c in checks if c.get("state") == "down"), None)}
+    downs = [c.get("label", "?") for c in checks if c.get("state") == "down"]
+    certs = []
+    for c in checks:
         cd = c.get("cert_days_remaining")
         if isinstance(cd, (int, float)) and cd <= 21:
             certs.append((c.get("label", "?"), int(cd)))
@@ -7187,11 +7197,9 @@ def render_brief(theme="dark"):
     if d["capacity"]:
         parts.append(head("📈 Capacity nudges"))
         parts.append(rows_table([f'{ic} {_he(txt)}' for ic, txt in d["capacity"]]))
-    # cta + footer
-    parts.append(f'<tr><td style="padding:14px 24px 22px" align="center">'
-                 f'<a href="#" style="display:inline-block;background:{P["accent"]};color:{P["bg"]};'
-                 f'font-weight:700;text-decoration:none;padding:10px 22px;border-radius:8px;font-size:14px">'
-                 f'Open dashboard →</a></td></tr>')
+    # footer — no CTA link: a brief has no absolute dashboard URL to point at, and
+    # a fragment-only href="#" is stripped/dead in Gmail/Outlook/Apple Mail. The
+    # footer line tells the reader where the brief is configured instead.
     parts.append(f'<tr><td style="padding:14px 24px;border-top:1px solid {P["bd"]};font-size:12px;color:{P["mut"]}">'
                  f'HomeLab Monitor v{VERSION} · daily brief from {_he(hub)} · configure in Settings → Alerts</td></tr>')
 
@@ -7230,20 +7238,9 @@ def _send_brief_email(s, subject, html, text):
     msg["To"] = s["email_to"]
     msg.set_content(text)
     msg.add_alternative(html, subtype="html")
-    host = s["email_host"]; port = int(s.get("email_port", "587") or 587)
-    use_tls = s.get("email_use_tls", "1") == "1"
-    ctx = None
-    try:
-        ctx = (smtplib.SMTP_SSL(host, port, timeout=10) if (use_tls and port == 465)
-               else smtplib.SMTP(host, port, timeout=10))
-        if use_tls and port != 465:
-            ctx.starttls()
-        if s.get("email_username") and s.get("email_password"):
-            ctx.login(s["email_username"], s["email_password"])
-        ctx.send_message(msg)
-    finally:
-        if ctx is not None:
-            ctx.quit()
+    _smtp_send(msg, s["email_host"], s.get("email_port", "587") or 587,
+               s.get("email_use_tls", "1") == "1",
+               s.get("email_username"), s.get("email_password"))
 
 def send_brief(s, channel):
     """Render and deliver the brief to one channel. Raises on delivery failure."""
@@ -7251,15 +7248,15 @@ def send_brief(s, channel):
     if channel == "email":
         _send_brief_email(s, subject, html, summary)
     elif channel == "discord":
-        send_discord(s["discord_webhook_url"], "info", subject, summary)
+        send_discord(s.get("discord_webhook_url"), "info", subject, summary)
     elif channel == "telegram":
-        _post_to_telegram(s["telegram_token"], s["telegram_chat_id"], "info", subject, summary)
+        _post_to_telegram(s.get("telegram_token"), s.get("telegram_chat_id"), "info", subject, summary)
     elif channel == "ntfy":
-        send_ntfy(s.get("ntfy_server") or "https://ntfy.sh", s["ntfy_topic"], "info", subject, summary)
+        send_ntfy(s.get("ntfy_server") or "https://ntfy.sh", s.get("ntfy_topic"), "info", subject, summary)
     elif channel == "slack":
-        send_slack(s["slack_webhook_url"], "info", subject, summary)
+        send_slack(s.get("slack_webhook_url"), "info", subject, summary)
     elif channel == "webhook":
-        send_webhook(s["webhook_url"], "info", subject, summary, _alert_host_label() or "")
+        send_webhook(s.get("webhook_url"), "info", subject, summary, _alert_host_label() or "")
     else:
         raise ValueError(f"unknown brief channel: {channel}")
 

--- a/app.py
+++ b/app.py
@@ -3829,6 +3829,22 @@ def _validate_email_settings(updates):
             return f"{label} must include '@'."
     return None
 
+_BRIEF_TIME_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+def _validate_brief_settings(updates):
+    """Reject malformed daily-brief fields. Enum-validating brief_channel/theme here
+    means an arbitrary value can never reach the settings store (or the dashboard
+    that renders it into an <option>), closing the stored-XSS surface at the source."""
+    if "brief_channel" in updates:
+        v = (updates["brief_channel"] or "").strip()
+        if v and v not in _BRIEF_CHANNELS:
+            return "Unknown daily-brief channel."
+    if "brief_theme" in updates and (updates["brief_theme"] or "").strip() not in ("dark", "light"):
+        return "Daily-brief theme must be 'dark' or 'light'."
+    if "brief_time" in updates and not _BRIEF_TIME_RE.match((updates["brief_time"] or "").strip()):
+        return "Daily-brief time must be HH:MM (24-hour)."
+    return None
+
 def save_settings(updates):
     """Persist any subset of known setting keys. Unknown keys are ignored."""
     safe = [(k, "" if v is None else str(v)) for k, v in updates.items() if k in SETTING_DEFAULTS]
@@ -4308,11 +4324,11 @@ def _send_email(host, port, use_tls, username, password, from_addr, to_addr, lev
         ctx = smtplib.SMTP_SSL(host, port_num, timeout=10)
     else:
         ctx = smtplib.SMTP(host, port_num, timeout=10)
-        if use_tls:
-            ctx.starttls()
-    if username and password:
-        ctx.login(username, password)
     try:
+        if use_tls and port_num != 465:
+            ctx.starttls()
+        if username and password:
+            ctx.login(username, password)
         ctx.send_message(msg)
     finally:
         ctx.quit()
@@ -6767,7 +6783,8 @@ def api_settings():
         # Secrets pass through the "_set: false" sentinel from the UI as a way
         # to clear without revealing the current value.
         updates = {k: body[k] for k in body if k in SETTING_DEFAULTS}
-        err = _validate_url_settings(updates) or _validate_email_settings(updates)
+        err = (_validate_url_settings(updates) or _validate_email_settings(updates)
+               or _validate_brief_settings(updates))
         if err:
             return jsonify({"ok": False, "error": err}), 400
         save_settings(updates)
@@ -7219,11 +7236,11 @@ def _send_brief_email(s, subject, html, text):
         ctx = smtplib.SMTP_SSL(host, port, timeout=10)
     else:
         ctx = smtplib.SMTP(host, port, timeout=10)
-        if use_tls:
-            ctx.starttls()
-    if s.get("email_username") and s.get("email_password"):
-        ctx.login(s["email_username"], s["email_password"])
     try:
+        if use_tls and port != 465:
+            ctx.starttls()
+        if s.get("email_username") and s.get("email_password"):
+            ctx.login(s["email_username"], s["email_password"])
         ctx.send_message(msg)
     finally:
         ctx.quit()
@@ -7266,20 +7283,29 @@ def _brief_due(now=None):
         return None
     return s, ch, today
 
+def _brief_run_once(now=None):
+    """One scheduler pass. Returns True if a brief was due (and attempted). The day
+    is claimed *before* the send so a transient failure can't trigger a same-minute
+    retry / duplicate delivery — a daily digest prefers a single best-effort send
+    over risking two."""
+    due = _brief_due(now)
+    if not due:
+        return False
+    s, ch, today = due
+    _BRIEF_LAST_SENT["date"] = today
+    try:
+        send_brief(s, ch)
+        print(f"daily brief sent to {ch}", flush=True)
+    except Exception as e:
+        print("brief send error:", e, flush=True)
+    return True
+
 def brief_worker():
     """Dedicated daemon: every 30s, send the daily brief if it's due. Inert unless
     the brief is enabled with a configured channel."""
     while True:
         try:
-            due = _brief_due()
-            if due:
-                s, ch, today = due
-                try:
-                    send_brief(s, ch)
-                    _BRIEF_LAST_SENT["date"] = today
-                    print(f"daily brief sent to {ch}", flush=True)
-                except Exception as e:
-                    print("brief send error:", e, flush=True)
+            _brief_run_once()
         except Exception as e:
             print("brief_worker error:", e, flush=True)
         time.sleep(30)

--- a/app.py
+++ b/app.py
@@ -3759,6 +3759,11 @@ SETTING_DEFAULTS = {
     "api_key":             "",         # Bearer/X-API-Key for run ingest; empty => not generated (ingest fail-closed)
     "mlflow_uri":          "",         # MLflow tracking server base (blank = off)
     "mlflow_token":        "",         # optional bearer for a secured MLflow
+    # ── Daily brief (#170) — opt-in once-a-day HTML health digest ──────────────
+    "brief_enabled":       "0",        # "0" / "1"
+    "brief_time":          "08:00",    # local time-of-day "HH:MM" to send
+    "brief_channel":       "",         # one of: email|discord|telegram|ntfy|slack|webhook (must be configured)
+    "brief_theme":         "dark",     # "dark" | "light" — palette for the HTML brief
 }
 SETTING_SECRETS = {"discord_webhook_url", "telegram_token", "email_password", "slack_webhook_url", "webhook_url", "api_key", "mlflow_token"}   # never round-tripped to the UI in full
 
@@ -6896,9 +6901,416 @@ def api_notify_rules_test():
 def index():
     return app.send_static_file("dashboard.html")
 
+# ── Daily brief (#170) ───────────────────────────────────────────────────────
+# An opt-in, once-a-day HTML health digest assembled from data we already collect
+# (overview + fleet + uptime checks + recent events + GPU/cost). Email gets the
+# full self-contained, inline-styled HTML (survives Gmail/Outlook with no external
+# assets); chat channels get a compact text summary with the things that need
+# attention. Pure stdlib. Each section degrades gracefully when its data is absent.
+_BRIEF_CHANNELS = ("email", "discord", "telegram", "ntfy", "slack", "webhook")
+
+_BRIEF_PALETTE = {
+    "dark":  {"bg": "#0d1117", "card": "#161b22", "bd": "#30363d", "sub": "#21262d",
+              "tx": "#e6edf3", "mut": "#8b949e", "ok": "#3fb950", "warn": "#d29922",
+              "crit": "#f85149", "accent": "#d29922", "inset": "#0d1117"},
+    "light": {"bg": "#f6f8fa", "card": "#ffffff", "bd": "#d0d7de", "sub": "#eaeef2",
+              "tx": "#1f2328", "mut": "#636c76", "ok": "#1a7f37", "warn": "#9a6700",
+              "crit": "#cf222e", "accent": "#9a6700", "inset": "#f6f8fa"},
+}
+
+def _he(s):
+    """Minimal HTML escape (no new import; the brief never embeds attributes)."""
+    return str("" if s is None else s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+def _brief_channel_ready(s, ch):
+    """True when channel `ch` has enough config saved to actually deliver."""
+    if ch == "email":    return bool(s.get("email_host") and s.get("email_from") and s.get("email_to"))
+    if ch == "discord":  return bool(s.get("discord_webhook_url"))
+    if ch == "telegram": return bool(s.get("telegram_token") and s.get("telegram_chat_id"))
+    if ch == "ntfy":     return bool(s.get("ntfy_topic"))
+    if ch == "slack":    return bool(s.get("slack_webhook_url"))
+    if ch == "webhook":  return bool(s.get("webhook_url"))
+    return False
+
+def _brief_yesterday_cost():
+    """(cost, kwh, currency) for the previous local calendar day, tariff-aware.
+    (None, None, currency) when cost tracking is off or there were no samples."""
+    ctx = _cost_ctx()
+    cur = ctx.get("currency") or "$"
+    if not ctx.get("day"):                       # no price configured → cost card hidden
+        return None, None, cur
+    now = int(time.time())
+    lt = time.localtime(now)
+    today0 = int(time.mktime((lt.tm_year, lt.tm_mon, lt.tm_mday, 0, 0, 0, 0, 0, -1)))
+    y0 = today0 - 86400
+    kwh_per = INTERVAL / 3_600_000.0
+    cost = kwh = 0.0
+    try:
+        with LOCK:
+            for ts, w in DB.execute(f"SELECT ts, {_TOTAL_W_EXPR} w FROM samples WHERE ts>=? AND ts<?", (y0, today0)):
+                cost += (w or 0) * kwh_per * _price_at(ctx, ts)
+                kwh  += (w or 0) * kwh_per
+    except Exception:
+        return None, None, cur
+    if kwh <= 0:
+        return None, None, cur
+    return round(cost, 2), round(kwh, 2), cur
+
+def _brief_fleet():
+    """Hub + registered hosts with an up/down flag. The hub is always up (we're the
+    one rendering). A registered host counts as up if its last check exists and its
+    summary didn't fail."""
+    out = []
+    host = LATEST.get("host") or {}
+    cpu = round(host.get("cpu", 0) or 0)
+    ram_pct = round(host["ram_used"] / host["ram_total"] * 100) if host.get("ram_total") else 0
+    out.append({"name": host.get("hostname") or "this host", "up": True, "hub": True,
+                "detail": f"{cpu}% CPU · {ram_pct}% RAM"})
+    for h in list_hosts():
+        chk = h.get("last_check") or {}
+        overall = ((chk.get("summary") or {}).get("overall"))
+        up = bool(chk) and overall != "fail"
+        out.append({"name": h.get("name", "?"), "up": up, "hub": False,
+                    "detail": "" if up else "not reachable at last check"})
+    return {"hosts": out, "up": sum(1 for x in out if x["up"]), "total": len(out)}
+
+def _brief_checks():
+    """Uptime rollup: counts, any down, and certs expiring within 21 days. The cert
+    list is empty until per-check TLS expiry (#163) lands — the section just hides it."""
+    summ = uptime_summary()
+    downs, certs = [], []
+    for c in uptime_overview().get("checks", []):
+        if not c.get("enabled"):
+            continue
+        if c.get("state") == "down":
+            downs.append(c.get("label", "?"))
+        cd = c.get("cert_days_remaining")
+        if isinstance(cd, (int, float)) and cd <= 21:
+            certs.append((c.get("label", "?"), int(cd)))
+    return {"summary": summ, "downs": downs, "certs": certs, "enabled": summ["total"] > 0}
+
+def _brief_events(window=86400, limit=8):
+    """Recent rows from the events log (OOM/down/recovery, etc.) over the window."""
+    now = int(time.time())
+    try:
+        with LOCK:
+            rows = DB.execute("SELECT ts, service, kind, detail FROM events "
+                              "WHERE ts>=? ORDER BY ts DESC LIMIT ?", (now - window, limit)).fetchall()
+    except Exception:
+        rows = []
+    return [{"ts": r[0], "service": r[1], "kind": r[2], "detail": r[3]} for r in rows]
+
+def _brief_ai_cost():
+    models = [{"model": m.get("model", "?"), "service": m.get("service", "?"), "vram": m.get("vram")}
+              for m in (LATEST.get("models") or [])]
+    cost, kwh, cur = _brief_yesterday_cost()
+    gpus = LATEST.get("gpus") or []
+    gpu_name = (gpus[0].get("name") if gpus else None) or ((LATEST.get("host") or {}).get("hw") or {}).get("gpu_name")
+    return {"available": bool(LATEST.get("gpu_avail")), "gpu_name": gpu_name,
+            "temp": LATEST.get("temp"), "util": LATEST.get("util"),
+            "mem_used": LATEST.get("mem_used"), "mem_total": LATEST.get("mem_total"),
+            "models": models, "cost": cost, "kwh": kwh, "currency": cur}
+
+def _brief_capacity():
+    """Disks at/above 80% (trending full) + an idle-VRAM squatter when the GPU sits idle."""
+    out = []
+    host = LATEST.get("host") or {}
+    for d in (host.get("disks") or []):
+        if (d.get("pct") or 0) >= 80:
+            out.append(("💾", f"{d.get('mount', '?')} at {round(d.get('pct', 0))}%"))
+    if (LATEST.get("util") or 0) < 5:
+        for m in (LATEST.get("models") or []):
+            if (m.get("vram") or 0) >= 256:
+                out.append(("🅿️", f"{m.get('service', '?')} holding {round(m['vram'])} MB while the GPU is idle"))
+                break
+    return out
+
+def _brief_assemble():
+    """Gather every section's data + derive the headline / action list. One dict."""
+    gpu_avail = LATEST.get("gpu_avail")
+    now = {"gpu": {"util": LATEST.get("util"), "mem_used": LATEST.get("mem_used"),
+                   "mem_total": (LATEST.get("mem_total") or 24576) if gpu_avail else 0,
+                   "power": LATEST.get("power"), "temp": LATEST.get("temp"),
+                   "available": bool(gpu_avail)},
+           "host": LATEST.get("host") or {}}
+    docker  = HEALTH.get("docker")  or {"available": False, "summary": {"total": 0, "running": 0, "problems": 0}, "containers": []}
+    systemd = HEALTH.get("systemd") or {"available": False, "summary": {}, "services": []}
+    overview = build_overview(now, docker, systemd)
+    fleet    = _brief_fleet()
+    checks   = _brief_checks()
+    events   = _brief_events()
+    ai       = _brief_ai_cost()
+    capacity = _brief_capacity()
+
+    actions = []
+    for x in fleet["hosts"]:
+        if not x["up"]:
+            actions.append((2, f"Host {x['name']} is offline"))
+    for lbl in checks["downs"]:
+        actions.append((2, f"Check “{lbl}” is down"))
+    for lbl, d in checks["certs"]:
+        actions.append((1 if d > 7 else 2, f"TLS cert {lbl} expires in {d} day{'s' if d != 1 else ''}"))
+    for c in overview:
+        if c["status"] in ("crit", "warn"):
+            actions.append((2 if c["status"] == "crit" else 1, f"{c['label']}: {c['detail']}"))
+    crit = any(p == 2 for p, _ in actions)
+    actions_text = [t for _, t in sorted(actions, key=lambda a: -a[0])]
+
+    return {"overview": overview, "fleet": fleet, "checks": checks, "events": events,
+            "ai": ai, "capacity": capacity, "actions": actions_text,
+            "issues": len(actions_text), "crit": crit, "now": int(time.time())}
+
+def render_brief(theme="dark"):
+    """Return (html, summary, subject). `html` is a self-contained inline-styled
+    email body; `summary` is the compact text for chat channels; `subject` is the
+    email/notification title."""
+    P = _BRIEF_PALETTE["light"] if theme == "light" else _BRIEF_PALETTE["dark"]
+    d = _brief_assemble()
+    hub = _alert_host_label() or "homelab"
+    when = time.strftime("%a %d %b", time.localtime(d["now"]))
+    issues, crit = d["issues"], d["crit"]
+    fleet, checks, ai = d["fleet"], d["checks"], d["ai"]
+
+    if issues == 0:
+        head_emoji, head_text, head_col = "✅", "All systems healthy", P["ok"]
+        head_sub = "nothing needs you today"
+    else:
+        head_emoji = "🔴" if crit else "🟠"
+        head_text = f"{issues} thing{'s' if issues != 1 else ''} to look at"
+        head_col = P["crit"] if crit else P["warn"]
+        head_sub = "otherwise the lab is healthy"
+
+    cost_kpi = f"{ai['cost']}" if ai["cost"] is not None else "—"
+    cur = ai["currency"]
+    kpis = [(f"{fleet['up']}/{fleet['total']}", "Hosts up", P["ok"] if fleet["up"] == fleet["total"] else P["warn"]),
+            ((f"{checks['summary']['up']}/{checks['summary']['total']}" if checks["enabled"] else "—"),
+             "Checks up", P["ok"] if checks["enabled"] and not checks["downs"] else (P["warn"] if checks["downs"] else P["mut"])),
+            (str(issues), "To look at", head_col if issues else P["ok"]),
+            (cost_kpi, f"{cur} ydy", P["tx"])]
+
+    # ── HTML assembly (table layout, inline styles only) ──────────────────────
+    def head(t):
+        return (f'<tr><td style="padding:18px 24px 6px"><div style="font-size:12px;text-transform:uppercase;'
+                f'letter-spacing:.06em;color:{P["accent"]};font-weight:600">{t}</div></td></tr>')
+    def rows_table(lines):
+        body = "".join(f'<tr><td style="padding:6px 0;border-bottom:1px solid {P["sub"]};'
+                       f'font-size:14px;color:{P["tx"]}">{ln}</td></tr>' for ln in lines)
+        return (f'<tr><td style="padding:0 24px 6px"><table role="presentation" width="100%" '
+                f'cellpadding="0" cellspacing="0">{body}</table></td></tr>')
+
+    parts = []
+    parts.append(f'<tr><td style="padding:20px 24px;border-bottom:1px solid {P["bd"]}">'
+                 f'<table role="presentation" width="100%"><tr>'
+                 f'<td style="font-size:18px;font-weight:700;color:{P["tx"]}">📰 Daily brief</td>'
+                 f'<td align="right" style="font-size:13px;color:{P["mut"]}">{when} · {_he(hub)}</td>'
+                 f'</tr></table></td></tr>')
+    # KPI strip
+    tiles = "".join(
+        f'<td width="25%" style="padding:11px 6px;text-align:center;background:{P["inset"]};'
+        f'border:1px solid {P["sub"]};border-radius:8px">'
+        f'<div style="font-size:20px;font-weight:700;color:{col}">{_he(val)}</div>'
+        f'<div style="font-size:10px;color:{P["mut"]};text-transform:uppercase;letter-spacing:.05em">{_he(lbl)}</div></td>'
+        for val, lbl, col in kpis)
+    parts.append(f'<tr><td style="padding:16px 24px 2px"><table role="presentation" width="100%" '
+                 f'cellpadding="0" cellspacing="6"><tr>{tiles}</tr></table></td></tr>')
+    # headline
+    parts.append(f'<tr><td style="padding:18px 24px"><table role="presentation" width="100%" '
+                 f'style="background:{head_col}1a;border:1px solid {head_col};border-radius:10px">'
+                 f'<tr><td style="padding:14px 16px;font-size:16px;color:{P["tx"]}">'
+                 f'<span style="font-size:20px">{head_emoji}</span> &nbsp;<b>{_he(head_text)}</b> '
+                 f'&nbsp;<span style="color:{P["mut"]}">· {head_sub}</span></td></tr></table></td></tr>')
+    # action needed
+    if d["actions"]:
+        parts.append(head("⚡ Action needed"))
+        parts.append(rows_table([_he(a) for a in d["actions"]]))
+    # fleet
+    parts.append(head("🖥️ Fleet"))
+    fleet_lines = []
+    for x in fleet["hosts"]:
+        dot = "🟢" if x["up"] else "🔴"
+        extra = f' <span style="color:{P["mut"]}">· {_he(x["detail"])}</span>' if x["detail"] else ""
+        tag = " (hub)" if x["hub"] else ""
+        fleet_lines.append(f'{dot} {_he(x["name"])}{tag}{extra}')
+    parts.append(rows_table(fleet_lines))
+    # checks
+    if checks["enabled"]:
+        parts.append(head("📡 Checks"))
+        sm = checks["summary"]
+        clines = [f'{"🟢" if not checks["downs"] else "🔴"} {sm["up"]}/{sm["total"]} checks responding']
+        for lbl in checks["downs"]:
+            clines.append(f'🔴 {_he(lbl)} is down')
+        for lbl, dd in checks["certs"]:
+            clines.append(f'🟠 cert {_he(lbl)} expires in {dd} day{"s" if dd != 1 else ""}')
+        parts.append(rows_table(clines))
+    # alerts (events) last 24h
+    if d["events"]:
+        parts.append(head("🔔 Alerts · last 24h"))
+        elines = []
+        for e in d["events"]:
+            t = time.strftime("%H:%M", time.localtime(e["ts"]))
+            who = e.get("service") or e.get("kind") or "event"
+            elines.append(f'{_he(t)} — {_he(who)}: {_he(e.get("detail") or e.get("kind") or "")}')
+        parts.append(rows_table(elines))
+    # ai & cost
+    parts.append(head("🤖 AI &amp; cost"))
+    ailines = []
+    if ai["available"]:
+        gname = ai["gpu_name"] or "GPU"
+        t = f' · {round(ai["temp"])}°C' if ai.get("temp") is not None else ""
+        ailines.append(f'{_he(gname)}{t} · {len(ai["models"])} model{"s" if len(ai["models"]) != 1 else ""} loaded')
+    else:
+        ailines.append("No GPU detected on the hub")
+    if ai["cost"] is not None:
+        ailines.append(f'Yesterday\'s energy: <b>{ai["cost"]} {_he(cur)}</b> · {ai["kwh"]} kWh')
+    if ai["models"]:
+        names = ", ".join(_he(m["model"]) for m in ai["models"][:4])
+        ailines.append(f'<span style="color:{P["mut"]}">models: {names}</span>')
+    parts.append(rows_table(ailines))
+    # capacity nudges
+    if d["capacity"]:
+        parts.append(head("📈 Capacity nudges"))
+        parts.append(rows_table([f'{ic} {_he(txt)}' for ic, txt in d["capacity"]]))
+    # cta + footer
+    parts.append(f'<tr><td style="padding:14px 24px 22px" align="center">'
+                 f'<a href="#" style="display:inline-block;background:{P["accent"]};color:{P["bg"]};'
+                 f'font-weight:700;text-decoration:none;padding:10px 22px;border-radius:8px;font-size:14px">'
+                 f'Open dashboard →</a></td></tr>')
+    parts.append(f'<tr><td style="padding:14px 24px;border-top:1px solid {P["bd"]};font-size:12px;color:{P["mut"]}">'
+                 f'HomeLab Monitor v{VERSION} · daily brief from {_he(hub)} · configure in Settings → Alerts</td></tr>')
+
+    html = (f'<!DOCTYPE html><html><body style="margin:0;background:{P["bg"]};padding:24px 0;'
+            f'font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">'
+            f'<table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" '
+            f'style="width:600px;max-width:92%;margin:0 auto;background:{P["card"]};'
+            f'border:1px solid {P["bd"]};border-radius:12px;overflow:hidden">'
+            f'{"".join(parts)}</table></body></html>')
+
+    # ── compact text summary for chat channels ────────────────────────────────
+    slines = [f'{head_emoji} {head_text}']
+    if d["actions"]:
+        slines.append("")
+        slines.append("⚡ Action needed:")
+        slines += [f'• {a}' for a in d["actions"][:5]]
+    slines.append("")
+    stat = f'🖥️ {fleet["up"]}/{fleet["total"]} up'
+    if checks["enabled"]:
+        stat += f' · 📡 {checks["summary"]["up"]}/{checks["summary"]["total"]} checks'
+    if d["events"]:
+        stat += f' · 🔔 {len(d["events"])} in 24h'
+    if ai["cost"] is not None:
+        stat += f' · 🤖 {ai["cost"]} {cur}'
+    slines.append(stat)
+    summary = "\n".join(slines)
+
+    subject = f"[{hub}] Daily brief — {head_text}"
+    return html, summary, subject
+
+def _send_brief_email(s, subject, html, text):
+    """Send the brief as a multipart email: plain-text fallback + HTML body."""
+    msg = email.message.EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = s["email_from"]
+    msg["To"] = s["email_to"]
+    msg.set_content(text)
+    msg.add_alternative(html, subtype="html")
+    host = s["email_host"]; port = int(s.get("email_port", "587") or 587)
+    use_tls = s.get("email_use_tls", "1") == "1"
+    if use_tls and port == 465:
+        ctx = smtplib.SMTP_SSL(host, port, timeout=10)
+    else:
+        ctx = smtplib.SMTP(host, port, timeout=10)
+        if use_tls:
+            ctx.starttls()
+    if s.get("email_username") and s.get("email_password"):
+        ctx.login(s["email_username"], s["email_password"])
+    try:
+        ctx.send_message(msg)
+    finally:
+        ctx.quit()
+
+def send_brief(s, channel):
+    """Render and deliver the brief to one channel. Raises on delivery failure."""
+    html, summary, subject = render_brief(s.get("brief_theme", "dark"))
+    if channel == "email":
+        _send_brief_email(s, subject, html, summary)
+    elif channel == "discord":
+        send_discord(s["discord_webhook_url"], "info", subject, summary)
+    elif channel == "telegram":
+        _post_to_telegram(s["telegram_token"], s["telegram_chat_id"], "info", subject, summary)
+    elif channel == "ntfy":
+        send_ntfy(s.get("ntfy_server") or "https://ntfy.sh", s["ntfy_topic"], "info", subject, summary)
+    elif channel == "slack":
+        send_slack(s["slack_webhook_url"], "info", subject, summary)
+    elif channel == "webhook":
+        send_webhook(s["webhook_url"], "info", subject, summary, _alert_host_label() or "")
+    else:
+        raise ValueError(f"unknown brief channel: {channel}")
+
+_BRIEF_LAST_SENT = {"date": None}
+
+def _brief_due(now=None):
+    """Return (settings, channel, date_str) when a brief should fire right now, else None.
+    Fires once per local day at the configured HH:MM, only if enabled and the chosen
+    channel is configured."""
+    s = get_settings()
+    if s.get("brief_enabled") != "1":
+        return None
+    ch = s.get("brief_channel") or ""
+    if not ch or not _brief_channel_ready(s, ch):
+        return None
+    lt = time.localtime(now or time.time())
+    if time.strftime("%H:%M", lt) != (s.get("brief_time") or "08:00"):
+        return None
+    today = time.strftime("%Y-%m-%d", lt)
+    if _BRIEF_LAST_SENT["date"] == today:
+        return None
+    return s, ch, today
+
+def brief_worker():
+    """Dedicated daemon: every 30s, send the daily brief if it's due. Inert unless
+    the brief is enabled with a configured channel."""
+    while True:
+        try:
+            due = _brief_due()
+            if due:
+                s, ch, today = due
+                try:
+                    send_brief(s, ch)
+                    _BRIEF_LAST_SENT["date"] = today
+                    print(f"daily brief sent to {ch}", flush=True)
+                except Exception as e:
+                    print("brief send error:", e, flush=True)
+        except Exception as e:
+            print("brief_worker error:", e, flush=True)
+        time.sleep(30)
+
+@app.route("/api/brief/preview")
+def api_brief_preview():
+    """Render the current brief as HTML (the Preview button opens this in a tab)."""
+    theme = request.args.get("theme") or get_settings().get("brief_theme", "dark")
+    html, _, _ = render_brief("light" if theme == "light" else "dark")
+    return Response(html, mimetype="text/html; charset=utf-8")
+
+@app.route("/api/brief/test", methods=["POST"])
+def api_brief_test():
+    """Render + deliver a brief now to the chosen channel (Send-test button)."""
+    s = get_settings()
+    body = request.get_json(silent=True) or {}
+    ch = (body.get("channel") or s.get("brief_channel") or "").strip()
+    if ch not in _BRIEF_CHANNELS:
+        return jsonify({"ok": False, "error": "Pick a channel for the daily brief first."}), 400
+    if not _brief_channel_ready(s, ch):
+        return jsonify({"ok": False, "error": f"The {ch} channel isn't configured yet — fill it in above under Alerts."}), 400
+    try:
+        send_brief(s, ch)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 502
+    return jsonify({"ok": True, "channel": ch})
+
 threading.Thread(target=collector, daemon=True).start()
 threading.Thread(target=host_poller, daemon=True).start()
 threading.Thread(target=uptime_worker, daemon=True).start()
+threading.Thread(target=brief_worker, daemon=True).start()
 
 if __name__ == "__main__":
     print(

--- a/app.py
+++ b/app.py
@@ -4320,18 +4320,18 @@ def _send_email(host, port, use_tls, username, password, from_addr, to_addr, lev
     msg.set_content(f"{detail}\n\nHomeLab Monitor · {level}")
 
     port_num = int(port)
-    if use_tls and port_num == 465:
-        ctx = smtplib.SMTP_SSL(host, port_num, timeout=10)
-    else:
-        ctx = smtplib.SMTP(host, port_num, timeout=10)
+    ctx = None
     try:
+        ctx = (smtplib.SMTP_SSL(host, port_num, timeout=10) if (use_tls and port_num == 465)
+               else smtplib.SMTP(host, port_num, timeout=10))
         if use_tls and port_num != 465:
             ctx.starttls()
         if username and password:
             ctx.login(username, password)
         ctx.send_message(msg)
     finally:
-        ctx.quit()
+        if ctx is not None:
+            ctx.quit()
 
 def send_slack(webhook, level, title, detail):
     payload = {"text": f"[{level}] {title}\n\n{detail}"}
@@ -7232,18 +7232,18 @@ def _send_brief_email(s, subject, html, text):
     msg.add_alternative(html, subtype="html")
     host = s["email_host"]; port = int(s.get("email_port", "587") or 587)
     use_tls = s.get("email_use_tls", "1") == "1"
-    if use_tls and port == 465:
-        ctx = smtplib.SMTP_SSL(host, port, timeout=10)
-    else:
-        ctx = smtplib.SMTP(host, port, timeout=10)
+    ctx = None
     try:
+        ctx = (smtplib.SMTP_SSL(host, port, timeout=10) if (use_tls and port == 465)
+               else smtplib.SMTP(host, port, timeout=10))
         if use_tls and port != 465:
             ctx.starttls()
         if s.get("email_username") and s.get("email_password"):
             ctx.login(s["email_username"], s["email_password"])
         ctx.send_message(msg)
     finally:
-        ctx.quit()
+        if ctx is not None:
+            ctx.quit()
 
 def send_brief(s, channel):
     """Render and deliver the brief to one channel. Raises on delivery failure."""

--- a/app.py
+++ b/app.py
@@ -3830,6 +3830,9 @@ def _validate_email_settings(updates):
     return None
 
 _BRIEF_TIME_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+# Channels the daily brief can target (also used by the worker/test route below).
+# Defined here, next to the validator that enum-checks it, so the dependency is local.
+_BRIEF_CHANNELS = ("email", "discord", "telegram", "ntfy", "slack", "webhook")
 
 def _validate_brief_settings(updates):
     """Reject malformed daily-brief fields. Enum-validating brief_channel/theme here
@@ -6930,7 +6933,7 @@ def index():
 # full self-contained, inline-styled HTML (survives Gmail/Outlook with no external
 # assets); chat channels get a compact text summary with the things that need
 # attention. Pure stdlib. Each section degrades gracefully when its data is absent.
-_BRIEF_CHANNELS = ("email", "discord", "telegram", "ntfy", "slack", "webhook")
+# (_BRIEF_CHANNELS is defined up by the settings validators that consume it.)
 
 _BRIEF_PALETTE = {
     "dark":  {"bg": "#0d1117", "card": "#161b22", "bd": "#30363d", "sub": "#21262d",

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -4051,14 +4051,14 @@ function fillBrief(s){
   // Keep the saved channel visible even if it's no longer configured (flag it).
   if(saved && !chans.some(c=>c[0]===saved)) chans.push([saved, (labels[saved]||saved)+' (not configured)']);
   sel.innerHTML = chans.length
-    ? chans.map(c=>`<option value="${c[0]}"${c[0]===saved?' selected':''}>${esc(c[1])}</option>`).join('')
+    ? chans.map(c=>`<option value="${esc(c[0]).replace(/"/g,'&quot;')}"${c[0]===saved?' selected':''}>${esc(c[1])}</option>`).join('')
     : '<option value="">— configure a channel above first —</option>';
   document.getElementById('al_brief_chan_cap').style.display = chans.length ? 'none' : '';
 }
 function showBriefStatus(level,text){
   const el=document.getElementById('brief-status');
   el.className='ins '+level; el.style.display='flex';
-  el.innerHTML=`<div class="ic">${(window.ICON&&ICON[level])||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
+  el.innerHTML=`<div class="ic">${ICON[level]||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
   setTimeout(()=>{el.style.display='none';}, 6000);
 }
 function briefPreview(){

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -2638,6 +2638,7 @@ const ICONS={
   '📊':'<line x1="12" x2="12" y1="20" y2="10"/><line x1="18" x2="18" y1="20" y2="4"/><line x1="6" x2="6" y1="20" y2="16"/>',
   '📋':'<rect width="8" height="4" x="8" y="2" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4M12 16h4M8 11h.01M8 16h.01"/>',
   '📦':'<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.3 7 12 12 20.7 7"/><line x1="12" x2="12" y1="22" y2="12"/>',
+  '📰':'<path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2Zm0 0a2 2 0 0 1-2-2v-9c0-1.1.9-2 2-2h2"/><path d="M18 14h-8"/><path d="M15 18h-5"/><path d="M10 6h8v4h-8z"/>',
   '📶':'<path d="M2 20h.01M7 20v-4M12 20v-8M17 20V8M22 4v16"/>',
   '🔬':'<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
   '🖥':'<rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/>',
@@ -4055,12 +4056,15 @@ function fillBrief(s){
     : '<option value="">— configure a channel above first —</option>';
   document.getElementById('al_brief_chan_cap').style.display = chans.length ? 'none' : '';
 }
-function showBriefStatus(level,text){
-  const el=document.getElementById('brief-status');
+// Shared renderer for the dismissing .ins status banners (brief, rules, …).
+function showInlineStatus(id,level,text){
+  const el=document.getElementById(id);
+  if(!el) return;
   el.className='ins '+level; el.style.display='flex';
   el.innerHTML=`<div class="ic">${ICON[level]||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
   setTimeout(()=>{el.style.display='none';}, 6000);
 }
+function showBriefStatus(level,text){ showInlineStatus('brief-status',level,text); }
 function briefPreview(){
   const theme=document.getElementById('al_brief_theme').value || 'dark';
   window.open('/api/brief/preview?theme='+encodeURIComponent(theme), '_blank');
@@ -4186,12 +4190,7 @@ let RULES = [];
 const RULE_KINDS = ['container','systemd','gpu','host','uptime'];
 const RULE_CHANNELS = ['all','discord','ntfy','telegram','email','slack','webhook'];
 const RULE_LEVELS = ['info','warning','critical'];
-function showRulesStatus(level, text){
-  const el=document.getElementById('rules-status');
-  el.className='ins '+level; el.style.display='flex';
-  el.innerHTML=`<div class="ic">${ICON[level]||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
-  setTimeout(()=>{el.style.display='none';}, 6000);
-}
+function showRulesStatus(level, text){ showInlineStatus('rules-status',level,text); }
 async function loadRules(){
   let j; try{ j=await(await fetch('/api/notify/rules')).json(); }catch(e){ return; }
   RULES = j.rules || [];

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1938,6 +1938,44 @@ body.mc-customizing .mc-board .mc-widget{ border-radius:12px }
           <button class="rb" id="rules-add-btn" data-i18n="rules.add" data-i18n-def="+ Add rule">+ Add rule</button>
         </div>
       </div>
+
+      <!-- ── Daily brief (#170) ── -->
+      <div style="margin-top:24px;border-top:1px solid var(--bd);padding-top:16px;max-width:800px">
+        <h2 class="card-sub" data-i18n="brief.title" data-i18n-def="📰 Daily brief">📰 Daily brief</h2>
+        <p class="cap" data-i18n="brief.intro" data-i18n-def="A scheduled “is the lab OK?” digest — the calm counterpart to alerts. Sent once a day to one channel: email gets the full HTML report, chat channels get a compact summary with the things that need attention.">A scheduled “is the lab OK?” digest — the calm counterpart to alerts. Sent once a day to one channel: email gets the full HTML report, chat channels get a compact summary with the things that need attention.</p>
+
+        <div id="brief-status" class="ins info" style="display:none;margin:8px 0"></div>
+
+        <label style="display:flex;align-items:center;gap:9px;margin:10px 0">
+          <input type="checkbox" id="al_brief_enabled">
+          <span data-i18n-html="brief.enabled_label"><b>Daily brief enabled</b> — send once a day at the time below.</span>
+        </label>
+
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:14px;max-width:560px">
+          <div>
+            <div class="flabel" data-i18n="brief.time" data-i18n-def="Send at (local time)">Send at (local time)</div>
+            <input type="time" id="al_brief_time" class="field" value="08:00">
+          </div>
+          <div>
+            <div class="flabel" data-i18n="brief.channel" data-i18n-def="Send to channel">Send to channel</div>
+            <select id="al_brief_channel" class="field"></select>
+          </div>
+          <div>
+            <div class="flabel" data-i18n="brief.theme" data-i18n-def="Theme">Theme</div>
+            <select id="al_brief_theme" class="field">
+              <option value="dark" data-i18n="opt.theme_dark" data-i18n-def="Dark">Dark</option>
+              <option value="light" data-i18n="opt.theme_light" data-i18n-def="Light">Light</option>
+            </select>
+          </div>
+        </div>
+        <p class="cap" id="al_brief_chan_cap" style="margin-top:6px" data-i18n="brief.chan_cap" data-i18n-def="Only channels you've configured above appear here. Save the channel first if it isn't listed.">Only channels you've configured above appear here. Save the channel first if it isn't listed.</p>
+
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+          <button class="rb" id="al_brief_preview" data-i18n="brief.preview" data-i18n-def="Preview">Preview</button>
+          <button class="rb" id="al_brief_test" data-i18n="brief.test" data-i18n-def="Send test brief">Send test brief</button>
+        </div>
+        <p class="cap" style="margin-top:6px" data-i18n="brief.note" data-i18n-def="Preview and Send test use your last saved settings — click Save above first if you just changed the channel.">Preview and Send test use your last saved settings — click Save above first if you just changed the channel.</p>
+      </div>
     </div>
     </div><!-- /set-pane-alerts -->
     <div id="set-pane-costs" hidden>
@@ -3986,7 +4024,56 @@ async function loadAlerts(){
   document.getElementById('al_webhook_state').textContent = s.webhook_url_set
     ? 'A webhook is saved. Leave blank to keep it; type a new one to replace; type CLEAR and save to remove.'
     : 'No webhook saved yet.';
+  fillBrief(s);
   ALERTS_LOADED=true;
+}
+
+// ── Daily brief (#170) ────────────────────────────────────────────────────────
+// Which channels are configured (so the brief dropdown only offers usable ones).
+function configuredChannels(s){
+  const out=[];
+  if(s.email_host && s.email_from && s.email_to) out.push(['email', 'Email ('+s.email_to+')']);
+  if(s.discord_webhook_url_set) out.push(['discord','Discord']);
+  if(s.telegram_token_set && s.telegram_chat_id) out.push(['telegram','Telegram']);
+  if(s.ntfy_topic) out.push(['ntfy','ntfy ('+s.ntfy_topic+')']);
+  if(s.slack_webhook_url_set) out.push(['slack','Slack']);
+  if(s.webhook_url_set) out.push(['webhook','Webhook']);
+  return out;
+}
+function fillBrief(s){
+  document.getElementById('al_brief_enabled').checked = s.brief_enabled==='1';
+  document.getElementById('al_brief_time').value = s.brief_time || '08:00';
+  document.getElementById('al_brief_theme').value = (s.brief_theme==='light') ? 'light' : 'dark';
+  const sel=document.getElementById('al_brief_channel');
+  const chans=configuredChannels(s);
+  const saved=s.brief_channel || '';
+  const labels={email:'Email',discord:'Discord',telegram:'Telegram',ntfy:'ntfy',slack:'Slack',webhook:'Webhook'};
+  // Keep the saved channel visible even if it's no longer configured (flag it).
+  if(saved && !chans.some(c=>c[0]===saved)) chans.push([saved, (labels[saved]||saved)+' (not configured)']);
+  sel.innerHTML = chans.length
+    ? chans.map(c=>`<option value="${c[0]}"${c[0]===saved?' selected':''}>${esc(c[1])}</option>`).join('')
+    : '<option value="">— configure a channel above first —</option>';
+  document.getElementById('al_brief_chan_cap').style.display = chans.length ? 'none' : '';
+}
+function showBriefStatus(level,text){
+  const el=document.getElementById('brief-status');
+  el.className='ins '+level; el.style.display='flex';
+  el.innerHTML=`<div class="ic">${(window.ICON&&ICON[level])||'•'}</div><div><div class="t">${esc(text)}</div></div>`;
+  setTimeout(()=>{el.style.display='none';}, 6000);
+}
+function briefPreview(){
+  const theme=document.getElementById('al_brief_theme').value || 'dark';
+  window.open('/api/brief/preview?theme='+encodeURIComponent(theme), '_blank');
+}
+async function briefTest(){
+  const ch=document.getElementById('al_brief_channel').value;
+  if(!ch){ showBriefStatus('warning','Configure and save a channel first.'); return; }
+  showBriefStatus('info','Sending test brief to '+ch+'…');
+  let j; try{ j=await(await fetch('/api/brief/test',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({channel:ch})})).json(); }
+  catch(e){ showBriefStatus('critical','Test failed: '+e); return; }
+  if(j.ok) showBriefStatus('ok','Test brief sent to '+j.channel+'.');
+  else showBriefStatus('critical', j.error || 'Test failed — check the channel settings above.');
 }
 
 function toast(level,text){
@@ -4042,6 +4129,10 @@ async function saveAlerts(){
     system_idle_watts: (document.getElementById('al_idle_w')||{}).value || '',
     mlflow_uri:        (document.getElementById('al_mlflow_uri')||{}).value || '',
     country:          document.getElementById('al_country').value,
+    brief_enabled:    document.getElementById('al_brief_enabled').checked ? '1' : '0',
+    brief_time:       document.getElementById('al_brief_time').value || '08:00',
+    brief_channel:    document.getElementById('al_brief_channel').value || '',
+    brief_theme:      document.getElementById('al_brief_theme').value || 'dark',
   };
   // Only send the webhook field if the user actually typed in it — empty means
   // "no change" when one is already saved (matching the placeholder hint),
@@ -6719,6 +6810,8 @@ async function maybeWhatsNew(curVersion){
 window.addEventListener('hashchange',()=>{const h=location.hash.slice(1); if(h && TABS.some(t=>t.id===h) && h!==TAB) showTab(h);});
 document.getElementById('al_save').onclick = saveAlerts;
 document.getElementById('al_test').onclick = testAlerts;
+document.getElementById('al_brief_preview').onclick = briefPreview;
+document.getElementById('al_brief_test').onclick = briefTest;
 wireUptime();
 const al_save_costs = document.getElementById('al_save_costs');
 if(al_save_costs) al_save_costs.onclick = saveAlerts;   // both panes persist all settings

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -88,6 +88,11 @@ class TestRenderContract(unittest.TestCase):
         html, _, _ = app.render_brief("light")
         self.assertIn(app._BRIEF_PALETTE["light"]["bg"], html)
 
+    def test_no_dead_fragment_link(self):
+        """Email clients strip/neutralise href="#"; the brief must not ship one."""
+        html, _, _ = app.render_brief("dark")
+        self.assertNotIn('href="#"', html)
+
 
 class TestSchedule(unittest.TestCase):
     def setUp(self):

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -1,0 +1,165 @@
+"""Unit tests for the Daily Brief (#170): the render contract (html/summary/subject),
+the all-green vs. needs-attention headline + Action-needed block, graceful section
+degradation, the settings round-trip, the schedule (_brief_due) once-per-day logic,
+and the preview/test API contract. All delivery is mocked — NO real outbound in CI."""
+import os
+import sys
+import time
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+def _clean():
+    with app.LOCK:
+        app.DB.execute("DELETE FROM hosts")
+        app.DB.execute("DELETE FROM uptime_checks")
+        app.DB.execute("DELETE FROM events")
+        app.DB.execute("DELETE FROM settings")
+        app.DB.commit()
+    app._BRIEF_LAST_SENT["date"] = None
+
+
+def _healthy_state(disk_pct=40):
+    """A green fleet snapshot in app.LATEST / app.HEALTH."""
+    app.LATEST.update({
+        "util": 0, "mem_used": 500, "mem_total": 24576, "power": 40, "temp": 41,
+        "gpu_avail": True, "gpus": [{"name": "Test GPU"}], "models": [],
+        "host": {"hostname": "testhub", "cpu": 2, "ram_used": 1000, "ram_total": 8000,
+                 "disks": [{"mount": "/", "pct": disk_pct}]},
+    })
+    app.HEALTH.update({
+        "docker": {"available": True, "summary": {"total": 3, "running": 3, "problems": 0}, "containers": []},
+        "systemd": {"available": True, "summary": {"running": 10, "failed": 0}, "services": []},
+        "at": int(time.time()),
+    })
+
+
+class TestRenderContract(unittest.TestCase):
+    def setUp(self):
+        _clean()
+        _healthy_state()
+
+    def test_returns_html_summary_subject(self):
+        html, summary, subject = app.render_brief("dark")
+        self.assertTrue(html.lstrip().startswith("<!DOCTYPE html>"))
+        self.assertIn("📰 Daily brief", html)
+        self.assertIn("testhub", subject)
+        self.assertIsInstance(summary, str)
+
+    def test_all_green_has_no_action_block(self):
+        html, summary, subject = app.render_brief("dark")
+        self.assertIn("All systems healthy", html)
+        self.assertIn("All systems healthy", subject)
+        self.assertNotIn("Action needed", html)
+        self.assertNotIn("Action needed", summary)
+
+    def test_issue_surfaces_headline_and_action(self):
+        _healthy_state(disk_pct=95)          # host card goes crit on disk
+        html, summary, subject = app.render_brief("dark")
+        self.assertIn("to look at", html)
+        self.assertIn("Action needed", html)
+        self.assertIn("Action needed", summary)
+        self.assertNotIn("All systems healthy", subject)
+
+    def test_offline_registered_host_is_an_action(self):
+        with app.LOCK:
+            app.DB.execute("INSERT INTO hosts(name, ssh_target, tags, added_at, last_check_at, last_check_json) "
+                           "VALUES(?,?,?,?,?,?)",
+                           ("edge", "u@edge", "", int(time.time()), int(time.time()),
+                            '{"summary": {"overall": "fail"}}'))
+            app.DB.commit()
+        html, summary, subject = app.render_brief("dark")
+        self.assertIn("edge", html)
+        self.assertIn("offline", html.lower())
+
+    def test_events_section_appears_when_present(self):
+        with app.LOCK:
+            app.DB.execute("INSERT INTO events(ts, service, kind, detail) VALUES(?,?,?,?)",
+                           (int(time.time()) - 300, "immich", "oom", "killed worker"))
+            app.DB.commit()
+        html, _, _ = app.render_brief("dark")
+        self.assertIn("Alerts", html)
+        self.assertIn("immich", html)
+
+    def test_light_theme_uses_light_palette(self):
+        html, _, _ = app.render_brief("light")
+        self.assertIn(app._BRIEF_PALETTE["light"]["bg"], html)
+
+
+class TestSchedule(unittest.TestCase):
+    def setUp(self):
+        _clean()
+        _healthy_state()
+
+    def _enable(self):
+        app.save_settings({"brief_enabled": "1", "brief_channel": "email", "email_host": "smtp.x",
+                           "email_from": "a@x", "email_to": "b@x"})
+
+    def test_due_fires_at_configured_time_once_per_day(self):
+        now = time.time()
+        hhmm = time.strftime("%H:%M", time.localtime(now))
+        self._enable()
+        app.save_settings({"brief_time": hhmm})
+        due = app._brief_due(now)
+        self.assertIsNotNone(due)
+        self.assertEqual(due[1], "email")
+        # mark sent today → suppressed
+        app._BRIEF_LAST_SENT["date"] = due[2]
+        self.assertIsNone(app._brief_due(now))
+
+    def test_not_due_when_disabled_or_unconfigured(self):
+        now = time.time()
+        hhmm = time.strftime("%H:%M", time.localtime(now))
+        app.save_settings({"brief_enabled": "0", "brief_time": hhmm})
+        self.assertIsNone(app._brief_due(now))
+        # enabled but channel not configured
+        app.save_settings({"brief_enabled": "1", "brief_channel": "discord", "brief_time": hhmm})
+        self.assertIsNone(app._brief_due(now))
+
+    def test_channel_ready(self):
+        s = {"email_host": "h", "email_from": "a@x", "email_to": "b@x"}
+        self.assertTrue(app._brief_channel_ready(s, "email"))
+        self.assertFalse(app._brief_channel_ready({}, "email"))
+        self.assertTrue(app._brief_channel_ready({"discord_webhook_url": "u"}, "discord"))
+
+
+class TestApi(unittest.TestCase):
+    def setUp(self):
+        _clean()
+        _healthy_state()
+        self.c = app.app.test_client()
+
+    def test_preview_returns_html(self):
+        r = self.c.get("/api/brief/preview")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("text/html", r.headers.get("Content-Type", ""))
+        self.assertIn(b"Daily brief", r.data)
+
+    def test_test_requires_configured_channel(self):
+        r = self.c.post("/api/brief/test", json={"channel": "email"})
+        self.assertEqual(r.status_code, 400)   # email not configured
+
+    def test_test_delivers_when_configured(self):
+        app.save_settings({"email_host": "smtp.x", "email_from": "a@x", "email_to": "b@x"})
+        with patch.object(app, "_send_brief_email", MagicMock()) as m:
+            r = self.c.post("/api/brief/test", json={"channel": "email"})
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.get_json()["ok"])
+        m.assert_called_once()
+
+    def test_brief_settings_round_trip(self):
+        r = self.c.post("/api/settings", json={"brief_enabled": "1", "brief_time": "07:30",
+                                               "brief_channel": "ntfy", "brief_theme": "light"})
+        self.assertEqual(r.status_code, 200)
+        s = self.c.get("/api/settings").get_json()["settings"]
+        self.assertEqual(s["brief_enabled"], "1")
+        self.assertEqual(s["brief_time"], "07:30")
+        self.assertEqual(s["brief_channel"], "ntfy")
+        self.assertEqual(s["brief_theme"], "light")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -125,6 +125,20 @@ class TestSchedule(unittest.TestCase):
         self.assertFalse(app._brief_channel_ready({}, "email"))
         self.assertTrue(app._brief_channel_ready({"discord_webhook_url": "u"}, "discord"))
 
+    def test_run_once_claims_day_before_send_no_duplicate(self):
+        """A transient send failure must still claim the day so the worker can't
+        re-fire in the same minute and deliver a duplicate."""
+        now = time.time()
+        hhmm = time.strftime("%H:%M", time.localtime(now))
+        self._enable()
+        app.save_settings({"brief_time": hhmm})
+        today = time.strftime("%Y-%m-%d", time.localtime(now))
+        with patch.object(app, "send_brief", MagicMock(side_effect=RuntimeError("smtp down"))) as m:
+            self.assertTrue(app._brief_run_once(now))     # due → attempted
+            self.assertEqual(app._BRIEF_LAST_SENT["date"], today)  # claimed despite failure
+            self.assertFalse(app._brief_run_once(now))    # same minute → not due again
+        m.assert_called_once()                            # exactly one delivery attempt
+
 
 class TestApi(unittest.TestCase):
     def setUp(self):
@@ -149,6 +163,16 @@ class TestApi(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.get_json()["ok"])
         m.assert_called_once()
+
+    def test_unknown_channel_rejected(self):
+        """brief_channel is enum-validated server-side, so a crafted value can never
+        reach the store (or the dashboard's <option>). Closes the stored-XSS surface."""
+        r = self.c.post("/api/settings", json={"brief_channel": 'discord" onmouseover="x'})
+        self.assertEqual(r.status_code, 400)
+        r2 = self.c.post("/api/settings", json={"brief_theme": "neon"})
+        self.assertEqual(r2.status_code, 400)
+        r3 = self.c.post("/api/settings", json={"brief_time": "9am"})
+        self.assertEqual(r3.status_code, 400)
 
     def test_brief_settings_round_trip(self):
         r = self.c.post("/api/settings", json={"brief_enabled": "1", "brief_time": "07:30",


### PR DESCRIPTION
Implements **#170 — Daily brief**: an opt-in, once-a-day HTML health digest, the calm counterpart to edge-triggered alerts ("everything's fine — or here's the one thing to look at").

Builds on the design mockup; grounded in the data we already collect. **Pure stdlib, no new dependency.**

## What it does
- Renders a **self-contained, inline-styled, theme-aware HTML report** (table layout — survives Gmail/Outlook with no external assets).
- Delivers once a day to **one chosen channel**: **email** gets the full HTML; **Discord / Telegram / ntfy / Slack / webhook** get a compact summary with the things that need attention.
- Opt-in and **off by default**; the channel dropdown only offers channels you've already configured under Alerts — no new credentials.

## Report anatomy
Headline + KPI strip (Hosts up / Checks up / To-look-at / yesterday's cost) → **Action needed** (omitted entirely when all-green) → **Fleet** → **Checks** → **Alerts (24h)** → **AI & cost** → **Capacity nudges**. Each section degrades gracefully when its data source is absent — e.g. the TLS-cert line lights up automatically once #163 lands; the cost line hides when no kWh price is set.

## Backend (`app.py`)
- `render_brief(theme) -> (html, summary, subject)` + section assemblers built on existing accessors: `build_overview`, `list_hosts`, `uptime_summary`/`uptime_overview`, the `events` table, `LATEST` GPU/models, and a tariff-aware `_brief_yesterday_cost` (reuses `_cost_ctx`/`_price_at`).
- `_send_brief_email` adds an **HTML alternative** to the existing SMTP path (keeps the plain-text fallback); `send_brief` routes to one channel via the existing `send_*` functions.
- `brief_worker` daemon fires once per **local** day at the configured `HH:MM`.
- 4 opt-in settings: `brief_enabled` (default `0`), `brief_time`, `brief_channel`, `brief_theme`.
- Routes: `GET /api/brief/preview` (renders the HTML) and `POST /api/brief/test` (delivers now; clean 400 on misconfig, 502 on delivery failure).

## Frontend (`static/dashboard.html`)
- New **Daily brief** block under Settings → 🔔 Alerts: enable toggle, time, channel dropdown (only configured channels), theme, **Preview** + **Send test**. Reuses existing `flabel`/`field`/`rb`/`ins` classes and persists via the shared **Save**.

## Tests & verification
- `tests/test_brief.py` (13 tests): render contract, all-green vs needs-attention headline + Action block, offline-host & events sections, light palette, schedule once-per-day + channel-ready logic, preview 200, test-endpoint validation + mocked delivery, settings round-trip.
- **Full suite: 244 passed** (231 existing + 13 new), zero regressions.
- All inline `<script>` blocks compile clean.
- Rendered the real `render_brief()` output for both the all-green and needs-attention states and verified visually (screenshots in the linked thread).

## Notes
- No version bump / CHANGELOG edit (handled by the maintainer at release time, per CONTRIBUTING).
- Snapshot-PNG attachment (#31) for chat channels is intentionally left for a follow-up; the summary already links back to the dashboard.
- Suggest landing late in the 0.18 line so the Checks/Alerts sections have their upstream data — though it ships useful today (Fleet / AI & cost / Capacity / headline all have live data now).
