### PR TITLE
fix: Windows Docker check misreports 'not installed' on daemon errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -3446,6 +3446,17 @@ def _detect_os(user, host, port):
     info["label"] = pretty if family == "windows" else (f"{pretty}" + (f" · {init}" if init else ""))
     return info
 
+def _remedy_docker_windows_daemon():
+    """Docker CLI is present on a Windows host but the daemon didn't answer
+    cleanly — usually Docker Desktop's engine needs a restart (e.g. after an
+    auto-update bumps the CLI's API version ahead of the running engine)."""
+    return {"where": "on the remote (Windows)",
+            "cmd": "# Docker Desktop's engine isn't answering API calls cleanly.\n"
+                   "# Restart it from the system tray (Docker Desktop icon > Restart),\n"
+                   "# or from an elevated PowerShell:\n"
+                   "Restart-Service com.docker.service -Force\n"
+                   "# Then confirm `docker ps` works locally before you re-test here."}
+
 def _remedy_docker_group(user, os_info):
     """Per-OS instructions for joining the docker group / fixing socket perms."""
     fam = (os_info.get("family") or "linux")
@@ -3662,16 +3673,34 @@ def probe_host(name):
         else:
             checks.append({"id": "proc", "label": "Host readable (WMI)", "status": "warn",
                            "detail": (err or "no reply from PowerShell")[:160]})
-        # Docker on Windows: only if the CLI is on PATH (Docker Desktop, or a WSL
-        # engine exposed to Windows). Honest "info" otherwise.
+        # Docker on Windows: first check the CLI is even on PATH — only THEN run
+        # it. Previously we ran `docker version` straight away and treated any
+        # failure (missing CLI *or* a daemon-side error) as "not installed".
+        # But Docker Desktop's client/engine API-version handshake can itself
+        # fail with a message like "request returned 500 Internal Server Error
+        # ... check if the server supports the requested API version" — that
+        # text contains the word "error", so it used to get misclassified as
+        # "CLI not on PATH" even though Docker is very much installed, just
+        # unhealthy. Split "CLI absent" (info) from "CLI present but the
+        # daemon didn't respond cleanly" (warn) like the Linux path already
+        # does for permission-denied vs. not-installed.
         _, out, err, _ = _ssh_with_stdin(user, host, port, _WIN_PS_CMD,
-            b"try{(docker version --format '{{.Server.Version}}')}catch{''}", timeout=12)
-        dv = (out or "").strip().splitlines()[-1].strip() if (out or "").strip() else ""
-        if dv and "." in dv and "error" not in dv.lower() and "cannot" not in dv.lower():
-            checks.append({"id": "docker", "label": "Docker", "status": "ok", "detail": f"server v{dv}"})
+            b"if(-not (Get-Command docker -EA SilentlyContinue)){Write-Output 'DOCKER_ABSENT'}else{"
+            b"$v=(docker version --format '{{.Server.Version}}' 2>&1);"
+            b"if($LASTEXITCODE -eq 0){Write-Output \"DOCKER_OK:$v\"}else{Write-Output \"DOCKER_ERR:$v\"}}",
+            timeout=12)
+        line = (out or "").strip().splitlines()[-1].strip() if (out or "").strip() else ""
+        if line.startswith("DOCKER_OK:") and "." in line:
+            checks.append({"id": "docker", "label": "Docker", "status": "ok",
+                           "detail": f"server v{line.split(':', 1)[1].strip()}"})
+        elif line.startswith("DOCKER_ERR:"):
+            checks.append({"id": "docker", "label": "Docker", "status": "warn",
+                           "detail": f"Docker is installed on {name} but the daemon didn't respond cleanly: "
+                                     f"{line.split(':', 1)[1].strip()[:160]}",
+                           "remedy": _remedy_docker_windows_daemon()})
         else:
             checks.append({"id": "docker", "label": "Docker", "status": "info",
-                           "detail": "Docker CLI not on PATH — container panel hidden for this host"})
+                           "detail": "Docker CLI not found on PATH — container panel hidden for this host"})
         # systemd D-Bus analogue: Windows services are always queryable.
         checks.append({"id": "dbus", "label": "Windows services", "status": "ok",
                        "detail": "Get-Service available"})

