### PR TITLE
fix(overview): hero engine GPU gauge reflects VRAM saturation (0.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ release notes.
 
 ## [Unreleased]
 
+## [0.22.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.22.1) — 2026-06-27 · **Hero engine GPU gauge tells the truth about a full card**
+*A small fix so the Overview's "Lab's Engine" GPU gauge stops reading calm when the card is actually maxed.*
+
+**Fixed**
+- **Overview engine GPU gauge now reflects VRAM saturation, not just compute util.** A GPU with models loaded but no inference running (low util, ~full VRAM) was showing a calm low number on the hero engine gauge while the GPU tab and the Overview status tile both correctly flagged it **crit** at ~94% VRAM. The gauge now reads the *binding constraint* — `max(util%, VRAM%)` — so a memory-pinned card lights up to match the rest of the UI, with both VRAM and `% util` shown in the line beneath.
+
 ## [0.22.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.22.0) — 2026-06-27 · **A real status page — public lab health, plus a page per service**
 *The throwaway `/public` page is reborn in the app's own skin: overall lab health, a live list of the services you watch, and a dedicated status page for each one — uptime over 24h/7d/30d/90d, incident history and response times. Alerts also gain email, Slack and generic-webhook channels, services get brand logos, and the AI Models tab now lists every model pulled to disk.*
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.22.0"
+VERSION      = "0.22.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -5493,11 +5493,17 @@ function mcPaintTri($){
   const pg=$('mc-pct-gpu');
   if(gpu && gpu.available){
     const util=Math.round(gpu.util||0), mt=gpu.mem_total||0, mu=gpu.mem_used||0, tp=Math.round(gpu.temp||0), pw=Math.round(gpu.power||0);
+    const vramPct=mt?Math.round(mu/mt*100):0;
+    // The GPU is "maxed" if EITHER compute (util) OR memory (VRAM) is saturated.
+    // A VRAM-pinned-but-idle card (models loaded, no inference) reads as low util
+    // yet is effectively full — show the binding constraint so the hero matches the
+    // crit VRAM tile + GPU tab instead of contradicting them with a calm util %.
+    const sat=Math.max(util, vramPct);
     if(pg) pg.style.visibility='visible';
-    mcCountUp($('mc-g-gpu'), util, 900, 0);
-    mcSetTriArc('mc-arc-gpu', util, mcTriColor(util,'var(--accent)'));
-    // VRAM (+ temp) on line one; live power draw on its own line below it.
-    $('mc-sub-gpu').innerHTML = esc((mt?(fmtMB(mu)+' / '+fmtMB(mt)):'GPU') + (tp?(' · '+tp+'°C'):''))
+    mcCountUp($('mc-g-gpu'), sat, 900, 0);
+    mcSetTriArc('mc-arc-gpu', sat, mcTriColor(sat,'var(--accent)'));
+    // VRAM + util (+ temp) on line one; live power draw on its own line below it.
+    $('mc-sub-gpu').innerHTML = esc((mt?(fmtMB(mu)+' / '+fmtMB(mt)):'GPU') + ' · '+util+'% util' + (tp?(' · '+tp+'°C'):''))
       + (pw?`<span class="mc-tg-pwr">${pw} W</span>`:'');
   } else {
     $('mc-g-gpu').textContent='—'; if(pg) pg.style.visibility='hidden';

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -5498,7 +5498,7 @@ function mcPaintTri($){
     // A VRAM-pinned-but-idle card (models loaded, no inference) reads as low util
     // yet is effectively full — show the binding constraint so the hero matches the
     // crit VRAM tile + GPU tab instead of contradicting them with a calm util %.
-    const sat=Math.max(util, vramPct);
+    const sat=Math.min(100, Math.max(util, vramPct));
     if(pg) pg.style.visibility='visible';
     mcCountUp($('mc-g-gpu'), sat, 900, 0);
     mcSetTriArc('mc-arc-gpu', sat, mcTriColor(sat,'var(--accent)'));


### PR DESCRIPTION
## What
The Overview **"Lab's Engine"** GPU gauge was driven purely by `gpu.util`. A GPU with models loaded but idle (low compute util, ~full VRAM) showed a calm low number on the hero gauge — while the **GPU tab** ("94% full") and the **Overview status tile** ("94% VRAM", crit) both correctly flagged it as effectively maxed.

Caught live on ardi:9800: util **8%**, VRAM **23133/24576 MB ≈ 94%**, status **crit** — hero gauge read **8**.

## Fix
Drive the engine GPU gauge by the binding constraint **`max(util%, VRAM%)`** so a memory-pinned card lights up to match the rest of the UI. Both VRAM and `% util` now appear in the subline so neither metric is lost. A genuinely compute-busy card still reads its util as before.

`static/dashboard.html` `mcApplyEngine()` only. Version bump 0.22.0 → 0.22.1 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)