### PR TITLE
fix(gpu): report GTT, not the 512 MB VRAM carve-out, on unified-memory APUs

### DIFF
--- a/app.py
+++ b/app.py
@@ -4795,8 +4795,21 @@ def amd_gpus(drm_root=None):
                     continue
         except OSError:
             continue
-        total  = _amd_read_int(os.path.join(dev, "mem_info_vram_total"))   # bytes
-        used   = _amd_read_int(os.path.join(dev, "mem_info_vram_used"))    # bytes
+        vram_total = _amd_read_int(os.path.join(dev, "mem_info_vram_total"))  # bytes
+        vram_used  = _amd_read_int(os.path.join(dev, "mem_info_vram_used"))   # bytes
+        # APU / unified-memory iGPU (e.g. Ryzen AI Max / Strix Halo): the dedicated
+        # VRAM is a tiny BIOS carve-out (<= ~1 GiB) while the real working set — where
+        # models actually load — lives in GTT (system RAM mapped to the GPU, up to
+        # nearly all system RAM). Reporting the 512 MB carve-out makes the dashboard
+        # read "29% full / VRAM ran low" on an idle 128 GB box. When this looks like an
+        # APU (tiny VRAM + large GTT), report GTT instead so residency + pressure
+        # reflect reality. Discrete cards (large VRAM) are unaffected.
+        gtt_total = _amd_read_int(os.path.join(dev, "mem_info_gtt_total"))    # bytes
+        gtt_used  = _amd_read_int(os.path.join(dev, "mem_info_gtt_used"))     # bytes
+        if vram_total and gtt_total and vram_total <= (1 << 30):  # VRAM <= 1 GiB -> iGPU
+            total, used = gtt_total, (gtt_used or 0)
+        else:
+            total, used = vram_total, vram_used
         busy   = _amd_read_int(os.path.join(dev, "gpu_busy_percent"))      # %
         temp_m = _amd_hwmon(dev, "temp1_input")     # millidegrees C
         powr_u = _amd_hwmon(dev, "power1_average")  # microwatts

--- a/probe.py
+++ b/probe.py
@@ -435,8 +435,21 @@ def _amd_gpu_sysfs(drm_root="/sys/class/drm"):
                     continue
         except OSError:
             continue
-        total = _int(os.path.join(dev, "mem_info_vram_total"))   # bytes
-        used  = _int(os.path.join(dev, "mem_info_vram_used"))    # bytes
+        vram_total = _int(os.path.join(dev, "mem_info_vram_total"))  # bytes
+        vram_used  = _int(os.path.join(dev, "mem_info_vram_used"))   # bytes
+        # APU / unified-memory iGPU (e.g. Ryzen AI Max / Strix Halo): the dedicated
+        # VRAM is a tiny BIOS carve-out (<= ~1 GiB) while the real working set — where
+        # models actually load — lives in GTT (system RAM mapped to the GPU). Reporting
+        # the 512 MB carve-out makes an idle 128 GB box read "29% full / VRAM ran low".
+        # When this looks like an APU (tiny VRAM + large GTT), report GTT so residency +
+        # pressure reflect reality. Discrete cards (large VRAM) are unaffected. Kept in
+        # lockstep with app.amd_gpus() — same heuristic, same numbers.
+        gtt_total = _int(os.path.join(dev, "mem_info_gtt_total"))    # bytes
+        gtt_used  = _int(os.path.join(dev, "mem_info_gtt_used"))     # bytes
+        if vram_total and gtt_total and vram_total <= (1 << 30):  # VRAM <= 1 GiB -> iGPU
+            total, used = gtt_total, (gtt_used or 0)
+        else:
+            total, used = vram_total, vram_used
         busy  = _int(os.path.join(dev, "gpu_busy_percent"))      # %
         temp = 0
         try:

--- a/tests/test_amd_gpu.py
+++ b/tests/test_amd_gpu.py
@@ -21,12 +21,18 @@ def _write(path, value):
 
 
 def _amd_card(drm, idx, *, total, used, busy, temp_mc=None, power_uw=None,
-              name=None, vendor="0x1002"):
-    """Lay down a single fake card<idx>/device/ node under <drm>."""
+              name=None, vendor="0x1002", gtt_total=None, gtt_used=None):
+    """Lay down a single fake card<idx>/device/ node under <drm>. `total`/`used` are
+    the dedicated-VRAM nodes; pass `gtt_total`/`gtt_used` to also emit the GTT nodes
+    an APU exposes (unified-memory pool mapped from system RAM)."""
     dev = os.path.join(drm, "card%d" % idx, "device")
     _write(os.path.join(dev, "vendor"), vendor + "\n")
     _write(os.path.join(dev, "mem_info_vram_total"), total)
     _write(os.path.join(dev, "mem_info_vram_used"), used)
+    if gtt_total is not None:
+        _write(os.path.join(dev, "mem_info_gtt_total"), gtt_total)
+    if gtt_used is not None:
+        _write(os.path.join(dev, "mem_info_gtt_used"), gtt_used)
     _write(os.path.join(dev, "gpu_busy_percent"), busy)
     if temp_mc is not None:
         _write(os.path.join(dev, "hwmon", "hwmon3", "temp1_input"), temp_mc)
