### PR TITLE
Status page redesign: status.claude.com-style components in the app's skin

### DIFF
--- a/app.py
+++ b/app.py
@@ -7625,28 +7625,60 @@ def _public_monitor_host(check):
     except Exception:
         return ""
 
+def _public_monitor(check, now):
+    """One public component for the status page — a single 90-day query yields
+    everything the Statuspage-style row needs: current state, 24h/7d/90d uptime,
+    a day-by-day bar, the recent heartbeat, cert status, and recent incidents.
+    No raw target (host only)."""
+    cid = check["id"]
+    with LOCK:
+        rows = DB.execute(
+            "SELECT ts,up,latency_ms,code,err,cert_days_remaining,cert_expires_at "
+            "FROM uptime_results WHERE check_id=? AND ts>=? ORDER BY ts",
+            (cid, now - 7776000)).fetchall()        # 90 days
+    def win(w):
+        sub = [r for r in rows if r[0] >= now - w]
+        return round(100.0 * sum(1 for r in sub if r[1]) / len(sub), 2) if sub else None
+    last = rows[-1] if rows else None
+    state = "unknown" if not last else ("up" if last[1] else "down")
+    cert_days = last[5] if (last and len(last) > 5) else None
+    cert_status = None
+    if cert_days is not None:
+        cert_status = "red" if cert_days <= 7 else "amber" if cert_days <= 21 else "ok"
+    return {
+        "id": cid, "label": check["label"], "type": check["type"],
+        "host": _public_monitor_host(check), "state": state,
+        "last_latency_ms": (last[2] if last else None),
+        "last_checked": (last[0] if last else None),
+        "uptime": win(86400), "uptime7": win(604800), "uptime90": win(7776000),
+        "up_since": _uptime_up_since(rows),
+        "daily": _uptime_daily(rows),
+        "strip": [{"up": bool(r[1]), "t": r[0]} for r in rows[-_UPTIME_STRIP_CELLS:]],
+        "incidents": _uptime_incidents(rows, cap=5),
+        "cert_days_remaining": cert_days, "cert_status": cert_status,
+    }
+
 def _public_monitors(now):
-    """Index summary of every public+enabled check: label, host, state, 24h/7d
-    uptime, last latency, heartbeat strip, cert status. No raw target."""
-    out = []
-    for c in list_uptime_checks():
-        if not (c.get("public") and c.get("enabled")):
-            continue
-        s = _uptime_state(c["id"], now)
-        out.append({
-            "id": c["id"], "label": c["label"], "type": c["type"],
-            "host": _public_monitor_host(c),
-            "state": s["state"], "uptime": s["uptime"], "uptime7": s["uptime7"],
-            "last_latency_ms": s["last_latency_ms"], "last_checked": s["last_checked"],
-            "strip": s["strip"],
-            "cert_days_remaining": s["cert_days_remaining"], "cert_status": s["cert_status"],
-        })
-    return out
+    """Every public+enabled check as a status-page component, in display order."""
+    return [_public_monitor(c, now) for c in list_uptime_checks()
+            if c.get("public") and c.get("enabled")]
 
 def _public_monitors_summary(monitors):
     return {"total": len(monitors),
             "up": sum(1 for m in monitors if m["state"] == "up"),
             "down": sum(1 for m in monitors if m["state"] == "down")}
+
+def _public_incident_feed(monitors, now, days=14, cap=25):
+    """Recent incidents across all public components, tagged with the service
+    name, most-recent first — drives the page's 'Past incidents' timeline."""
+    cutoff = now - days * 86400
+    feed = []
+    for m in monitors:
+        for inc in m.get("incidents", []):
+            if inc["start"] >= cutoff or (inc.get("end") and inc["end"] >= cutoff):
+                feed.append({"service": m["label"], **inc})
+    feed.sort(key=lambda i: i["start"], reverse=True)
+    return feed[:cap]
 
 def _uptime_window_pct(check_id, now, window):
     with LOCK:
@@ -7763,13 +7795,15 @@ def api_public_status():
     systemd = HEALTH.get("systemd") or {"available": False, "reason": "warming up", "services": [], "summary": {}}
     cards = build_overview(now, docker, systemd)
     safe_cards = [{k: v for k, v in c.items() if k in ("key", "label", "status", "metric", "detail")} for c in cards]
-    monitors = _public_monitors(int(time.time()))
+    _now = int(time.time())
+    monitors = _public_monitors(_now)
     return jsonify({
         "lab_name": cfg.get("lab_name", "My HomeLab"),
         "lab_emoji": cfg.get("lab_emoji", "🏠"),
         "overview": safe_cards,
         "monitors": monitors,
         "monitors_summary": _public_monitors_summary(monitors),
+        "incidents": _public_incident_feed(monitors, _now),
         "status": _public_overall_status(safe_cards, monitors),
     })
 

