### PR TITLE
feat(system): copy buttons on the System & Hardware cards

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -6182,12 +6182,13 @@ async function copyText(text, btn){
   let ok = true;
   try { await navigator.clipboard.writeText(text); }
   catch(e){
+    const ta=document.createElement('textarea');
     try {
-      const ta=document.createElement('textarea');
       ta.value=text; ta.style.position='fixed'; ta.style.opacity='0';
       document.body.appendChild(ta); ta.focus(); ta.select();
-      ok = document.execCommand('copy'); ta.remove();
+      ok = document.execCommand('copy');
     } catch(_){ ok=false; }
+    finally { ta.remove(); }   // always clean up, even if execCommand/select threw
   }
   if(btn && ok && !btn._copyTimer){   // ignore re-clicks while ✓ is showing, so a
     const old=btn.innerHTML;          // rapid double-click can't capture ✓ as the

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -743,7 +743,7 @@ a{color:var(--info)}
 /* System / Network / Security detail */
 .infogrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(290px,1fr));gap:14px}
 .infocard{background:var(--inset);border:1px solid var(--bd);border-radius:9px;padding:12px 14px}
-.infocard h3{margin:0 0 8px;font-size:12px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em;font-weight:600}
+.infocard h3{margin:0 0 8px;font-size:12px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em;font-weight:600;display:flex;align-items:center;gap:7px}
 .inforow{display:flex;gap:10px;padding:4px 0;font-size:13px;align-items:baseline}
 .inforow .k{color:var(--mut);flex:0 0 104px}
 .inforow .v{color:var(--tx);font-family:var(--mono);word-break:break-word;min-width:0}
@@ -756,7 +756,6 @@ a{color:var(--info)}
 .copybtn:focus-visible{opacity:1;outline:1px solid var(--accent);outline-offset:1px}
 .copybtn.copied{color:var(--ok);opacity:1}
 .copybtn .sic{width:13px;height:13px}
-.infocard h3{display:flex;align-items:center;gap:7px}
 .infocard h3 .copybtn{opacity:.5;padding:1px}
 .infocard h3 .copybtn:hover{opacity:1}
 .kpirow{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px}
@@ -6190,10 +6189,10 @@ async function copyText(text, btn){
       ok = document.execCommand('copy'); ta.remove();
     } catch(_){ ok=false; }
   }
-  if(btn && ok){
-    const old=btn.innerHTML;
-    btn.classList.add('copied'); btn.innerHTML=sic('check');
-    setTimeout(()=>{ btn.classList.remove('copied'); btn.innerHTML=old; }, 1100);
+  if(btn && ok && !btn._copyTimer){   // ignore re-clicks while ✓ is showing, so a
+    const old=btn.innerHTML;          // rapid double-click can't capture ✓ as the
+    btn.classList.add('copied'); btn.innerHTML=sic('check');   // "original" icon
+    btn._copyTimer=setTimeout(()=>{ btn.classList.remove('copied'); btn.innerHTML=old; btn._copyTimer=null; }, 1100);
   }
 }
 // Wire per-row + per-card copy buttons inside a freshly-rendered .infogrid.

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -746,7 +746,19 @@ a{color:var(--info)}
 .infocard h3{margin:0 0 8px;font-size:12px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em;font-weight:600}
 .inforow{display:flex;gap:10px;padding:4px 0;font-size:13px;align-items:baseline}
 .inforow .k{color:var(--mut);flex:0 0 104px}