--- a/tests/test_win_docker_probe.py
+++ b/tests/test_win_docker_probe.py
@@ -1,0 +1,81 @@
+"""Unit tests for the Windows-host Docker capability check in probe_host().
+
+Regression coverage for a real bug: a Docker Desktop client/engine API-version
+mismatch (a genuine, live "daemon is unhealthy" condition) prints an error
+message containing the word "error" — which used to get misclassified as
+"Docker CLI not on PATH" (status: info, "not installed") instead of "CLI
+present, daemon not responding" (status: warn). All SSH calls are mocked —
+no real network in CI."""
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+def _add_host(name="work", ssh_target="user@1.2.3.4"):
+    with app.LOCK:
+        app.DB.execute("DELETE FROM hosts WHERE name=?", (name,))
+        app.DB.execute("INSERT INTO hosts(name, ssh_target, added_at) VALUES(?,?,0)",
+                       (name, ssh_target))
+        app.DB.commit()
+
+
+class TestWindowsDockerProbe(unittest.TestCase):
+    def setUp(self):
+        _add_host()
+
+    def tearDown(self):
+        with app.LOCK:
+            app.DB.execute("DELETE FROM hosts WHERE name=?", ("work",))
+            app.DB.commit()
+
+    def _run_probe(self, docker_stdout):
+        """Drive probe_host() down the Windows branch with a canned response
+        for the Docker capability check specifically."""
+        with patch.object(app, "_tcp_probe", return_value=(True, None)), \
+             patch.object(app, "_ensure_ssh_keypair"), \
+             patch.object(app, "_detect_os", return_value={"family": "windows", "label": "Windows 11"}), \
+             patch.object(app, "_ssh", return_value=(0, "ok", "", 5)), \
+             patch.object(app, "_ssh_with_stdin") as m:
+            def side_effect(user, host, port, cmd, stdin_bytes, timeout=60):
+                if b"docker" in stdin_bytes:
+                    return (0, docker_stdout, "", 5)
+                if b"LastBootUpTime" in stdin_bytes:
+                    return (0, "up=123", "", 5)
+                if b"nvidia-smi" in stdin_bytes:
+                    return (0, "missing", "", 5)
+                return (0, "", "", 5)
+            m.side_effect = side_effect
+            return app.probe_host("work")
+
+    def _docker_check(self, result):
+        return next(c for c in result["checks"] if c["id"] == "docker")
+
+    def test_daemon_error_is_warn_not_absent(self):
+        """The exact real-world failure: CLI present, daemon returns an API
+        version-mismatch error containing the word 'error'. Must NOT be
+        reported as 'Docker CLI not on PATH'."""
+        dk = self._docker_check(self._run_probe(
+            "DOCKER_ERR:request returned 500 Internal Server Error for API route "
+            "and version http://%2F%2F.%2Fpipe%2FdockerDesktopLinuxEngine/v1.54/version, "
+            "check if the server supports the requested API version"))
+        self.assertEqual(dk["status"], "warn")
+        self.assertIn("daemon didn't respond cleanly", dk["detail"])
+        self.assertIn("remedy", dk)
+
+    def test_cli_absent_is_info(self):
+        dk = self._docker_check(self._run_probe("DOCKER_ABSENT"))
+        self.assertEqual(dk["status"], "info")
+        self.assertIn("not found on PATH", dk["detail"])
+
+    def test_cli_ok_reports_server_version(self):
+        dk = self._docker_check(self._run_probe("DOCKER_OK:27.3.1"))
+        self.assertEqual(dk["status"], "ok")
+        self.assertIn("27.3.1", dk["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

On a Windows host with Docker Desktop actually installed and running, the Hosts > Test flow reported:

> **Docker is not installed on Work**
> The Containers tab needs the Docker daemon. Install Docker on this host (or check that the daemon is running) and re-Test.

## Root cause

`probe_host()`'s Windows branch ran `docker version --format '{{.Server.Version}}'` and classified the result as "Docker CLI not on PATH" whenever the output didn't look like a clean version string — including when it contained the word "error". But a genuine Docker Desktop client/engine API-version mismatch fails with:

```
request returned 500 Internal Server Error for API route and version http://.../v1.54/version, check if the server supports the requested API version
```

...which itself contains "error", so a host where Docker is installed (just having an engine hiccup) got told it wasn't installed at all. Reproduced live on a Windows machine with a stuck Docker Desktop engine — confirmed `docker ps`/`docker version` fail identically outside of homelab-monitor too, but the CLI and install are both present.

## Fix

Split the check into two steps, mirroring how the Linux path already separates "permission denied" from "not installed":

1. `Get-Command docker` first — if that's absent, it's genuinely not installed/on PATH (`status: info`, unchanged wording).
2. If present, run `docker version --format ...` and classify by exit code, not by scanning the text for "error"/"cannot". A non-zero exit (daemon not responding, API mismatch, etc.) now reports `status: warn` — "Docker is installed on `<host>` but the daemon didn't respond cleanly" — with a remedy pointing at restarting Docker Desktop's engine service. This reuses the existing frontend "warn" rendering (dashboard.html already has a distinct message for that state), so no UI changes were needed.

## Tests

Added `tests/test_win_docker_probe.py` — mocks `_ssh_with_stdin`/`_ssh`/`_detect_os` to drive `probe_host()` down the Windows branch for three cases: CLI absent, CLI present + daemon error (the actual regression, using the real 500/API-version error text), and CLI present + healthy. All three assert the exact status/detail classification.

Full suite: 289 passed, 2 pre-existing failures unrelated to this change (Windows-only tempfile-cleanup quirk in `test_backup.py`, and a Linux-only `/proc/diskstats` test in `test_disk_io.py` that doesn't run on a Windows dev box) — confirmed identical on `next` before this change.