### PR TITLE
feat: icons for the sidebar nav

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -585,6 +585,9 @@ body{background:var(--canvas)}
 .nrow{display:flex;align-items:center;gap:9px;width:100%;border:0;background:none;color:var(--mut);font:inherit;font-size:13px;text-align:left;padding:8px 10px;border-radius:6px;cursor:pointer}
 .nrow:hover{background:var(--hover);color:var(--tx)}
 .nrow.on{background:var(--sel);color:var(--tx);font-weight:600}
+.nrow .hic{width:16px;height:16px;opacity:.75}
+.nrow:hover .hic,.nrow.on .hic{opacity:1}
+.nrow.on .hic{color:var(--accent)}
 .nrow .tdot{width:7px;height:7px;border-radius:2px;margin-left:auto}
 .foot{border-top:1px solid var(--bd);padding:10px;display:flex;flex-direction:column;gap:9px}
 .foot .ghstar{align-self:flex-start}
@@ -2882,7 +2885,29 @@ function fmtLabels(L){ if(!L.length)return[]; const md=(L[L.length-1]-L[0])>2*86
 // ── Tab navigation ────────────────────────────────────────────────────────────
 // rev6: nav rows live in a grouped sidebar (Monitoring / AI / Settings), always
 // visible — no gear drawer. tdot = per-section attention square (set in renderHealth).
-const tabBtn = t => `<button class="nrow" data-t="${t.id}"><span>${I18N.t('nav.'+t.id, t.label)}</span><span class="tdot" id="ndot-${t.id}" style="display:none"></span></button>`;
+// Nav icons reuse the exact SVG each tab already draws in its own page header
+// (ICONS, keyed by the emoji that used to prefix it) so the sidebar row visually
+// matches what you land on. The four tabs with no existing header icon get a
+// small dedicated glyph in the same stroke family.
+const NAV_ICON = {
+  overview:    '<path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/>',
+  gpu:         ICONS['🎮'],
+  costs:       ICONS['💰'],
+  containers:  ICONS['📦'],
+  services:    ICONS['🧩'],
+  host:        ICONS['🖥'],
+  disks:       '<line x1="22" x2="2" y1="12" y2="12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" x2="6.01" y1="16" y2="16"/><line x1="10" x2="10.01" y1="16" y2="16"/>',
+  diskio:      '<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/>',
+  network:     ICONS['📶'],
+  security:    ICONS['🛡'],
+  uptime:      ICONS['🛰'],
+  models:      ICONS['🧠'],
+  experiments: ICONS['🧪'],
+  hosts:       ICONS['🌐'],
+  alerts:      '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
+  backup:      ICONS['💾'],
+};
+const tabBtn = t => `<button class="nrow" data-t="${t.id}">${svgIc(NAV_ICON[t.id]||'')}<span>${I18N.t('nav.'+t.id, t.label)}</span><span class="tdot" id="ndot-${t.id}" style="display:none"></span></button>`;
 const isSettingsTab = id => !!(TABS.find(t=>t.id===id)||{}).settings;
 function buildNav(){
   const nl = document.getElementById('navlist'); if(!nl) return;


### PR DESCRIPTION
The left nav was plain text, unlike every content page which already carries an SVG icon in its own h2 header. Added one icon per nav row, reusing the exact SVG each tab already draws in its header (same `ICONS` registry, keyed by the emoji that used to prefix it) so the row visually matches what you land on. The four tabs with no existing header icon (Overview, Disks, Disk I/O, Settings) get a small dedicated glyph in the same stroke family: gauge, hard-drive, activity pulse, and gear.

No backend changes. Full suite: 286 passed, 2 pre-existing failures unrelated to this change (confirmed pre-existing on unpatched `next`).