--- a/static/public.html
+++ b/static/public.html
@@ -1,138 +1,137 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Status</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <style>
-/* Same design tokens as the dashboard — this public page is part of the product. */
-:root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
---crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;--canvas:#0a0e14;--inset:#0d1117;--hover:#1c2230;
+/* The dashboard's own tokens — this status page is part of the product, dark-first. */
+:root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;
+--crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;--inset:#0d1117;--hover:#1c2230;
 --okbg:#3fb95018;--warnbg:#d2992218;--critbg:#f8514918;
 --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace}
-[data-theme="light"]{--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;--free:#eaeef2;
---crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;--canvas:#f6f8fa;--inset:#f6f8fa;--hover:#eef1f4;
+[data-theme="light"]{--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;
+--crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;--inset:#f6f8fa;--hover:#eef1f4;
 --okbg:#1a7f3714;--warnbg:#9a670014;--critbg:#cf222e14}
-@media(prefers-color-scheme:light){:root:not([data-theme]){--bg:#ffffff;--card:#ffffff;--bd:#d0d7de;--tx:#1f2328;--mut:#636c76;--accent:#9a6700;--free:#eaeef2;
---crit:#cf222e;--warn:#9a6700;--ok:#1a7f37;--info:#0969da;--canvas:#f6f8fa;--inset:#f6f8fa;--hover:#eef1f4;
---okbg:#1a7f3714;--warnbg:#9a670014;--critbg:#cf222e14}}
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:var(--bg);color:var(--tx);min-height:100vh;
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
   font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
-.wrap{max-width:920px;margin:0 auto;padding:26px 18px 60px}
+.wrap{max-width:860px;margin:0 auto;padding:30px 18px 60px}
 a{color:inherit;text-decoration:none}
-.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+.sd{width:9px;height:9px;border-radius:50%;flex:none;background:var(--mut)}
+.sd.ok{background:var(--ok)}.sd.warn{background:var(--warn)}.sd.crit{background:var(--crit)}.sd.unknown,.sd.info{background:var(--mut)}
 
-/* header */
-.top{display:flex;align-items:center;gap:10px;margin-bottom:20px;flex-wrap:wrap}
-.brand{display:flex;align-items:center;gap:9px;font-size:18px;font-weight:700}
-.brand .em{font-size:20px;line-height:1}
-.brand .sub{color:var(--mut);font-weight:500;font-size:13px;letter-spacing:.02em}
+/* header — brand uses the app's radar logo, not an emoji */
+.top{display:flex;align-items:center;gap:11px;margin-bottom:26px}
+.brand{display:flex;align-items:center;gap:10px;font-size:18px;font-weight:700}
+.brand img{width:26px;height:26px;display:block}
+.brand .sub{color:var(--mut);font-weight:500;font-size:13px}
 .spring{flex:1}
-.tbtn{background:var(--card);border:1px solid var(--bd);color:var(--mut);border-radius:7px;
-  width:32px;height:32px;cursor:pointer;font-size:15px;display:grid;place-items:center;transition:border-color .15s,color .15s}
+.tbtn{background:var(--card);border:1px solid var(--bd);color:var(--mut);border-radius:8px;
+  width:34px;height:34px;cursor:pointer;display:grid;place-items:center;transition:border-color .15s,color .15s}
 .tbtn:hover{border-color:var(--accent);color:var(--tx)}
+.tbtn svg{width:16px;height:16px;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
 
 /* overall banner */
-.banner{display:flex;align-items:center;gap:11px;padding:13px 16px;border-radius:11px;
-  border:1px solid var(--bd);font-weight:600;font-size:15px;margin-bottom:22px;background:var(--card)}
+.banner{display:flex;align-items:center;gap:12px;padding:16px 18px;border-radius:12px;
+  border:1px solid var(--bd);font-weight:600;font-size:16px;margin-bottom:26px;background:var(--card)}
+.banner .bd{width:12px;height:12px;border-radius:50%;background:currentColor;flex:none}
 .banner.ok{background:var(--okbg);border-color:var(--ok);color:var(--ok)}
 .banner.warn{background:var(--warnbg);border-color:var(--warn);color:var(--warn)}
 .banner.crit{background:var(--critbg);border-color:var(--crit);color:var(--crit)}
-.dot{width:10px;height:10px;border-radius:50%;background:currentColor;flex:none}
-.dot.pulse{animation:pulse 2.2s infinite}
 @keyframes pulse{0%{box-shadow:0 0 0 0 currentColor}70%{box-shadow:0 0 0 7px transparent}100%{box-shadow:0 0 0 0 transparent}}
+.banner.ok .bd{animation:pulse 2.4s infinite}
 
-/* section heads */
+/* section label */
 .sect{font-size:11px;font-weight:700;letter-spacing:.13em;text-transform:uppercase;color:var(--mut);
-  margin:0 2px 10px;display:flex;align-items:center;gap:8px}
-.sect .cnt{margin-left:auto;letter-spacing:.04em;font-weight:600;text-transform:none}
+  margin:0 2px 11px;display:flex;align-items:center;gap:8px}
+.sect .cnt{margin-left:auto;letter-spacing:.03em;font-weight:600;text-transform:none;font-family:var(--mono)}
 
-/* system cards */
-.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:12px;margin-bottom:26px}
-.card{background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:15px 16px;display:flex;flex-direction:column;gap:5px}
-.card .ch{display:flex;align-items:center;gap:8px;font-size:11px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--mut)}
-.card .sd{width:8px;height:8px;border-radius:50%;flex:none}
-.card .metric{font-size:24px;font-weight:700;line-height:1.15;font-family:var(--mono)}
-.card .detail{font-size:12px;color:var(--mut)}
-.sd.ok{background:var(--ok)}.sd.warn{background:var(--warn)}.sd.crit{background:var(--crit)}.sd.unknown,.sd.info{background:var(--mut)}
+/* system strip */
+.sys{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:10px;margin-bottom:30px}
+.syscard{background:var(--card);border:1px solid var(--bd);border-radius:11px;padding:13px 14px}
+.syscard .h{display:flex;align-items:center;gap:8px;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--mut)}
+.syscard .m{font-size:21px;font-weight:700;font-family:var(--mono);line-height:1.2;margin-top:5px}
+.syscard .d{font-size:12px;color:var(--mut);margin-top:1px}
 
-/* monitor rows */
-.mons{display:flex;flex-direction:column;border:1px solid var(--bd);border-radius:12px;overflow:hidden;background:var(--card)}
-.mon{display:grid;grid-template-columns:auto 1fr auto auto auto auto;align-items:center;gap:14px;
-  padding:13px 16px;border-bottom:1px solid var(--bd);transition:background .12s}
-.mon:last-child{border-bottom:0}
-a.mon:hover{background:var(--hover)}
-.mon .nm{min-width:0}
-.mon .nm b{font-weight:600;font-size:14px;display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.mon .nm span{color:var(--mut);font-size:12px;font-family:var(--mono);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block}
-.mon .up{font-family:var(--mono);font-size:13px;text-align:right;color:var(--mut)}
-.mon .up b{color:var(--tx);font-weight:600}
-.mon .lat{font-family:var(--mono);font-size:13px;color:var(--mut);text-align:right;min-width:54px}
-.mon .arr{color:var(--mut);font-size:16px}
-a.mon:hover .arr{color:var(--accent)}
+/* components (status-page style: name + status + 90-day bar) */
+.comps{display:flex;flex-direction:column;gap:10px;margin-bottom:14px}
+.comp{display:block;background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:15px 17px;transition:border-color .14s}
+a.comp:hover{border-color:var(--accent)}
+.comp-h{display:flex;align-items:center;gap:9px;margin-bottom:11px}
+.comp-nm{font-weight:600;font-size:15px}
+.comp-host{color:var(--mut);font-size:12px;font-family:var(--mono);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.comp-st{font-size:12px;font-weight:600;color:var(--mut)}
+.comp-st.ok{color:var(--ok)}.comp-st.crit{color:var(--crit)}.comp-st.warn{color:var(--warn)}
+a.comp:hover .comp-arr{color:var(--accent)}
+.comp-arr{color:var(--mut);font-size:15px;margin-left:4px}
 
-/* heartbeat */
-.hb{display:flex;gap:2px;align-items:flex-end;height:22px}
-.hb .c{width:4px;height:100%;border-radius:1px;background:var(--mut);opacity:.35}
-.hb .c.ok{background:var(--ok);opacity:1}
-.hb .c.down{background:var(--crit);opacity:1}
-.hb.lg{height:34px;gap:2px;flex-wrap:nowrap}
-.hb.lg .c{width:100%;min-width:3px;border-radius:2px}
+/* the 90-day daily bar */
+.daybar{display:flex;gap:2px;height:36px;align-items:stretch}
+.daybar .d{flex:1 1 0;min-width:2px;border-radius:2px;background:var(--ok)}
+.daybar .d.down{background:var(--crit)}
+.daybar .d.part{background:var(--warn)}
+.daybar .d.nodata{background:var(--bd);opacity:.45}
+.axis{display:flex;justify-content:space-between;font-size:11px;color:var(--mut);margin-top:8px;font-family:var(--mono)}
+.axis .mid{color:var(--tx);font-weight:600}
 
-/* pills */
-.pill{font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;
-  padding:3px 9px;border-radius:999px;border:1px solid var(--bd);color:var(--mut);white-space:nowrap}
-.pill.ok{color:var(--ok);border-color:var(--ok);background:var(--okbg)}
-.pill.crit{color:var(--crit);border-color:var(--crit);background:var(--critbg)}
-.pill.big{font-size:13px;padding:5px 13px}
+/* legend */
+.legend{display:flex;flex-wrap:wrap;gap:16px;margin:6px 2px 30px;font-size:12px;color:var(--mut)}
+.legend span{display:inline-flex;align-items:center;gap:6px}
+.legend i{width:10px;height:10px;border-radius:3px;display:inline-block}
+
+/* incidents */
+.incwrap{background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:6px 18px}
+.incday{padding:14px 0;border-bottom:1px solid var(--bd)}
+.incday:last-child{border-bottom:0}
+.incdate{font-size:12px;font-weight:700;color:var(--mut);letter-spacing:.04em;margin-bottom:10px;font-family:var(--mono)}
+.incrow{display:flex;gap:11px;padding:7px 0}
+.incrow .bdot{width:9px;height:9px;border-radius:50%;background:var(--crit);margin-top:5px;flex:none}
+.inctitle{font-weight:600;font-size:14px}
+.incmeta{font-size:12px;color:var(--mut);font-family:var(--mono);margin-top:2px}
+.empty{color:var(--mut);font-size:13px;padding:18px 2px;text-align:center}
 
 /* detail */
-.back{display:inline-flex;align-items:center;gap:6px;color:var(--mut);font-size:13px;margin-bottom:16px}
+.back{display:inline-flex;align-items:center;gap:6px;color:var(--mut);font-size:13px;margin-bottom:18px}
 .back:hover{color:var(--accent)}
 .dhead{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:4px}
-.dhead h1{font-size:22px;font-weight:700}
-.dsub{color:var(--mut);font-size:13px;font-family:var(--mono);margin-bottom:20px}
-.tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px}
-.tile{background:var(--card);border:1px solid var(--bd);border-radius:11px;padding:13px 14px;text-align:center}
+.dhead h1{font-size:23px;font-weight:700}
+.statepill{font-size:12px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;padding:5px 13px;border-radius:999px;border:1px solid var(--bd);color:var(--mut)}
+.statepill.ok{color:var(--ok);border-color:var(--ok);background:var(--okbg)}
+.statepill.crit{color:var(--crit);border-color:var(--crit);background:var(--critbg)}
+.dsub{color:var(--mut);font-size:13px;font-family:var(--mono);margin-bottom:22px}
+.tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:22px}
+.tile{background:var(--card);border:1px solid var(--bd);border-radius:11px;padding:14px;text-align:center}
 .tile .k{font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mut)}
