### PR TITLE
fix(containers): log drawer no longer dies with a traceback when logs go quiet

### DIFF
--- a/app.py
+++ b/app.py
@@ -5637,18 +5637,18 @@ def sync_mlflow():
 
 _CT_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
 
-def _docker_log_stream(name, tail, follow):
+def _docker_log_stream(name, tail, follow, timeout=20):
     """Yield Server-Sent Events of a container's logs over the Docker socket.
     Demuxes Docker's 8-byte stream framing (skipped for TTY containers); for
     follow=1 it keeps the connection open and emits a heartbeat every ~20s so a
-    closed browser EventSource is noticed and the socket torn down cleanly."""
-    c = http.client.HTTPConnection("localhost", timeout=None)
-    c.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    c.sock.connect(DOCKER_SOCK)
-    if follow:
-        c.sock.settimeout(20)
-    path = (f"/containers/{name}/logs?stdout=1&stderr=1&timestamps=0"
-            f"&tail={tail}&follow={'1' if follow else '0'}")
+    closed browser EventSource is noticed and the socket torn down cleanly.
+    Speaks HTTP/1.0 straight over the socket: a 1.0 response is streamed raw
+    (no chunked transfer-encoding), so a quiet-log heartbeat timeout simply
+    recv()s again. The previous http.client version could not resume its chunked
+    decoder after a timeout — the stdlib marks the socket file timed-out and
+    every later read raises "cannot read from timed out object" — so the stream
+    died with a traceback whenever a followed container went quiet."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     text = ""
     def lines_from(s):
         nonlocal text
@@ -5659,39 +5659,59 @@ def _docker_log_stream(name, tail, follow):
             out.append(line)
         return out
     try:
-        c.request("GET", path)
-        r = c.getresponse()
-        if r.status != 200:
-            yield f"event: srverror\ndata: {r.status} {r.reason}\n\n"
+        sock.connect(DOCKER_SOCK)
+        if follow:
+            sock.settimeout(timeout)
+        path = (f"/containers/{name}/logs?stdout=1&stderr=1&timestamps=0"
+                f"&tail={tail}&follow={'1' if follow else '0'}")
+        sock.sendall(f"GET {path} HTTP/1.0\r\nHost: localhost\r\n\r\n".encode())
+        head = b""
+        while b"\r\n\r\n" not in head and len(head) < 65536:
+            data = sock.recv(4096)
+            if not data:
+                break
+            head += data
+        head, _, chunk = head.partition(b"\r\n\r\n")
+        st = head.split(b"\r\n", 1)[0].split(None, 2)   # e.g. b'HTTP/1.0 404 No such container'
+        code = int(st[1]) if len(st) > 1 and st[1].isdigit() else 0
+        if code != 200:
+            reason = st[2].decode("utf-8", "replace") if len(st) > 2 else "bad response from docker"
+            yield f"event: srverror\ndata: {code} {reason}\n\n"
             return
         framed, buf = None, b""
         while True:
+            if chunk:
+                if framed is None:
+                    framed = chunk[0] in (0, 1, 2)     # 8-byte header stream vs raw TTY
+                if framed:
+                    buf += chunk
+                    while len(buf) >= 8:
+                        size = int.from_bytes(buf[4:8], "big")
+                        if len(buf) < 8 + size:
+                            break
+                        payload, buf = buf[8:8 + size], buf[8 + size:]
+                        for line in lines_from(payload.decode("utf-8", "replace")):
+                            yield f"data: {line}\n\n"
+                else:
+                    for line in lines_from(chunk.decode("utf-8", "replace")):
+                        yield f"data: {line}\n\n"
             try:
-                chunk = r.read(4096)
+                chunk = sock.recv(4096)
             except socket.timeout:
+                chunk = b""
                 yield ": keep-alive\n\n"          # heartbeat → Flask sees a gone client
                 continue
             if not chunk:
                 break
-            if framed is None:
-                framed = chunk[0] in (0, 1, 2)     # 8-byte header stream vs raw TTY
-            if framed:
-                buf += chunk
-                while len(buf) >= 8:
-                    size = int.from_bytes(buf[4:8], "big")
-                    if len(buf) < 8 + size:
-                        break
-                    payload, buf = buf[8:8 + size], buf[8 + size:]
-                    for line in lines_from(payload.decode("utf-8", "replace")):
-                        yield f"data: {line}\n\n"
-            else:
-                for line in lines_from(chunk.decode("utf-8", "replace")):
-                    yield f"data: {line}\n\n"
         if text:
             yield f"data: {text}\n\n"
         yield "event: end\ndata: done\n\n"
+    except OSError as e:
+        # Docker socket unreachable / connection reset mid-stream: tell the log
+        # drawer instead of tracebacking through werkzeug into our own logs.
+        yield f"event: srverror\ndata: {e}\n\n"
     finally:
