### PR TITLE
feat(metrics): export RAPL CPU/DRAM package power via Prometheus

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,6 +145,8 @@ if _PROM_OK:
         "gpu_temp":          _make_gauge("homelab_gpu_temp_c",          "GPU temperature (°C)",              ["gpu"]),
         "gpu_power":         _make_gauge("homelab_gpu_power_w",         "GPU power draw (W)",                ["gpu"]),
         "host_cpu":          _make_gauge("homelab_host_cpu_pct",        "Host CPU usage (%)"),
+        "host_cpu_power":    _make_gauge("homelab_host_cpu_power_w",    "Host CPU package power, RAPL (W)"),
+        "host_dram_power":   _make_gauge("homelab_host_dram_power_w",   "Host DRAM power, RAPL (W)"),
         "host_mem_used":     _make_gauge("homelab_host_mem_used_pct",   "Host memory used (%)"),
         "host_disk_used":    _make_gauge("homelab_host_disk_used_pct",  "Host disk used (%)",                ["mountpoint"]),
         "container_state":   _make_gauge("homelab_container_state",     "Container state (1=running)",       ["name", "state"]),
@@ -398,6 +400,7 @@ _apply_schema_migrations(DB)
 _backfill_rollups(DB)
 
 LATEST = {"ts": 0, "util": 0, "mem_used": 0, "mem_total": 24576, "power": 0, "temp": 0,
+          "cpu_power": None, "dram_power": None,
           "procs": [], "models": [], "callers": [], "host": {}, "gpu_avail": None, "gpu_vendor": None, "gpus": [], "gpu_extra": {},
           "model_meta": {}, "serving": [], "training": [], "devtools": [], "model_catalog": []}
 # Current state of the "status" monitors (Docker + systemd). The background

--- a/app.py
+++ b/app.py
@@ -998,8 +998,8 @@ def _rapl_domains():
     return out
 
 def read_rapl_power():