-.tile .v{font-size:21px;font-weight:700;font-family:var(--mono);margin-top:4px}
-.panel{background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:16px 18px;margin-bottom:18px}
-.panel h3{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);
-  margin-bottom:12px;display:flex;align-items:center;gap:8px}
+.tile .v{font-size:22px;font-weight:700;font-family:var(--mono);margin-top:4px}
+.panel{background:var(--card);border:1px solid var(--bd);border-radius:12px;padding:17px 18px;margin-bottom:16px}
+.panel h3{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);margin-bottom:13px;display:flex;gap:8px}
 .panel h3 .meta{margin-left:auto;font-family:var(--mono);font-weight:600;letter-spacing:0;text-transform:none}
-.axis{display:flex;justify-content:space-between;font-size:11px;color:var(--mut);margin-top:7px;font-family:var(--mono)}
-.spark{width:100%;height:64px;display:block}
-.inc{display:flex;gap:12px;padding:10px 0;border-bottom:1px solid var(--bd);font-size:13px;align-items:baseline}
-.inc:last-child{border-bottom:0}
-.inc .when{font-family:var(--mono);color:var(--tx);white-space:nowrap}
-.inc .dur{font-family:var(--mono);color:var(--crit);white-space:nowrap}
-.inc .why{color:var(--mut);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.empty{color:var(--mut);font-size:13px;padding:6px 2px}
-.cert-ok{color:var(--ok)}.cert-amber{color:var(--warn)}.cert-red{color:var(--crit)}
+.spark{width:100%;height:66px;display:block}
 
-.foot{margin-top:26px;text-align:center;font-size:12px;color:var(--mut)}
-.foot a{color:var(--mut)}.foot a:hover{color:var(--accent)}
-@media(max-width:560px){.tiles{grid-template-columns:repeat(2,1fr)}.mon{grid-template-columns:auto 1fr auto auto;gap:10px}.mon .hb,.mon .lat{display:none}}
+.foot{margin-top:30px;display:flex;align-items:center;justify-content:center;gap:8px;font-size:12px;color:var(--mut)}
+.foot img{width:15px;height:15px;opacity:.8}
+.foot a:hover{color:var(--accent)}
+@media(max-width:560px){.tiles{grid-template-columns:repeat(2,1fr)}.comp-host{display:none}}
 </style>
 </head>
 <body>
 <div class="wrap">
   <div class="top">
-    <a href="/public" class="brand"><span class="em" id="lab-em">🏠</span><span id="lab-nm">HomeLab</span><span class="sub">· status</span></a>
+    <a href="/public" class="brand"><img src="/static/logo.svg" alt=""><span id="lab-nm">HomeLab</span><span class="sub">status</span></a>
     <span class="spring"></span>
-    <button class="tbtn" id="themebtn" title="Toggle theme" aria-label="Toggle theme">◐</button>
+    <button class="tbtn" id="themebtn" title="Toggle theme" aria-label="Toggle theme"></button>
   </div>
   <div id="view"></div>
-  <div class="foot">
-    <span id="foot-upd"></span> · <a href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener">HomeLab Monitor</a>
-  </div>
+  <div class="foot"><img src="/static/logo.svg" alt=""><a href="https://github.com/SikamikanikoBG/homelab-monitor" target="_blank" rel="noopener">HomeLab Monitor</a> · <span id="foot-upd"></span></div>
 </div>
 <script>
 const $=id=>document.getElementById(id);
 const esc=s=>(s==null?'':String(s)).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const SUN='<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M6.3 17.7l-1.4 1.4M19.1 4.9l-1.4 1.4"/></svg>';
+const MOON='<svg viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9z"/></svg>';
 function pct(v){ return v==null?'—':(Math.round(v*100)/100)+'%'; }
 function ms(v){ return v==null?'—':Math.round(v)+' ms'; }
 function clock(){ return new Date().toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}); }
