### PR TITLE
fix(containers): a nested bind mount was billed to the one container that named it

### DIFF
--- a/app.py
+++ b/app.py
@@ -1795,10 +1795,11 @@ def _container_disk(ct, prev=None, shared=frozenset()):
     """A container's real on-disk footprint: writable layer (SizeRw) + every
     read-write volume and bind mount it owns. Read-only mounts (configs, the
     docker socket, our own /rootfs) aren't this container's data, so they're
-    skipped, and so are sources in `shared` — a bind/volume mounted by more than
-    one container (e.g. a common /srv/share) belongs to none of them, and counting
-    it under each both double-counts and makes unrelated rows show the same huge
-    number. Falls back toward SizeRw alone when host paths can't be measured —
+    skipped, and so are sources in `shared` — data reachable read-write from more
+    than one container (e.g. a common /srv/share, or a directory another container
+    covers by mounting its parent) belongs to none of them, and counting it under
+    each both double-counts and makes unrelated rows show the same huge number.
+    Falls back toward SizeRw alone when host paths can't be measured —
     e.g. HOST_ROOT not mounted — which is the old behaviour.
 
     `prev` is this container's last computed total: if a mount's `du` overruns
@@ -1809,8 +1810,8 @@ def _container_disk(ct, prev=None, shared=frozenset()):
     for m in (ct.get("Mounts") or []):
         if not m.get("RW") or m.get("Type") not in ("volume", "bind"):
             continue
-        src = m.get("Source")
-        if not src or not src.startswith("/") or src in shared:
+        src = _norm_src(m.get("Source"))
+        if not src or src in shared:
             continue
         sz = _dir_size(src)
         if sz is None:
@@ -1821,19 +1822,85 @@ def _container_disk(ct, prev=None, shared=frozenset()):
         return max(total, prev)
     return total
 
+def _norm_src(src):
+    """A mount source as a normalised host path, or None when it isn't one.
+
+    Podman reports pseudo-sources (`devpts`, `tmpfs`) for some mounts and
+    `_container_disk` has always skipped anything not absolute; the sharing check
+    has to apply the same rule and the same normalisation, or the two disagree
+    about what a source is and the `src in shared` skip silently misses."""
+    if not src or not src.startswith("/"):
+        return None
+    p = os.path.normpath(src)
+    return p[1:] if p.startswith("//") else p   # POSIX keeps a leading "//" verbatim
+
+def _covers(parent, child):
+    """True when `parent` is a *strict* ancestor directory of `child`.
+
+    Both arguments must already be normalised (see `_norm_src`). Compared per path
+    component, so `/srv` doesn't "contain" `/srvfoo`, and `/` is an ancestor of
+    every other absolute path. Equality is deliberately False: the caller treats
+    "someone mounts the same source" and "someone mounts a directory above mine"
+    as two different cases.
+
+    Purely lexical, so it can't see through symlinks: if `/srv/models` is a link
+    to `/mnt/disk/models` and another container mounts `/mnt/disk`, the sharing
+    goes unnoticed. Resolving that would mean `realpath` against the host rootfs,
+    which isn't always mounted — the pre-existing behaviour, left alone."""
+    if parent == child:
+        return False
+    return True if parent == "/" else child.startswith(parent + "/")
+
+_shared_note = {"seen": frozenset()}
+
 def _shared_mount_sources(sized):