-        try: c.close()
+        try: sock.close()
         except Exception: pass
 
 

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -1,0 +1,121 @@
+"""Tests for the container-logs SSE stream (app._docker_log_stream) against a
+fake Docker daemon on a real unix socket: HTTP/1.0 handshake, 8-byte stream
+demux, TTY raw mode, error surfacing, and the heartbeat regression — a followed
+container going quiet used to kill the stream with a werkzeug traceback
+("OSError: cannot read from timed out object") because http.client's chunked
+decoder cannot resume after a socket timeout."""
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+OK_HEAD = (b"HTTP/1.0 200 OK\r\n"
+           b"Content-Type: application/vnd.docker.multiplexed-stream\r\n\r\n")
+
+
+def _frame(payload, stream=1):
+    """Docker's 8-byte multiplex framing: stream id + 3 zero bytes + BE length."""
+    return bytes([stream, 0, 0, 0]) + len(payload).to_bytes(4, "big") + payload
+
+
+@unittest.skipUnless(hasattr(socket, "AF_UNIX"), "unix sockets required")
+class TestDockerLogStream(unittest.TestCase):
+    """Each test scripts the fake daemon's reply as a list of bytes-to-send and
+    float seconds-to-sleep, then consumes the generator to completion."""
+
+    def setUp(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        self.sock_path = os.path.join(d, "docker.sock")
+        p = mock.patch.object(app, "DOCKER_SOCK", self.sock_path)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _serve(self, script):
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(self.sock_path)
+        srv.listen(1)
+        self.requests = []
+
+        def run():
+            conn, _ = srv.accept()
+            req = b""
+            while b"\r\n\r\n" not in req:
+                d = conn.recv(4096)
+                if not d:
+                    break
+                req += d
+            self.requests.append(req)
+            for item in script:
+                if isinstance(item, (int, float)):
+                    time.sleep(item)
+                else:
+                    conn.sendall(item)
+            conn.close()
+            srv.close()
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+
+    def test_tail_demux_and_end_event(self):
+        self._serve([OK_HEAD, _frame(b"hello\n") + _frame(b"world\n", stream=2)])
+        out = list(app._docker_log_stream("web", "200", 0))
+        self.assertEqual(out, ["data: hello\n\n", "data: world\n\n",
+                               "event: end\ndata: done\n\n"])
+        # The request must be HTTP/1.0 — that's what keeps the reply un-chunked.
+        self.assertIn(b"HTTP/1.0\r\n", self.requests[0])
+        self.assertIn(b"/containers/web/logs?", self.requests[0])
+
+    def test_tty_container_streams_raw(self):
+        # A TTY container has no framing: first byte is printable, pass through.
+        self._serve([OK_HEAD, b"plain line one\nplain line two\n"])
+        out = list(app._docker_log_stream("tty", "50", 0))
+        self.assertEqual(out[:2], ["data: plain line one\n\n", "data: plain line two\n\n"])
+
+    def test_error_status_becomes_srverror_event(self):
+        self._serve([b"HTTP/1.0 404 No such container: web\r\n\r\n"])
+        out = list(app._docker_log_stream("web", "200", 0))
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].startswith("event: srverror\ndata: 404"))
+
+    def test_quiet_follow_heartbeats_then_resumes(self):
+        # THE regression: follow a container that goes quiet longer than the
+        # heartbeat timeout, then speaks again. The old http.client version raised
+        # "cannot read from timed out object" on the read after the first timeout;
+        # now the quiet spell must yield keep-alive comments and the stream must
+        # deliver the later line and a clean end.
+        self._serve([OK_HEAD, _frame(b"before quiet\n"), 0.5, _frame(b"after quiet\n")])
+        out = list(app._docker_log_stream("web", "200", 1, timeout=0.1))
+        self.assertIn("data: before quiet\n\n", out)
+        self.assertIn(": keep-alive\n\n", out)
+        self.assertIn("data: after quiet\n\n", out)
+        self.assertEqual(out[-1], "event: end\ndata: done\n\n")
+        # And no event may be an error.
+        self.assertFalse(any(e.startswith("event: srverror") for e in out))
+
+    def test_frame_split_across_reads(self):
+        # A frame torn across TCP segments must reassemble (send header+payload in
+        # separate writes with a pause so they arrive as separate recv()s).
+        payload = b"x" * 6000 + b"\n"
+        f = _frame(payload)
+        self._serve([OK_HEAD, f[:10], 0.05, f[10:]])
+        out = list(app._docker_log_stream("web", "200", 0))
+        self.assertEqual(out[0], "data: " + "x" * 6000 + "\n\n")
+
+    def test_unreachable_socket_yields_srverror(self):
+        # No daemon listening at DOCKER_SOCK → a single srverror event, no raise.
+        out = list(app._docker_log_stream("web", "200", 1))
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].startswith("event: srverror\ndata: "))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Following a container's logs in the drawer would die after the logs went quiet for ~40s, spamming the monitor's own logs with `OSError: cannot read from timed out object` tracebacks from werkzeug. Reported from the field while testing `:next`; present since the drawer shipped (#28, v0.26.0) — it just needed a quiet container and an open drawer to trigger.

## Why

The stream used a 20s socket timeout as its heartbeat timer, caught the first `socket.timeout`, and retried the read — but the stdlib marks the socket file as timed-out after any timeout, so the very next read raises a plain `OSError` that nothing caught. Resuming `http.client`'s chunked decoder after a timeout is unsafe regardless: a timeout can tear partial reads out of the chunked framing state.

## How

The generator now speaks HTTP/1.0 directly over the Docker socket. A 1.0 response is streamed raw — no chunked transfer-encoding — so a quiet-log heartbeat is simply `recv()` again, with no decoder state to corrupt (verified against a live dockerd). Socket-level failures (daemon unreachable, reset mid-stream) surface as an `srverror` SSE event in the drawer instead of a traceback.

## Testing

6 new tests against a fake Docker daemon on a real unix socket: HTTP/1.0 handshake + 8-byte multiplex demux, TTY raw mode, frames torn across reads, non-200 statuses, unreachable socket, and the exact regression — quiet spell → keep-alive heartbeats → stream resumes and ends cleanly. Full suite: no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ps18DL1o19vwyWf1736oj