-    """Per-interval RAPL watts, or {} when unavailable. Keys: cpu_w (psys if present
-    else sum of package-* domains), dram_w (sum of dram sub-domains), domains{name:w}.
+    """Per-interval RAPL watts, or {} when unavailable. Keys: cpu_power (psys if present
+    else sum of package-* domains), dram_power (sum of dram sub-domains), domains{name:w}.
     First call after start seeds state and returns {} (no prior delta)."""
     domains = _rapl_domains()
     if not domains:
@@ -1028,10 +1028,10 @@ def read_rapl_power():
     psys = per.get("psys")
     pkgs = [w for n, w in per.items() if n.startswith("package")]
     cpu_w = psys if psys is not None else (sum(pkgs) if pkgs else None)
-    drams = [w for n, w in per.items() if n == "dram" or n.endswith(":dram")]
-    dram_w = round(sum(drams), 1) if drams else None
-    return {"cpu_w": (round(cpu_w, 1) if cpu_w is not None else None),
-            "dram_w": dram_w, "domains": {n: round(w, 1) for n, w in per.items()}}
+    drams = [w for n, w in per.items() if n == "dram"]
+    dram_power = round(sum(drams), 1) if drams else None
+    return {"cpu_power": (round(cpu_w, 1) if cpu_w is not None else None),
+            "dram_power": dram_power, "domains": {n: round(w, 1) for n, w in per.items()}}
 
 _POWER_PROC_TOPN  = 8
 _POWER_PROC_MIN_W = 0.5
@@ -3346,6 +3346,12 @@ def _local_now_snapshot():
     for k in ("os", "hw", "net", "sec"):
         if H.get(k):
             out[k] = H[k]
+    # RAPL power — top-level in LATEST (not inside host), so pull explicitly.
+    # Mirrors the shape probe.py emits for remotes (cpu_power/dram_power in host).
+    for k in ("cpu_power", "dram_power"):
+        v = (LATEST or {}).get(k)
+        if v is not None:
+            out[k] = v
     # GPU summary — the existing collector already keeps these on LATEST's top
     # level. Re-use them so the All-hosts row for `local` matches the shape
     # probe.py emits for remotes.

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -318,6 +318,10 @@ def metrics():
     # ── Host ─────────────────────────────────────────────────────────────────
     host = _app.LATEST.get("host") or {}
     _app._G["host_cpu"].set(host.get("cpu", 0))
+    if _app.LATEST.get("cpu_power") is not None:
+        _app._G["host_cpu_power"].set(_app.LATEST["cpu_power"])
+    if _app.LATEST.get("dram_power") is not None:
+        _app._G["host_dram_power"].set(_app.LATEST["dram_power"])
     ram_total = host.get("ram_total") or 1
     ram_used  = host.get("ram_used", 0)
     _app._G["host_mem_used"].set(round(100 * ram_used / ram_total, 1))

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -250,6 +250,8 @@ def sample_once():
         print(f"collectors/sample_once read_rapl_power error: {e}", flush=True)
         rapl = {}
     cpu_power, dram_power = rapl.get("cpu_w"), rapl.get("dram_w")
+    # Surface measured watts on the live snapshot so /metrics can export them.
+    _app.LATEST["cpu_power"], _app.LATEST["dram_power"] = cpu_power, dram_power
     try:
         top_cpu = _app.collect_top_processes()
     except Exception as e:

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -251,7 +251,11 @@ def sample_once():
         rapl = {}
     cpu_power, dram_power = rapl.get("cpu_power"), rapl.get("dram_power")
     # Surface measured watts on the live snapshot so /metrics can export them.
-    _app.LATEST["cpu_power"], _app.LATEST["dram_power"] = cpu_power, dram_power
+    # Only overwrite on a real reading — a transient {} from read_rapl_power keeps the last good value.
+    if cpu_power is not None:
+        _app.LATEST["cpu_power"] = cpu_power
+    if dram_power is not None:
+        _app.LATEST["dram_power"] = dram_power
     try:
         top_cpu = _app.collect_top_processes()
     except Exception as e:

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -249,7 +249,7 @@ def sample_once():
     except Exception as e:
         print(f"collectors/sample_once read_rapl_power error: {e}", flush=True)
         rapl = {}
-    cpu_power, dram_power = rapl.get("cpu_w"), rapl.get("dram_w")
+    cpu_power, dram_power = rapl.get("cpu_power"), rapl.get("dram_power")
     # Surface measured watts on the live snapshot so /metrics can export them.
     _app.LATEST["cpu_power"], _app.LATEST["dram_power"] = cpu_power, dram_power
     try:

--- a/deploy/docker-compose.mc.yml
+++ b/deploy/docker-compose.mc.yml
@@ -47,5 +47,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/rootfs:ro
+      - /sys/class/powercap:/sys/class/powercap:ro      # RAPL CPU/DRAM power counters
       - ../data-mc:/data                                 # separate history DB — never touches prod/next
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro

--- a/deploy/docker-compose.next.yml
+++ b/deploy/docker-compose.next.yml
@@ -59,6 +59,7 @@ services:
       # two sockets (see website/configuration.md#write-actions).
       - /var/run/docker.sock:/var/run/docker.sock
       - /:/rootfs:ro                                    # read-only host fs for disk usage
+      - /sys/class/powercap:/sys/class/powercap:ro      # RAPL CPU/DRAM power counters
       - ./data-next:/data                               # separate history DB — never touches prod's ./data
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       # Use docker-compose.readonly.yml to lock this back down to :ro.
       - /var/run/docker.sock:/var/run/docker.sock
       - /:/rootfs:ro                                    # read-only host fs for disk usage
+      - /sys/class/powercap:/sys/class/powercap:ro      # RAPL CPU/DRAM power counters
       - ./data:/data                                    # SQLite history persists here
       # systemd service health + (by default) service controls. Read-write for
       # the same reason as the docker socket above — see docker-compose.readonly.yml

--- a/probe.py
+++ b/probe.py
@@ -1326,7 +1326,7 @@ def read_power(dwell=0.3):
     psys = per.get("psys")
     pkgs = [w for n, w in per.items() if n.startswith("package")]
     cpu_w = psys if psys is not None else (sum(pkgs) if pkgs else None)
-    drams = [w for n, w in per.items() if n == "dram" or n.endswith(":dram")]
+    drams = [w for n, w in per.items() if n == "dram"]
     out = {}
     if cpu_w is not None:
         out["cpu_power"] = round(cpu_w, 1)

--- a/probe.py
+++ b/probe.py
@@ -1255,10 +1255,91 @@ def read_sec():
     }}
 
 
+# ── CPU package power via RAPL (Intel/AMD powercap) ──────────────────────────
+# app.py keeps cross-call state to derive watts; the probe runs once per poll
+# over SSH and can't, so it reads the cumulative energy counter twice around a
+# short dwell (same trick read_cpu uses) and derives instantaneous watts.
+# Package-only, MEASURED — not wall power. Degrades to {} when RAPL is absent.
+RAPL_ROOT = os.environ.get("RAPL_ROOT", "/sys/class/powercap")
+
+def _rapl_uj(path):
+    try:
+        with open(os.path.join(path, "energy_uj")) as f:
+            e = int(f.read().strip())
+        with open(os.path.join(path, "max_energy_range_uj")) as f:
+            m = int(f.read().strip())
+        return e, m
+    except (OSError, ValueError):
+        return None
+
+def _rapl_domains():
+    out = {}
+    try:
+        for top in sorted(glob.glob(os.path.join(RAPL_ROOT, "intel-rapl:*"))):
+            if os.path.basename(top).startswith("intel-rapl-mmio"):
+                continue
+            nm = (_read_text(os.path.join(top, "name")) or "").strip()
+            if nm:
+                out[top] = nm
+            for sub in sorted(glob.glob(os.path.join(top, "intel-rapl:*:*"))):
+                snm = (_read_text(os.path.join(sub, "name")) or "").strip()
+                if snm:
+                    out[sub] = snm
+    except Exception:
+        pass
+    return out
+
+def read_power(dwell=0.3):
+    """Instantaneous RAPL watts via two reads dwell seconds apart. Returns
+    {"cpu_power": W, "dram_power": W} (key omitted if that domain is absent),
+    or {} when RAPL is unavailable. Mirrors app.read_rapl_power: psys if present
+    else sum(package-*); dram = sum of dram sub-domains."""
+    domains = _rapl_domains()
+    if not domains:
+        return {}
+    first = {}
+    for path in domains:
+        rd = _rapl_uj(path)
+        if rd is not None:
+            first[path] = (rd[0], rd[1], time.monotonic())
+    if not first:
+        return {}
+    time.sleep(dwell)
+    per = {}
+    for path, name in domains.items():
+        if path not in first:
+            continue
+        rd = _rapl_uj(path)
+        if rd is None:
+            continue
+        e1, mrange = rd
+        e0, _m0, t0 = first[path]
+        dt = time.monotonic() - t0
+        if dt <= 0:
+            continue
+        de = e1 - e0
+        if de < 0:                 # uint counter wraparound
+            de += mrange
+        per[name] = max(0.0, de / 1e6 / dt)
+    if not per:
+        return {}
+    psys = per.get("psys")
+    pkgs = [w for n, w in per.items() if n.startswith("package")]
+    cpu_w = psys if psys is not None else (sum(pkgs) if pkgs else None)
+    drams = [w for n, w in per.items() if n == "dram" or n.endswith(":dram")]
+    out = {}
+    if cpu_w is not None:
+        out["cpu_power"] = round(cpu_w, 1)
+    if drams:
+        out["dram_power"] = round(sum(drams), 1)
+    return out
+
+
 def main():
     data = {
         "host": {
             **read_cpu(),
+            **read_power(),
             **read_meminfo(),
             **read_loadavg(),
             **read_uptime(),
@@ -1273,7 +1354,7 @@ def main():
             "hostname": socket.gethostname(),
         },
         "at": int(time.time()),
-        "probe_version": "0.7",
+        "probe_version": "0.8",
     }
     json.dump(data, sys.stdout, separators=(",", ":"))
     sys.stdout.write("\n")

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -22,7 +22,7 @@ class TestRapl(unittest.TestCase):
             r2 = app.read_rapl_power()
         self.assertEqual(r1, {})
         # de = (1e8 - 9e8) + 1e9 = 2e8 µJ over 10 s = 20 W
-        self.assertAlmostEqual(r2["cpu_w"], 20.0, places=1)
+        self.assertAlmostEqual(r2["cpu_power"], 20.0, places=1)
 
     def test_absent_degrades_to_empty(self):
         with patch("app._rapl_domains", return_value={}):
@@ -37,8 +37,8 @@ class TestRapl(unittest.TestCase):
              patch("app.time.monotonic", side_effect=[0.0, 10.0]):   # one call per invocation
             app.read_rapl_power()
             r = app.read_rapl_power()
-        self.assertAlmostEqual(r["cpu_w"], 65.0, places=1)    # 650 J / 10 s
-        self.assertAlmostEqual(r["dram_w"], 13.0, places=1)   # 130 J / 10 s
+        self.assertAlmostEqual(r["cpu_power"], 65.0, places=1)    # 650 J / 10 s
+        self.assertAlmostEqual(r["dram_power"], 13.0, places=1)   # 130 J / 10 s
 
 
 class TestAttribution(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds real-time CPU and DRAM power consumption monitoring for Intel/AMD hosts that support RAPL, giving users visibility into per-package wattage directly on the dashboard.

- Reads RAPL energy counters from `/sys/class/powercap` and exposes CPU and DRAM package power as Prometheus gauges
- Mounts `/sys/class/powercap` in the Docker container so RAPL data is accessible inside the container
- Fixes broken RAPL tests and guards `LATEST` against transient `None` values

## Test plan

- [ ] RAPL metrics appear in Prometheus output on a host with RAPL support
- [ ] Container starts correctly with the new `/sys/class/powercap` mount
- [ ] RAPL tests pass (`pytest tests/`)
- [ ] No regression on hosts without RAPL (metrics absent, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)