@@ -73,6 +79,44 @@ class TestAmdSysfs(unittest.TestCase):
         self.assertEqual(out["gpu"]["mem_used"], 2048)
         self.assertEqual(out["gpu"]["util"], 10)
         self.assertEqual(out["gpu"]["temp"], 40)
+
+    def test_apu_reports_gtt_not_vram_carveout(self):
+        # Ryzen AI Max / Strix Halo: 512 MiB dedicated VRAM carve-out, 124 GiB GTT pool
+        # (18 MiB in use on an idle box). The reader must report the GTT pool, not the
+        # tiny carve-out — otherwise the tile reads "29% full" and pressure math flags a
+        # permanent low-VRAM insight. Both the hub collector and the probe must agree.
+        _amd_card(self.drm, 0, total=512 * 1024**2, used=148 * 1024**2, busy=0,
+                  gtt_total=124 * 1024**3, gtt_used=18 * 1024**2, name="AMD Radeon 8060S")
+        g = app.amd_gpus(drm_root=self.drm)[0]
+        self.assertEqual(g["mem_total"], 124 * 1024)   # 124 GiB, not 512 MiB
+        self.assertEqual(g["mem_used"], 18)            # GTT usage, not the 148 MiB carve-out
+        out = probe._amd_gpu_sysfs(drm_root=self.drm)
+        self.assertEqual(out["gpu"]["mem_total"], 124 * 1024)
+        self.assertEqual(out["gpu"]["mem_used"], 18)
+
+    def test_apu_missing_gtt_used_degrades_to_zero(self):
+        # amdgpu exposes gtt_total but (rarely) not gtt_used → used must fall back to 0,
+        # never crash the round()/None math, while total still reflects the GTT pool.
+        _amd_card(self.drm, 0, total=512 * 1024**2, used=148 * 1024**2, busy=0,
+                  gtt_total=124 * 1024**3, name="AMD Radeon 8060S")
+        g = app.amd_gpus(drm_root=self.drm)[0]
+        self.assertEqual(g["mem_total"], 124 * 1024)
+        self.assertEqual(g["mem_used"], 0)
+        out = probe._amd_gpu_sysfs(drm_root=self.drm)
+        self.assertEqual(out["gpu"]["mem_total"], 124 * 1024)
+        self.assertEqual(out["gpu"]["mem_used"], 0)
+
+    def test_discrete_card_with_gtt_still_reports_vram(self):
+        # Discrete cards also expose a GTT pool, but with a large dedicated VRAM they must
+        # keep reporting VRAM exactly as before — no behaviour change for the common case.
+        _amd_card(self.drm, 0, total=24 * 1024**3, used=8 * 1024**3, busy=55,
+                  gtt_total=64 * 1024**3, gtt_used=1 * 1024**3, name="AMD Radeon RX 7900 XTX")
+        g = app.amd_gpus(drm_root=self.drm)[0]
+        self.assertEqual(g["mem_total"], 24 * 1024)    # VRAM, not GTT
+        self.assertEqual(g["mem_used"], 8 * 1024)
+        out = probe._amd_gpu_sysfs(drm_root=self.drm)
+        self.assertEqual(out["gpu"]["mem_total"], 24 * 1024)
+        self.assertEqual(out["gpu"]["mem_used"], 8 * 1024)
 
     def test_non_amd_vendor_is_skipped(self):
         # An NVIDIA card (0x10de) in the same tree must be ignored by the AMD reader.


### PR DESCRIPTION
## What

On unified-memory APUs (Ryzen AI Max+ 395 / Strix Halo, Radeon 8060S), the GPU
panels read the dedicated-VRAM carve-out instead of the memory the GPU actually
uses. `amdgpu` exposes a tiny fixed VRAM window (512 MB here, the BIOS minimum)
via `mem_info_vram_*`, while models and buffers live in **GTT**: system RAM
mapped to the GPU, up to ~124 GB on a 128 GB box.

Caught live on an idle box: the GPU tile read **148 MB / 512 MB = 29% full**,
and the insight feed permanently flagged **"GPU VRAM ran low, only 364 MB
free"**, because `free_min = mem_total - peak` is always below
`PRESSURE_FREE_MB` (2048) when `mem_total` is 512 MB. Meanwhile the real pool
(`mem_info_gtt_total`) read 124 GB with ~0 used.

## Fix

`amd_gpus()` now reads `mem_info_gtt_total/used` and reports GTT when the card
looks like an APU (VRAM <= 1 GiB alongside a large GTT pool). Discrete cards
(large dedicated VRAM) fail that test and keep reporting VRAM exactly as before,
so there is no behaviour change for them.

`app.py` `amd_gpus()` only. After the change the same idle box reads **18 MB /
124.0 GB, 0% full**, and the insight flips to "GPU has plenty of headroom". When
a model loads into GTT, residency and the pressure math track the real number.