@@ -143,54 +142,71 @@ function relTime(ts){ if(!ts) return '—'; const s=Date.now()/1000-ts;
   if(s<86400) return Math.round(s/3600)+'h ago'; return Math.round(s/86400)+'d ago'; }
 function tsDate(ts){ return new Date(ts*1000).toLocaleDateString([], {month:'short',day:'numeric'}); }
 function tsTime(ts){ return new Date(ts*1000).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}); }
+function stLabel(s){ return s==='up'?'Operational':s==='down'?'Down':'No data'; }
+function stCls(s){ return s==='up'?'ok':s==='down'?'crit':'unknown'; }
 
-// theme: cycle auto -> dark -> light
-function applyTheme(t){ if(t==='auto'){document.documentElement.removeAttribute('data-theme');} else {document.documentElement.setAttribute('data-theme',t);} $('themebtn').textContent=t==='light'?'☀':t==='dark'?'☾':'◐'; }
-let THEME=localStorage.getItem('pub_theme')||'auto'; applyTheme(THEME);
-$('themebtn').onclick=()=>{ THEME=THEME==='auto'?'dark':THEME==='dark'?'light':'auto'; localStorage.setItem('pub_theme',THEME); applyTheme(THEME); };
+// theme: dark-first (the app's identity), persisted; toggle dark <-> light
+let THEME=localStorage.getItem('pub_theme')||'dark';
+function applyTheme(){ document.documentElement.setAttribute('data-theme',THEME); $('themebtn').innerHTML=THEME==='dark'?SUN:MOON; }
+applyTheme();
+$('themebtn').onclick=()=>{ THEME=THEME==='dark'?'light':'dark'; localStorage.setItem('pub_theme',THEME); applyTheme(); };
 