-    """Sources (volume/bind) mounted read-write by more than one container — i.e.
-    shared infrastructure that shouldn't be attributed to any single container."""
-    users = {}
-    for ct in sized:
-        seen = set()
+    """Sources (volume/bind) that shouldn't be attributed to any single container.
+
+    Two ways a source qualifies:
+
+    - **Another container mounts the same source.** The original rule, unchanged.
+    - **Another container mounts a directory above it.** New, and the reason this
+      function was touched: a container mounting `/srv/models` and another mounting
+      `/` (what toolbox and distrobox do, at `/run/host`) write the same bytes, but
+      no two sources match as strings. The whole tree used to be billed to the one
+      container that named it — on the host that prompted this, a container stopped
+      for two weeks with a 40.9 kB writable layer was charged 1.25 TB.
+
+    The check is deliberately **one-directional**: mounting a parent does not make
+    you lose it because someone else mounted a subdirectory of yours. A container
+    with 500 GB under `/srv/media` keeps being billed for it when another mounts
+    only `/srv/media/photos` — the sub-tree stops being double-counted, and the
+    exclusive part doesn't vanish from the report. Nesting between two mounts of
+    the *same* container is not sharing either."""
+    owners = {}                                    # source -> set of container indexes
+    for i, ct in enumerate(sized):
         for m in (ct.get("Mounts") or []):
             if m.get("RW") and m.get("Type") in ("volume", "bind"):
