### PR TITLE
feat: configurable data retention + misc hardening fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,8 @@ VERSION      = "0.24.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))
-RETENTION    = int(os.environ.get("RETENTION_DAYS", "180")) * 86400
+_RETENTION_DAYS_DEFAULT = int(os.environ.get("RETENTION_DAYS", "180"))
+RETENTION    = _RETENTION_DAYS_DEFAULT * 86400
 _DISK_IO_RETENTION = 7 * 86400   # per-device disk-I/O history: dense, 7-day ring
 _PROC_IO_RETENTION = 72 * 3600   # per-process I/O ring: short, spike-attribution only
 DOCKER_SOCK  = os.environ.get("DOCKER_SOCK", "/var/run/docker.sock")
@@ -107,13 +108,32 @@ app.register_blueprint(_hosts_api_bp)
 app.register_blueprint(_integrations_bp)
 
 # ── Prometheus gauges (defined once at module level) ──────────────────────────
+_GAUGES: dict = {}
 def _make_gauge(name, doc, labels=None):
-    """Create a Gauge, reusing the existing one if already registered (safe for multi-import)."""
+    """Create a Gauge once; return the cached instance on re-import (safe for multi-import)."""
+    if name in _GAUGES:
+        return _GAUGES[name]
     try:
-        return Gauge(name, doc, labels or [])
-    except ValueError:
-        from prometheus_client import REGISTRY
-        return REGISTRY._names_to_collectors.get(name) or REGISTRY._names_to_collectors.get(name + "_total")
+        g = Gauge(name, doc, labels or [])
+    except (ValueError, AttributeError):
+        # ValueError  — already in the global REGISTRY (Flask debug-reloader or double-import).
+        # AttributeError — prometheus_client internals renamed (version mismatch).
+        # Recover by scanning the registry; _names_to_collectors is private so we guard
+        # the whole block and raise loudly if we still can't find it — better than
+        # caching None and getting AttributeError later on .set() / .clear().
+        try:
+            from prometheus_client import REGISTRY
+            g = next((c for c in REGISTRY._names_to_collectors.values()
+                      if getattr(c, "_name", None) == name), None)
+        except Exception:
+            g = None
+        if g is None:
+            raise RuntimeError(
+                f"prometheus_client: could not recover gauge {name!r} from REGISTRY "
+                "after duplicate-registration — check for double-import or version mismatch"
+            )
+    _GAUGES[name] = g
+    return g
 
 if _PROM_OK:
     _G = {
@@ -1455,7 +1475,8 @@ _docker_enrich = {"data": {}, "at": 0}
 # spinning disk can take minutes; once the kernel has cached the metadata the
 # same scan is seconds, so we allow a generous per-mount timeout and keep the
 # last known value when a scan overruns it.
-_DOCKER_DISK_TTL = 1800
+_DOCKER_DISK_TTL   = 1800
+_DOCKER_POLICY_TTL = 1800  # restart policies change rarely; no need to inspect every 30 s
 _docker_disk = {"data": {}, "at": 0, "busy": False}
 
 def _docker_status(state, status):
@@ -1696,7 +1717,7 @@ def collect_docker():
     _maybe_refresh_docker_disk()   # background; first pass leaves disk_bytes None until it lands
     # Restart policy only matters to the (opt-in) controls UI — skip the extra
     # inspect round-trip entirely when controls are off.
-    if ENABLE_CONTROLS and time.time() - _docker_policy["at"] > _DOCKER_ENRICH_TTL:
+    if ENABLE_CONTROLS and time.time() - _docker_policy["at"] > _DOCKER_POLICY_TTL:
         _docker_policy["data"] = _refresh_docker_policies([c["id"] for c in items])
         _docker_policy["at"] = time.time()
     # Per-container GPU VRAM, attributed by the GPU sampler (nvidia-smi
@@ -1704,7 +1725,21 @@ def collect_docker():
     # keyed by service name (== container name for container-owned PIDs); host /
     # unattributed PIDs use "host:"/"pid:" keys that never match a container.
     vram_mb = {p.get("service"): p.get("mem") for p in (LATEST.get("procs") or [])}
-    self_id = (os.environ.get("HOSTNAME") or "")[:12]
+    # Prefer /proc/self/cgroup (reliable even when docker-compose overrides hostname:).
+    # cgroups v1 encodes the full 64-char container ID in the cgroup path; v2 doesn't,
+    # so fall back to the HOSTNAME env var (still the container short-ID by default).
+    self_id = ""
+    try:
+        with open("/proc/self/cgroup") as _f:
+            for _ln in _f:
+                _part = _ln.strip().split("/")[-1]
+                if len(_part) == 64 and all(c in "0123456789abcdef" for c in _part):
+                    self_id = _part[:12]
+                    break
+    except OSError:
+        pass
+    if not self_id:
+        self_id = (os.environ.get("HOSTNAME") or "")[:12]
     for c in items:
         e = _docker_enrich["data"].get(c["id"]) or {}
         c["mem_bytes"]  = e.get("mem_bytes")
@@ -3716,6 +3751,7 @@ def run_on_host_windows(name, ps_script):
 _ensure_ssh_keypair()
 
 SETTING_DEFAULTS = {
+    "retention_days":     str(_RETENTION_DAYS_DEFAULT),  # history retention in days
     "alerts_enabled":     "0",       # "0" / "1"
     "discord_webhook_url": "",
     "ntfy_topic":          "",
@@ -3845,6 +3881,30 @@ def save_settings(updates):
         DB.executemany("INSERT INTO settings(key,value) VALUES(?,?) "
                        "ON CONFLICT(key) DO UPDATE SET value=excluded.value", safe)
         DB.commit()
+
+def get_retention_secs():
+    """Return the effective retention window in seconds, read live from settings."""
+    try:
+        days = int(get_settings().get("retention_days") or _RETENTION_DAYS_DEFAULT)
+        days = max(1, min(days, 3650))
+    except (ValueError, TypeError):
+        days = _RETENTION_DAYS_DEFAULT
+    return days * 86400
+
+def _validate_retention_settings(updates):
+    """Return an error string if retention_days is invalid, else None."""
+    if "retention_days" not in updates:
+        return None
+    val = (updates["retention_days"] or "").strip()
+    if not val:
+        return None
+    try:
+        days = int(val)
+    except ValueError:
+        return "Retention days must be a whole number."
+    if days < 1 or days > 3650:
+        return "Retention days must be between 1 and 3650."
+    return None
 
 # ── Uptime checks: HTTP/TCP endpoint monitors ──────────────────────────────
 # User-defined HTTP/TCP endpoint monitors, probed from inside the container on a

--- a/backend/api/hosts_api.py
+++ b/backend/api/hosts_api.py
@@ -122,6 +122,8 @@ def api_hosts_run(name):
     on the remote, NEVER stored in the _app.DB, NEVER written to logs, NEVER
     in any process's argv. Don't pass arbitrary cmd from untrusted users —
     the API is reachable to anyone on the LAN who can hit the dashboard."""
+    if not _app.ENABLE_CONTROLS:
+        return jsonify({"ok": False, "error": "Controls are disabled (ENABLE_CONTROLS=0)."}), 403
     body = request.get_json(silent=True) or {}
     cmd = (body.get("cmd") or "").strip()
     sudo_password = body.get("sudo_password") or None

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -479,7 +479,7 @@ def api_settings():
         # to clear without revealing the current value.
         updates = {k: body[k] for k in body if k in _app.SETTING_DEFAULTS}
         err = (_app._validate_url_settings(updates) or _app._validate_email_settings(updates)
-               or _app._validate_brief_settings(updates))
+               or _app._validate_brief_settings(updates) or _app._validate_retention_settings(updates))
         if err:
             return jsonify({"ok": False, "error": err}), 400
         _app.save_settings(updates)

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -246,6 +246,9 @@ def sample_once():
         return
     from backend.db.repos import system as system_repo
     from backend.db.repos import experiments as exp_repo
+    # Read retention before acquiring LOCK — get_settings() also takes LOCK
+    # (non-reentrant), so calling it inside the block would deadlock the thread.
+    _retention = _app.get_retention_secs() if ts % 360 < _app.INTERVAL else None
     with _app.LOCK:
         # When the GPU is absent/failed, store NULL for the GPU columns (not 0) so
         # history charts skip the gap via AVG() instead of showing a fake 0 dip;
@@ -304,9 +307,9 @@ def sample_once():
                 if _pio_rows:
                     _app.DB.executemany("INSERT INTO proc_io_samples(ts,pid,comm,read_bps,write_bps) "
                                    "VALUES(?,?,?,?,?)", _pio_rows)
-        if ts % 360 < _app.INTERVAL:
+        if _retention is not None:
             for t in ("samples", "proc", "models", "edges", "events", "gpu_samples", "net_samples", "power_proc"):
-                _app.DB.executemany(f"DELETE FROM {t} WHERE ts<?", [(ts - _app.RETENTION,)])
+                _app.DB.executemany(f"DELETE FROM {t} WHERE ts<?", [(ts - _retention,)])
             _app.DB.executemany("DELETE FROM disk_io_samples WHERE ts<?", [(ts - _app._DISK_IO_RETENTION,)])
             _app.DB.executemany("DELETE FROM proc_io_samples WHERE ts<?", [(ts - _app._PROC_IO_RETENTION,)])
         if ts % 60 < _app.INTERVAL:   # stale-run janitor: a crashed/disconnected push run -> killed

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1847,6 +1847,7 @@ body.mc-customizing .mc-board .mc-widget{ border-radius:12px }
       <button type="button" class="subtab on" data-sp="alerts" data-i18n="set.tab_alerts">🔔 Alerts</button>
       <button type="button" class="subtab"    data-sp="costs" data-i18n="set.tab_costs">💰 Costs</button>
       <button type="button" class="subtab"    data-sp="integrations" data-i18n="set.tab_integrations">🧪 Integrations</button>
+      <button type="button" class="subtab"    data-sp="general" data-i18n="set.tab_general" data-i18n-def="⚙️ General">⚙️ General</button>
     </div>
 
     <!-- ── Alerts sub-page ── -->
@@ -2190,6 +2191,22 @@ with homelab.run("my-finetune", params={"lr":2e-4}) as r:
       </div>
       <div id="intg_status" class="cap" style="margin-top:6px"></div>
     </div><!-- /set-pane-integrations -->
+
+    <!-- ── General sub-page ── -->
+    <div id="set-pane-general" hidden>
+      <p class="cap" style="margin:2px 0 12px" data-i18n-html="general.intro" data-i18n-def="General system settings. Changes take effect immediately — no restart required.">General system settings. Changes take effect immediately — no restart required.</p>
+      <div id="general-status" class="ins info" style="display:none"></div>
+      <div style="display:grid;grid-template-columns:1fr;gap:14px;max-width:680px">
+        <div>
+          <div class="flabel" data-i18n="general.retention_label" data-i18n-def="Data retention (days)">Data retention (days)</div>
+          <input type="number" id="al_retention_days" min="1" max="3650" step="1" class="field" style="max-width:160px">
+          <p class="cap" style="margin-top:4px" data-i18n-html="general.retention_cap" data-i18n-def="How many days of metric history to keep. Older rows are pruned every ~6 minutes. Default: 180.">How many days of metric history to keep. Older rows are pruned every ~6 minutes. Default: 180.</p>
+        </div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
+          <button class="rb on" id="al_save_general" data-i18n="btn.save">Save</button>
+        </div>
+      </div>
+    </div><!-- /set-pane-general -->
   </div>
 </section>
 
@@ -3926,6 +3943,9 @@ function renderHealth(){
   document.getElementById('cttbl').onchange = e => {
     const sel = e.target.closest('.ct-policy'); if(!sel) return;
     const tr = sel.closest('.ctrow');
+    if(!confirm(`Change restart policy for "${tr.dataset.ct}" to "${sel.value}"?`)){
+      loadHealth(); return; // revert the select to server state
+    }
     setContainerRestartPolicy(tr.dataset.ct, sel.value);
   };
 
@@ -4544,6 +4564,7 @@ async function loadAlerts(){
   document.getElementById('al_email_user').value  = s.email_username||'';
   document.getElementById('al_minlevel').value    = s.alert_min_level||'warning';
   document.getElementById('al_disk').value        = s.disk_alert_pct||'90';
+  document.getElementById('al_retention_days').value = s.retention_days||'180';
   document.getElementById('al_kwh').value         = s.kwh_price||'';
   document.getElementById('al_currency').value    = s.currency||'$';
   document.getElementById('al_kwh_night').value   = s.kwh_price_night||'';
@@ -4688,7 +4709,8 @@ function collectSettingsBody(){
     email_to:         document.getElementById('al_email_to').value.trim(),
     email_username:   document.getElementById('al_email_user').value.trim(),
     alert_min_level:  document.getElementById('al_minlevel').value,
-    disk_alert_pct:   String(parseInt(document.getElementById('al_disk').value||'90',10)||90),
+    disk_alert_pct:   (v=>{const n=parseInt(v,10);return String(isNaN(n)?90:Math.max(0,Math.min(99,n)));})(document.getElementById('al_disk').value),
+    retention_days:   (v=>{const n=parseInt(v,10);return v.trim()===''?'180':String(isNaN(n)?180:Math.max(1,n));})(document.getElementById('al_retention_days').value),
     kwh_price:        document.getElementById('al_kwh').value.trim(),
     currency:         document.getElementById('al_currency').value.trim()||'$',
     tariff_mode:      TARIFF_DUAL ? 'dual' : 'single',
@@ -4773,7 +4795,8 @@ const AUTOSAVE_IDS=['al_enabled','al_ntfy_topic','al_ntfy_server','al_telegram_c
   'al_telegram_token','al_email_host','al_email_port','al_email_tls','al_email_from','al_email_to',
   'al_email_user','al_email_pass','al_discord','al_slack','al_webhook','al_minlevel','al_disk',
   'al_kwh','al_currency','al_kwh_night','al_night_start','al_night_end','al_idle_w','al_mlflow_uri',
-  'al_mlflow_token','al_country','al_brief_enabled','al_brief_time','al_brief_channel','al_brief_theme'];
+  'al_mlflow_token','al_country','al_brief_enabled','al_brief_time','al_brief_channel','al_brief_theme',
+  'al_retention_days'];
 function wireAutoSave(){
   AUTOSAVE_IDS.forEach(id=>{ const el=document.getElementById(id); if(el) el.addEventListener('change', scheduleAutoSave); });
   // Tariff mode is toggled by buttons (no change event) — autosave on those too.
@@ -7549,6 +7572,8 @@ document.getElementById('al_brief_test').onclick = briefTest;
 wireUptime();
 const al_save_costs = document.getElementById('al_save_costs');
 if(al_save_costs) al_save_costs.onclick = saveAlerts;   // both panes persist all settings
+const al_save_general = document.getElementById('al_save_general');
+if(al_save_general) al_save_general.onclick = saveAlerts;
 wireAutoSave();   // settings also persist on field focus-out (no Save-button hunt)
 document.getElementById('al_mode_single').onclick = () => setTariffMode(false);
 document.getElementById('al_mode_dual').onclick   = () => setTariffMode(true);

--- a/tests/snapshots/api_settings_get.json
+++ b/tests/snapshots/api_settings_get.json
@@ -26,6 +26,7 @@
     "night_start": "22:00",
     "ntfy_server": "https://ntfy.sh",
     "ntfy_topic": "",
+    "retention_days": "180",
     "slack_webhook_url_set": false,
     "system_idle_watts": "",
     "tariff_mode": "single",

--- a/tests/snapshots/api_settings_post.json
+++ b/tests/snapshots/api_settings_post.json
@@ -26,6 +26,7 @@
     "night_start": "22:00",
     "ntfy_server": "https://ntfy.sh",
     "ntfy_topic": "",
+    "retention_days": "180",
     "slack_webhook_url_set": false,
     "system_idle_watts": "",
     "tariff_mode": "single",


### PR DESCRIPTION
## Summary

- Add **General** settings tab with a `retention_days` field (1–3650 days); value is read live each pruning cycle so changes apply within ~6 minutes without a restart.
- Fix Prometheus gauge double-registration by caching gauges in a module-level `_GAUGES` dict (prevents `ValueError` on Flask debug-reloader / double-import).
- Fix docker policy refresh using the wrong TTL constant (`_DOCKER_ENRICH_TTL` → `_DOCKER_POLICY_TTL`).
- Improve container self-ID detection via `/proc/self/cgroup` (cgroups v1 full 64-char ID); falls back to `HOSTNAME` env var for v2 / non-container environments.
- Guard `POST /api/hosts/<name>/run` behind `ENABLE_CONTROLS` check (returns 403 when controls are disabled).
- Add a confirm dialog before changing a container's restart policy.
- Read retention window outside `LOCK` in `sample_once` to prevent deadlock (`get_settings` is also non-reentrant on `LOCK`).

## Test plan

- [ ] Open Settings → General, change retention days, verify value persists after save
- [ ] Confirm pruning respects the new value after ~6 minutes
- [ ] Restart Flask with `--debug` — verify no `ValueError` from Prometheus on reload
- [ ] With `ENABLE_CONTROLS=0`, confirm `POST /api/hosts/.../run` returns 403
- [ ] Change a container restart policy in the Health tab — confirm dialog appears and reverts on cancel
- [ ] Verify docker policy refresh no longer uses `_DOCKER_ENRICH_TTL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)