-function setBrand(d){ if(d.lab_emoji)$('lab-em').textContent=d.lab_emoji; if(d.lab_name){$('lab-nm').textContent=d.lab_name; document.title=(d.lab_emoji||'')+' '+d.lab_name+' · status';} }
-function notEnabled(){ $('view').innerHTML='<div class="empty" style="padding:40px 0;text-align:center">This status page isn\'t enabled.</div>'; }
+function setBrand(d){ if(d.lab_name){$('lab-nm').textContent=d.lab_name; document.title=d.lab_name+' status';} }
+function notEnabled(){ $('view').innerHTML='<div class="empty" style="padding:50px 0">This status page isn\'t enabled.</div>'; }
 
-function hb(strip, cls){ if(!strip||!strip.length) return '<div class="hb '+(cls||'')+'"></div>';
-  return '<div class="hb '+(cls||'')+'">'+strip.map(c=>{ const st=(typeof c.up==='boolean')?(c.up?'ok':'down'):(c.state||'unknown');
-    const t=c.date?(tsDate(c.date)+' · '+pct(c.up_pct)):(c.t?tsTime(c.t):''); return '<div class="c '+st+'" title="'+esc(t)+'"></div>'; }).join('')+'</div>'; }
-
-function monRow(m){
-  const st=m.state||'unknown';
-  const pill=st==='up'?'<span class="pill ok">Up</span>':st==='down'?'<span class="pill crit">Down</span>':'<span class="pill">—</span>';
-  return `<a class="mon" href="/public/${encodeURIComponent(m.id)}">
-    <span class="sd ${st==='up'?'ok':st==='down'?'crit':'unknown'}"></span>
-    <span class="nm"><b>${esc(m.label)}</b><span>${esc(m.host||'')}</span></span>
-    ${hb(m.strip)}
-    <span class="up"><b>${pct(m.uptime)}</b></span>
-    <span class="lat">${ms(m.last_latency_ms)}</span>
-    ${pill}<span class="arr">›</span></a>`;
+// 90-day daily uptime bar — pads the left with no-data so it's always full width to today
+function dayBar(daily){
+  const cells=daily||[]; const pad=Math.max(0,90-cells.length); let h='<div class="daybar">';
+  for(let i=0;i<pad;i++) h+='<span class="d nodata" title="no data"></span>';
+  for(const c of cells){ const st=c.state==='up'?'up':c.state==='down'?'down':(c.up_pct!=null&&c.up_pct<100?'part':'nodata');
+    h+=`<span class="d ${st}" title="${esc(tsDate(c.date)+' · '+pct(c.up_pct))}"></span>`; }
+  return h+'</div>';
+}
+function component(m){
+  const cls=stCls(m.state);
+  return `<a class="comp" href="/public/${encodeURIComponent(m.id)}">
+    <div class="comp-h"><span class="sd ${cls}"></span><span class="comp-nm">${esc(m.label)}</span>
+      <span class="comp-host">${esc(m.host||'')}</span><span class="spring"></span>
+      <span class="comp-st ${cls}">${stLabel(m.state)}</span><span class="comp-arr">›</span></div>
+    ${dayBar(m.daily)}
+    <div class="axis"><span>90 days ago</span><span class="mid">${pct(m.uptime90)} uptime</span><span>Today</span></div></a>`;
+}
+function incidentsBlock(list){
+  if(!list||!list.length) return '<div class="empty">No incidents in the last 14 days — all clear.</div>';
+  const groups={};
+  list.forEach(i=>{ const k=tsDate(i.start); (groups[k]=groups[k]||[]).push(i); });
+  return '<div class="incwrap">'+Object.keys(groups).map(day=>`<div class="incday"><div class="incdate">${esc(day)}</div>`+
+    groups[day].map(i=>{ const end=i.end?tsTime(i.end):'now'; const dur=i.duration_s!=null?('down '+fmtDur(i.duration_s)):'ongoing';
+      return `<div class="incrow"><span class="bdot"></span><div><div class="inctitle">${esc(i.service)} — ${esc(i.err||'outage')}</div>
+        <div class="incmeta">${dur} · ${tsTime(i.start)} → ${end}</div></div></div>`; }).join('')+'</div>').join('')+'</div>';
 }
 
 async function renderIndex(){
   let d; try{ const r=await fetch('/api/public-status'); if(!r.ok) return notEnabled(); d=await r.json(); }catch(e){ return; }
   setBrand(d);
+  const su=d.monitors_summary||{}, down=su.down||0;
   const ok=d.status==='ok', crit=d.status==='crit';
   const bcls=crit?'crit':ok?'ok':'warn';
-  const btxt=crit?'Some services are down':ok?'All systems operational':'Some systems need attention';
-  const cards=(d.overview||[]).map(c=>`<div class="card"><div class="ch"><span class="sd ${c.status||'unknown'}"></span>${esc(c.label||c.key)}</div>
-    <div class="metric">${esc(c.metric||'—')}</div><div class="detail">${esc(c.detail||'')}</div></div>`).join('');
-  const mons=d.monitors||[], su=d.monitors_summary||{};
-  const monBlock = mons.length
-    ? `<div class="sect">Monitored services<span class="cnt">${su.up||0} up · ${su.down||0} down</span></div><div class="mons">${mons.map(monRow).join('')}</div>`
+  const btxt=crit?(down?`${down} service${down>1?'s':''} down`:'Major outage'):ok?'All systems operational':'Degraded performance';
+  const sys=(d.overview||[]).map(c=>`<div class="syscard"><div class="h"><span class="sd ${c.status||'unknown'}"></span>${esc(c.label||c.key)}</div>
+    <div class="m">${esc(c.metric||'—')}</div><div class="d">${esc(c.detail||'')}</div></div>`).join('');
+  const mons=d.monitors||[];
+  const comps = mons.length
+    ? `<div class="sect">Services<span class="cnt">${su.up||0} up · ${down} down</span></div><div class="comps">${mons.map(component).join('')}</div>
+       <div class="legend"><span><i style="background:var(--ok)"></i>Operational</span><span><i style="background:var(--warn)"></i>Degraded</span><span><i style="background:var(--crit)"></i>Down</span><span><i style="background:var(--bd)"></i>No data</span></div>`
     : '';
-  $('view').innerHTML=`<div class="banner ${bcls}"><span class="dot ${ok?'pulse':''}"></span>${btxt}</div>
-    ${cards?`<div class="sect">System</div><div class="cards">${cards}</div>`:''}
-    ${monBlock}`;
-  $('foot-upd').textContent='Updated '+clock();
+  $('view').innerHTML=`<div class="banner ${bcls}"><span class="bd"></span>${btxt}</div>
+    ${sys?`<div class="sect">System</div><div class="sys">${sys}</div>`:''}
+    ${comps}
+    <div class="sect">Past incidents</div>${incidentsBlock(d.incidents)}`;
+  $('foot-upd').textContent='updated '+clock();
 }
 
 function spark(series){
   if(!series||series.length<2) return '<div class="empty">Not enough samples yet.</div>';
   const xs=series.map(p=>p.t), ys=series.map(p=>p.ms);
   const x0=Math.min(...xs),x1=Math.max(...xs),y0=Math.min(...ys),y1=Math.max(...ys);
-  const W=600,H=64,pad=4, sx=t=>x1===x0?0:(t-x0)/(x1-x0)*W, sy=v=>y1===y0?H/2:H-pad-(v-y0)/(y1-y0)*(H-2*pad);
+  const W=600,H=66,pad=5, sx=t=>x1===x0?0:(t-x0)/(x1-x0)*W, sy=v=>y1===y0?H/2:H-pad-(v-y0)/(y1-y0)*(H-2*pad);
   const pts=series.map(p=>sx(p.t).toFixed(1)+','+sy(p.ms).toFixed(1)).join(' ');
   const area=`${sx(x0).toFixed(1)},${H} ${pts} ${sx(x1).toFixed(1)},${H}`;
   return `<svg class="spark" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" aria-hidden="true">
@@ -201,32 +217,26 @@ function spark(series){
 async function renderDetail(id){
   let d; try{ const r=await fetch('/api/public-status/'+encodeURIComponent(id)); if(r.status===404){ location.href='/public'; return; } d=await r.json(); }catch(e){ return; }
   try{ const s=await (await fetch('/api/public-status')).json(); setBrand(s); }catch(e){}
-  const st=d.state||'unknown';
-  const pill=st==='up'?'<span class="pill ok big">Operational</span>':st==='down'?'<span class="pill crit big">Down</span>':'<span class="pill big">Unknown</span>';
-  const since=d.up_since?('up for '+fmtDur(Date.now()/1000-d.up_since)):(st==='down'?'currently down':'');
+  const cls=stCls(d.state);
+  const since=d.up_since?('up for '+fmtDur(Date.now()/1000-d.up_since)):(d.state==='down'?'currently down':'');
   const u=d.uptime||{};
   const tiles=[['24h',u['24h']],['7 days',u['7d']],['30 days',u['30d']],['90 days',u['90d']]]
     .map(([k,v])=>`<div class="tile"><div class="k">${k}</div><div class="v">${pct(v)}</div></div>`).join('');
   const ys=(d.response_series||[]).map(p=>p.ms);
   const meta=ys.length?`avg ${Math.round(ys.reduce((a,b)=>a+b,0)/ys.length)} · max ${Math.max(...ys)} ms`:'';
-  const inc=(d.incidents||[]);
-  const incHtml=inc.length?inc.map(i=>{
-    const end=i.end?tsTime(i.end):'now';
-    const dur=i.duration_s!=null?('down '+fmtDur(i.duration_s)):'ongoing';
-    return `<div class="inc"><span class="when">${tsDate(i.start)} ${tsTime(i.start)} → ${end}</span><span class="dur">${dur}</span><span class="why">${esc(i.err||'no error message')}</span></div>`;
-  }).join(''):'<div class="empty">No incidents in the retained history. 🎉</div>';
   let cert='';
-  if(d.cert_days_remaining!=null) cert=`<span class="cert-${esc(d.cert_status||'ok')}">🔒 TLS valid · ${d.cert_days_remaining}d left</span> · `;
+  if(d.cert_days_remaining!=null) cert=`TLS valid · ${d.cert_days_remaining}d left · `;
   $('view').innerHTML=`<a class="back" href="/public">‹ back to status</a>
-    <div class="dhead"><span class="sd ${st==='up'?'ok':st==='down'?'crit':'unknown'}" style="width:11px;height:11px"></span><h1>${esc(d.label)}</h1>${pill}</div>
+    <div class="dhead"><span class="sd ${cls}" style="width:12px;height:12px"></span><h1>${esc(d.label)}</h1>
+      <span class="statepill ${cls}">${d.state==='up'?'Operational':d.state==='down'?'Down':'Unknown'}</span></div>
     <div class="dsub">${esc(d.host||'')}${since?' · '+since:''}</div>
     <div class="tiles">${tiles}</div>
     <div class="panel"><h3>Uptime · last 90 days<span class="meta">${(d.daily||[]).length} days tracked</span></h3>
-      ${hb(d.daily,'lg')}<div class="axis"><span>90d ago</span><span>today</span></div></div>
+      ${dayBar(d.daily)}<div class="axis"><span>90 days ago</span><span class="mid">${pct(u['90d'])} uptime</span><span>Today</span></div></div>
     <div class="panel"><h3>Response time<span class="meta">${meta}</span></h3>${spark(d.response_series)}</div>
-    <div class="panel"><h3>Past incidents</h3>${incHtml}</div>
+    <div class="panel"><h3>Past incidents</h3>${incidentsBlock((d.incidents||[]).map(i=>({service:d.label,...i})))}</div>
     <div class="dsub" style="margin:0">${cert}checked ${relTime(d.last_checked)}</div>`;
-  $('foot-upd').textContent='Updated '+clock();
+  $('foot-upd').textContent='updated '+clock();
 }
 
 function route(){ const m=location.pathname.match(/\/public\/([^/]+)\/?$/); if(m) renderDetail(decodeURIComponent(m[1])); else renderIndex(); }


### PR DESCRIPTION
## Why

The first status-page pass (#213) was on-token but read generic/off-brand. This rebuilds it as a **proper status page** — the information architecture of a status.claude.com-style page — wearing the dashboard's own identity.

## What changed

**Design / identity**
- **Dark-first** (the app's identity), with the **radar `logo.svg`** as the brand mark — no emoji chrome — and the app's SVG icon family for the theme toggle. Exact GitHub-dark tokens, amber accent, mono numerals.

**Status-page architecture**
- Each monitored service is a **component with its own 90-day daily uptime bar**, an *Operational / Down* label, and a `90 days ago · NN% uptime · Today` axis — the signature status-page row.
- A **status legend** (Operational / Degraded / Down / No data) and a **date-grouped "Past incidents" timeline** aggregated across services.
- The system overview (GPU/Host/Containers/Services) stays as a compact group up top.
- Click any component for its **full per-service page**: 24h/7d/30d/90d tiles, the 90-day bar, a response-time chart, and that service's incidents.

**Backend**
- Each public monitor now carries `daily` buckets + `uptime90` + `incidents` (one 90-day query per component); `/api/public-status` adds an aggregated `incidents` feed. Still read-only and **host-only** — never the raw target or credentials.

## Verification
- Ran locally with seeded 90-day history (incl. incidents + a live-down check) and screenshotted both views in dark — the overview shows per-service 90-day bars + legend + the incident timeline; the detail page shows the tiles, 90-day bar, response chart and incidents. Both read as the same product as the dashboard.
- `tests/test_public_status.py` + `tests/test_uptime.py`: **72 passed**. `public.html` JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)