-                src = m.get("Source")
-                if src and src not in seen:        # a container mounting it twice still counts once
-                    seen.add(src)
-                    users[src] = users.get(src, 0) + 1
-    return frozenset(src for src, n in users.items() if n > 1)
+                src = _norm_src(m.get("Source"))
+                if src:
+                    owners.setdefault(src, set()).add(i)   # mounted twice still counts once
+    shared, covered = set(), set()
+    for src, mine in owners.items():
+        if len(mine) > 1:
+            shared.add(src)
+            continue
+        for other, theirs in owners.items():
+            if _covers(other, src) and theirs - mine:
+                shared.add(src)
+                covered.add(src)
+                break
+    # A parent mount can silently empty the disk column for a whole host (one
+    # container with `/` read-write covers everything), so say it once when the
+    # set changes rather than let the numbers disappear without explanation.
+    if covered != _shared_note["seen"]:
+        _shared_note["seen"] = frozenset(covered)
+        if covered:
+            names = sorted(covered)
+            head = ", ".join(names[:3]) + (f" (+{len(names) - 3} more)" if len(names) > 3 else "")
+            print(f"NOTE: not billing {head} to any container — another container mounts a "
+                  f"parent directory read-write, so that data isn't exclusively theirs",
+                  flush=True)
+    return frozenset(shared)
 
 def _refresh_docker_disk():
     """Measure every container's footprint (running or stopped — stopped

--- a/tests/test_container_disk.py
+++ b/tests/test_container_disk.py
@@ -1,0 +1,198 @@
+"""Unit tests for container disk attribution — `_norm_src` / `_covers` /
+`_shared_mount_sources`.
+
+The case that prompted these: on a toolbox/distrobox host, one stopped container
+mounted `/srv/models` while five running ones mounted `/` at `/run/host`. Nobody
+mounted the *same string*, so the shared-source filter (string equality) let the
+whole 1.25 TB models tree be billed to the stopped container.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+def _ct(cid, *mounts, size_rw=0):
+    """A /containers/json?size=1 row. `mounts` are (source, rw) or (source, rw, type)."""
+    return {
+        "Id": cid,
+        "SizeRw": size_rw,
+        "Mounts": [
+            {"Source": m[0], "RW": m[1], "Type": (m[2] if len(m) > 2 else "bind")}
+            for m in mounts
+        ],
+    }
+
+
+class TestNormSrc(unittest.TestCase):
+    def test_relative_and_empty_sources_are_rejected(self):
+        # podman reports these for pseudo-mounts; _container_disk always skipped them
+        for src in ("devpts", "tmpfs", "", None):
+            self.assertIsNone(app._norm_src(src))
+
+    def test_normalises_dot_dot_and_trailing_slash(self):
+        self.assertEqual(app._norm_src("/srv/models/"), "/srv/models")
+        self.assertEqual(app._norm_src("/srv/models/../cache"), "/srv/cache")
+        self.assertEqual(app._norm_src("/srv/./models"), "/srv/models")
+
+    def test_collapses_slashes_including_the_posix_double(self):
+        self.assertEqual(app._norm_src("/srv//models"), "/srv/models")
+        # os.path.normpath keeps a leading "//" verbatim — two spellings of one path
+        self.assertEqual(app._norm_src("//srv/models"), "/srv/models")
+
+    def test_root_stays_root(self):
+        self.assertEqual(app._norm_src("/"), "/")
+
+
+class TestCovers(unittest.TestCase):
+    def test_strict_ancestor(self):
+        self.assertTrue(app._covers("/srv", "/srv/models"))
+        self.assertTrue(app._covers("/", "/srv/models"))
+
+    def test_equality_is_not_coverage(self):
+        """Same-source sharing is the caller's other branch, not this one."""
+        self.assertFalse(app._covers("/srv/models", "/srv/models"))
+        self.assertFalse(app._covers("/", "/"))
+
+    def test_not_a_sibling_sharing_a_prefix(self):
+        # the string-prefix trap: /srv must not "contain" /srvfoo
+        self.assertFalse(app._covers("/srv", "/srvfoo"))
+        self.assertFalse(app._covers("/srv/models", "/srv/models-old"))
+        # compose named volumes with a common prefix must not collide either
+        self.assertFalse(app._covers("/var/lib/docker/volumes/p_db/_data",
+                                     "/var/lib/docker/volumes/p_db_data/_data"))
+
+    def test_child_does_not_cover_its_parent(self):
+        self.assertFalse(app._covers("/srv/models", "/srv"))
+
+
+class TestSharedMountSources(unittest.TestCase):
+    def setUp(self):
+        app._shared_note["seen"] = frozenset()   # the NOTE line is printed on change
+
+    def test_equal_sources_still_shared(self):
+        """The original behaviour must survive: same path, two containers."""
+        sized = [_ct("a", ("/srv/share", True)), _ct("b", ("/srv/share", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/share"}))
+
+    def test_sole_owner_is_not_shared(self):
+        """A container with its own volume keeps being charged for it."""
+        sized = [_ct("a", ("/var/lib/app", True)), _ct("b", ("/var/lib/other", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_nested_under_another_containers_mount(self):
+        """The reported bug: nobody mounts the same string, yet the data is shared."""
+        sized = [
+            _ct("stopped-toolbox", ("/srv/models", True)),
+            _ct("running-toolbox", ("/", True)),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models"}))
+
+    def test_the_parent_owner_keeps_its_data(self):
+        """One-directional on purpose: a container mounting a subdirectory of mine
+        must not make my exclusive data disappear from the report."""
+        sized = [
+            _ct("media", ("/srv/media", True)),          # 500 GB, mostly exclusive
+            _ct("gallery", ("/srv/media/photos", True)),  # small shared subdir
+        ]
+        self.assertEqual(app._shared_mount_sources(sized),
+                         frozenset({"/srv/media/photos"}))
+
+    def test_three_containers_merge(self):
+        """Two whole-root toolboxes plus the nested one: still exactly one verdict."""
+        sized = [
+            _ct("stopped", ("/srv/models", True)),
+            _ct("tool1", ("/", True)),
+            _ct("tool2", ("/", True)),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models", "/"}))
+
+    def test_read_only_mounts_do_not_make_data_shared(self):
+        """Our own /rootfs is read-only: it must not turn everyone else's volume
+        into shared data, or every row would collapse to SizeRw."""
+        sized = [_ct("app", ("/var/lib/app", True)), _ct("monitor", ("/", False))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_non_bind_volume_types_ignored(self):
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/", True, "tmpfs"))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_docker_named_volumes_are_handled_like_binds(self):
+        sized = [
+            _ct("a", ("/var/lib/docker/volumes/data/_data", True, "volume")),
+            _ct("b", ("/var/lib/docker/volumes/data/_data", True, "volume")),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized),
+                         frozenset({"/var/lib/docker/volumes/data/_data"}))
+
+    def test_same_container_mounting_parent_and_child_is_not_shared(self):
+        """One container owning both /srv and /srv/models shares with nobody."""
+        sized = [_ct("solo", ("/srv", True), ("/srv/models", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_same_container_mounting_one_source_twice(self):
+        sized = [_ct("solo", ("/srv/data", True), ("/srv/data", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_relative_sources_never_reach_the_shared_set(self):
+        """Consistent with _container_disk, which can't measure them anyway."""
+        sized = [_ct("a", ("devpts", True)), _ct("b", ("devpts", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_sharing_is_seen_through_unnormalised_spellings(self):
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/srv/../srv/models/", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models"}))
+
+    def test_dot_dot_that_escapes_is_not_a_child(self):
+        """/srv/models/../cache normalises to /srv/cache — not under /srv/models."""
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/srv/models/../cache", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+
+class TestContainerDiskUsesShared(unittest.TestCase):
+    SIZES = {"/srv/models": 1_251_228_588_133, "/srv/media": 500_000_000_000}
+
+    def setUp(self):
+        app._shared_note["seen"] = frozenset()
+        self._real_dir_size = app._dir_size
+        app._dir_size = lambda path, timeout=120: self.SIZES.get(path, 0)
+
+    def tearDown(self):
+        app._dir_size = self._real_dir_size
+
+    def test_nested_shared_mount_is_not_billed(self):
+        """End to end over the helpers: the stopped container is left with its
+        writable layer instead of the whole models tree."""
+        stopped = _ct("stopped-toolbox", ("/srv/models", True), size_rw=40_887)
+        running = _ct("running-toolbox", ("/", True), size_rw=3_070_000)
+        shared = app._shared_mount_sources([stopped, running])
+        self.assertEqual(app._container_disk(stopped, None, shared), 40_887)
+
+    def test_without_the_shared_set_it_is_billed(self):
+        """Control: same container, no sharing information, keeps the old (wrong)
+        total — so the test above measures the filter, not luck."""
+        stopped = _ct("stopped-toolbox", ("/srv/models", True), size_rw=40_887)
+        self.assertEqual(app._container_disk(stopped, None, frozenset()),
+                         40_887 + 1_251_228_588_133)
+
+    def test_parent_owner_still_billed_when_a_child_is_shared(self):
+        """The one-directional rule, end to end: /srv/media stays on its owner."""
+        media = _ct("media", ("/srv/media", True), size_rw=100)
+        gallery = _ct("gallery", ("/srv/media/photos", True), size_rw=50)
+        shared = app._shared_mount_sources([media, gallery])
+        self.assertEqual(app._container_disk(media, None, shared), 100 + 500_000_000_000)
+        self.assertEqual(app._container_disk(gallery, None, shared), 50)
+
+    def test_unnormalised_source_still_skipped(self):
+        """`src in shared` compares normalised paths on both sides — if only one
+        side were normalised the skip would silently miss."""
+        stopped = _ct("stopped", ("/srv/./models/", True), size_rw=7)
+        running = _ct("tool", ("/", True))
+        shared = app._shared_mount_sources([stopped, running])
+        self.assertEqual(app._container_disk(stopped, None, shared), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this changes

Fixes #264.

`_shared_mount_sources()` decided whether a mount was shared by comparing sources for **string
equality**, so it only ever caught two containers naming the same path. It missed the nested case:
one container mounting `/srv/models` and another mounting `/` (what toolbox and distrobox do, at
`/run/host`) write the same bytes under two different strings, so the whole tree was billed to the
single container that named it. On the host that surfaced this, a container **stopped for two weeks**
with a **40.9 kB** writable layer was reported at **1.25 TB**.

Sharing is now decided by path **coverage**, and deliberately **one-directional**: a source is shared
when another container mounts the same source, or a directory *above* it. Mounting a parent does not
make you lose it because someone else mounted a subdirectory of yours — a container with 500 GB under
`/srv/media` keeps being billed for it when another mounts only `/srv/media/photos`. The nested part
stops being double-counted, the exclusive part doesn't vanish from the report.

Sources are normalised once, in `_norm_src`, and both the sharing check and the skip inside
`_container_disk` go through it — normalising only one side would make `src in shared` miss silently.
That also gives `_shared_mount_sources` the same "absolute paths only" guard `_container_disk` always
had, so podman's pseudo-sources (`devpts`) stop landing in the shared set; they were never measurable
anyway.

Comparison is per path component, so `/srv` doesn't "contain" `/srvfoo`, and compose named volumes
sharing a prefix (`p_db/_data` vs `p_db_data/_data`) don't collide.

## Before / after on the real host

Fed the actual `/containers/json?all=1&size=1` payload from the affected host (13 containers) through
the old and the new code, with `_dir_size` returning the measured `du -sb /srv/models`
(1 251 228 588 133) and 0 elsewhere:

| container | before | after |
|---|---:|---:|
| `llama-rocm` (stopped 2 weeks) | 1 251 228 629 020 | **40 887** |
| the other 12 containers | unchanged | unchanged |

Nothing that was genuinely shared before stops being shared. The one source that leaves the set is
`devpts`, a relative pseudo-source that `_container_disk` already skipped, so no bytes move.

## Checklist

- [x] **Base branch is `next`** (the integration branch), not `main`.
- [x] Branched off the **latest `next`** — re-checked with `git fetch` just before opening this;
      `next` hasn't moved, so no rebase was needed.
- [ ] Tested locally with `docker compose up -d --build` — **not** done that way, and I'd rather say
      so than tick it. My deployment is rootful Podman and I can't rebuild it from this account.
      Instead I ran the collector against the live container payload of the affected host (table
      above), which I think is stronger evidence than a dashboard glance. Happy to do the Compose run
      too if you want it before merging.
- [x] No version bump in this PR.
- [ ] For a new monitor / probe: followed the **"add a monitor" pattern**. *(Not applicable — a fix
      inside an existing collector.)*

## Notes for the reviewer

**The trade-off to agree on.** On a host where some container mounts `/` read-write, every other
read-write mount becomes shared, so those rows fall back to their writable layer. That's the honest
reading of the "belongs to none of them" rule already in the docstring — if a container can write the
whole host, no host data is exclusively anyone's — but it can empty the disk column for a whole host,
and doing that silently would be impossible to diagnose in the field. So the collector now prints one
`NOTE:` line when the covered set changes, naming up to three sources. If you'd rather keep whole-root
mounts out of the coverage rule entirely, or drop the log line, say so and I'll rework it.

**Known limit, documented rather than fixed.** `_covers` is lexical and can't see through symlinks:
if `/srv/models` is a link to `/mnt/disk/models` and another container mounts `/mnt/disk`, the sharing
goes unnoticed. Resolving it means `realpath` against the host rootfs, which isn't always mounted, so
the docstring states the limit instead. This is pre-existing behaviour, not a regression.

**Tests.** `tests/test_container_disk.py` is new: 25 cases over `_norm_src`, `_covers` and
`_shared_mount_sources`, plus four end-to-end through `_container_disk` with `_dir_size` stubbed. Two
of them earn their keep specifically:

- `test_without_the_shared_set_it_is_billed` is the control for the fix — without it the main test
  would pass even if the filter did nothing.
- `test_parent_owner_still_billed_when_a_child_is_shared` pins the one-directional choice, so if
  someone later makes the rule symmetric the test says what breaks and why.

They run under plain `unittest` too. Locally, mirroring CI: `python -m py_compile app.py probe.py`
clean, `pytest tests/test_snapshots.py` 71 passed, `pytest tests/test_container_disk.py` 25 passed. I
noticed CI's pytest step is scoped to `tests/test_snapshots.py`; I left the workflow alone rather than
widen it inside a fix PR, so say the word if you'd like these wired in.

**Two adjacent things I deliberately left alone** (also in the issue, happy to take either separately):

1. A single container mounting both a parent and a child (`/srv` and `/srv/models`) counts the nested
   part twice in its own total. Untouched here — it's one container's own arithmetic, not sharing.
2. `_container_disk()` keeps `max(total, prev)` whenever any mount's `du` overruns its timeout, so a
   figure can grow but never shrink while scans stay incomplete. Deliberate per the docstring, but it
   does let a stale high-water mark outlive deleted data — which is why the dashboard was showing
   1.34 TB for a tree that measures 1.25 TB today.