-.inforow .v{color:var(--tx);font-family:var(--mono);word-break:break-word}
+.inforow .v{color:var(--tx);font-family:var(--mono);word-break:break-word;min-width:0}
+/* per-field + per-card copy buttons — quiet until hover, ✓/accent on action */
+.copybtn{margin-left:auto;flex:none;align-self:center;display:inline-flex;align-items:center;
+  background:none;border:0;color:var(--mut);cursor:pointer;padding:2px;border-radius:5px;
+  opacity:0;transition:opacity .12s,color .12s,background .12s}
+.inforow:hover .copybtn{opacity:.6}
+.copybtn:hover{color:var(--accent);background:var(--hover);opacity:1}
+.copybtn:focus-visible{opacity:1;outline:1px solid var(--accent);outline-offset:1px}
+.copybtn.copied{color:var(--ok);opacity:1}
+.copybtn .sic{width:13px;height:13px}
+.infocard h3{display:flex;align-items:center;gap:7px}
+.infocard h3 .copybtn{opacity:.5;padding:1px}
+.infocard h3 .copybtn:hover{opacity:1}
 .kpirow{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px}
 .kpirow .kpi{flex:1;min-width:120px}
 /* Security check rows reuse the app's .badge + .sdot + table styling; the only
@@ -2679,6 +2691,7 @@ const SIC={
   trendUp:'<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/>',
   trendDown:'<polyline points="22 17 13.5 8.5 8.5 13.5 2 7"/><polyline points="16 17 22 17 22 11"/>',
   scale:'<path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"/><path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"/><path d="M7 21h10M12 3v18M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2"/>',
+  copy:'<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
 };
 function sic(name){ const d=SIC[name]; return d ? `<svg class="sic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${d}</svg>` : ''; }
 const RUN_SRC_COLOR={jupyter:'#a371f7',colab:'#f59e0b',kaggle:'#4dabf7',mlflow:'#3fb950',api:'#8b949e',cli:'#6b7280'};
@@ -6149,7 +6162,59 @@ function waitingHostMsg(){
   return null;
 }
 function infoRow(k, v){
-  return (v==null || v==='') ? '' : `<div class="inforow"><span class="k">${k}</span><span class="v">${v}</span></div>`;
+  if(v==null || v==='') return '';
+  const t = I18N.t('copy.field','Copy value');
+  return `<div class="inforow"><span class="k">${k}</span><span class="v">${v}</span>`
+       + `<button type="button" class="copybtn" title="${t}" aria-label="${t}">${sic('copy')}</button></div>`;
+}
+// One System/Hardware card: title (+ a "copy whole card" button when it has rows)
+// and the rows. The per-row and per-card copy values are read at click time from
+// the rendered .k/.v text, so nothing sensitive is duplicated into attributes.
+function infoCard(title, rowsHtml, emptyMsg){
+  const t = I18N.t('copy.card','Copy whole card');
+  const copyAll = rowsHtml
+    ? `<button type="button" class="copybtn copyall" title="${t}" aria-label="${t}">${sic('copy')}</button>` : '';
+  return `<div class="infocard"><h3>${title}${copyAll}</h3>${rowsHtml || '<div class="muted">'+emptyMsg+'</div>'}</div>`;
+}
+// Copy text to the clipboard with a brief ✓ on the button. Falls back to a hidden
+// textarea + execCommand where the async Clipboard API isn't available (http / old).
+async function copyText(text, btn){
+  if(!text) return;
+  let ok = true;
+  try { await navigator.clipboard.writeText(text); }
+  catch(e){
+    try {
+      const ta=document.createElement('textarea');
+      ta.value=text; ta.style.position='fixed'; ta.style.opacity='0';
+      document.body.appendChild(ta); ta.focus(); ta.select();
+      ok = document.execCommand('copy'); ta.remove();
+    } catch(_){ ok=false; }
+  }
+  if(btn && ok){
+    const old=btn.innerHTML;
+    btn.classList.add('copied'); btn.innerHTML=sic('check');
+    setTimeout(()=>{ btn.classList.remove('copied'); btn.innerHTML=old; }, 1100);
+  }
+}
+// Wire per-row + per-card copy buttons inside a freshly-rendered .infogrid.
+function wireCopyButtons(root){
+  root.querySelectorAll('.copybtn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if(btn.classList.contains('copyall')){
+        const card = btn.closest('.infocard');
+        const title = (card.querySelector('h3')?.childNodes[0]?.textContent || '').trim();
+        const lines = [...card.querySelectorAll('.inforow')].map(r => {
+          const kk = (r.querySelector('.k')?.textContent || '').trim();
+          const vv = (r.querySelector('.v')?.textContent || '').replace(/\s+/g,' ').trim();
+          return (kk && vv) ? `${kk}: ${vv}` : '';
+        }).filter(Boolean);
+        copyText((title ? title+'\n' : '') + lines.join('\n'), btn);
+      } else {
+        const vv = (btn.previousElementSibling?.textContent || '').replace(/\s+/g,' ').trim();
+        copyText(vv, btn);
+      }
+    });
+  });
 }
 
 function renderSysInfo(){
@@ -6178,8 +6243,9 @@ function renderSysInfo(){
     infoRow(I18N.t('sys.gpu','GPU'),      gpu),
   ].join('');
   el.innerHTML = `<div class="infogrid">
-    <div class="infocard"><h3>${I18N.t('sys.card_system','System')}</h3>${sys||'<div class="muted">'+I18N.t('sys.no_system','No system info reported.')+'</div>'}</div>
-    <div class="infocard"><h3>${I18N.t('sys.card_hardware','Hardware')}</h3>${hwh||'<div class="muted">'+I18N.t('sys.no_hardware','No hardware info reported.')+'</div>'}</div></div>`;
+    ${infoCard(I18N.t('sys.card_system','System'), sys, I18N.t('sys.no_system','No system info reported.'))}
+    ${infoCard(I18N.t('sys.card_hardware','Hardware'), hwh, I18N.t('sys.no_hardware','No hardware info reported.'))}</div>`;
+  wireCopyButtons(el);
 }
 
 // Compact byte formatter for interface RX/TX counters (distinct from fmtBytes,


### PR DESCRIPTION
## What

Quick "grab my setup" copy on the **System** tab. Both detail cards — **System** and **Hardware** — get copy affordances:

- **Per-field copy icon** on every row — click to copy just that value (OS, kernel, hostname, CPU, memory, GPU, …).
- **Copy-whole-card button** in each card header — copies a clean `Label: value` block (prefixed with the card title), ready to paste into a GitHub issue, forum post, or notes.

Super handy when you want to share your rig without retyping it.

## How

- Adds a `copy` glyph to the `SIC` inline-icon map (Lucide), rendered through the existing `sic()` helper — no raw emoji, consistent with the rest of the UI.
- `infoRow()` now appends a `.copybtn`; a new `infoCard()` helper renders the per-card **copy-all** button (only when the card actually has rows).
- `copyText()` uses `navigator.clipboard.writeText` with a hidden-`textarea` + `execCommand('copy')` fallback for http/older browsers, and flips the icon to a ✓ for ~1s as confirmation.
- `wireCopyButtons()` reads values **at click time** from the rendered `.k`/`.v` text (whitespace-normalised) — nothing sensitive is duplicated into attributes; per-card copy joins each row as `Label: value`.
- Quiet by default: per-row icons fade in on row hover, the card icon sits at ~50% opacity; both use `--accent`/`--ok`/`--hover` tokens and are keyboard-focusable (`:focus-visible`).

## Scope / verification

- **Frontend-only** — `static/dashboard.html` (+70/−4). No backend, no new deps.
- All inline `<script>` blocks compile clean; Python suite unaffected (247 passed).
- Rendered a faithful harness of the two cards and verified the per-row + per-card buttons render, reveal on hover, and fire the ✓ confirmation on click (screenshot in the thread).

No i18n catalogue entries needed — the two new strings use `I18N.t(key, default)` inline defaults, matching the established pattern.
