### PR TITLE
release: v0.29.1 — shared container data stops landing on one container's bill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ release notes.
 
 ## [Unreleased] — `next`
 
+## [0.29.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.29.1) — 2026-08-07 · **A container stopped for two weeks was reported using 1.25 TB**
+*The fourth fix @andreahaku has landed here — this one found, diagnosed and fixed entirely from the outside, issue and pull request both. The Containers tab was charging a whole shared data directory to whichever container happened to name it.*
+
+**Fixed**
+- **Shared data is no longer billed to one container just because nobody else named the same path.** The check for "more than one container can write this" compared mount sources as strings, so it only ever caught two containers naming the same directory. It missed the nested case: one container mounting `/srv/models` while others mount `/` — which is what toolbox and distrobox do, at `/run/host` — write the same bytes under two different strings, so the entire tree was charged to the single container that named it. On the host that surfaced this, a container **stopped for two weeks** with a **40.9 kB** writable layer was reported at **1.25 TB**. Sharing is now decided by path coverage rather than string equality, and deliberately one-directional: mounting a parent doesn't cost you your data because someone else mounted a subdirectory of yours, so a container with 500 GB under `/srv/media` keeps being billed for it when another mounts only `/srv/media/photos`. Sources are normalised once for both the sharing check and the skip that consumes it — normalising only one side would make the skip miss in silence — and the collector logs a line when a parent mount takes data out of the count, because a disk column that empties itself without explanation is impossible to diagnose in the field. _(contributed by @andreahaku, #264/#265)_
+
 ## [0.29.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.29.0) — 2026-08-01 · **The GPU tab, on every box — per-card history, fan speed, and thermal alerts that ignore power caps**
 *The hub got charts; every other machine got a snapshot. That was a storage limitation, not a UI one — per-card history simply wasn't kept for remotes. It is now, for every host, so one tab serves the whole fleet: a panel per card on a shared scale, fan speed (not collected anywhere in this project before), thermal-throttle windows shaded on the sparkline, and which card each service is sitting on. Alerts are sustained and per card, and a card pinned at a power limit you set yourself doesn't count as throttling.*
 

--- a/app.py
+++ b/app.py
@@ -1795,10 +1795,11 @@ def _container_disk(ct, prev=None, shared=frozenset()):
     """A container's real on-disk footprint: writable layer (SizeRw) + every
     read-write volume and bind mount it owns. Read-only mounts (configs, the
     docker socket, our own /rootfs) aren't this container's data, so they're
-    skipped, and so are sources in `shared` — a bind/volume mounted by more than
-    one container (e.g. a common /srv/share) belongs to none of them, and counting
-    it under each both double-counts and makes unrelated rows show the same huge
-    number. Falls back toward SizeRw alone when host paths can't be measured —
+    skipped, and so are sources in `shared` — data reachable read-write from more
+    than one container (e.g. a common /srv/share, or a directory another container
+    covers by mounting its parent) belongs to none of them, and counting it under
+    each both double-counts and makes unrelated rows show the same huge number.
+    Falls back toward SizeRw alone when host paths can't be measured —
     e.g. HOST_ROOT not mounted — which is the old behaviour.
 
     `prev` is this container's last computed total: if a mount's `du` overruns
@@ -1809,8 +1810,8 @@ def _container_disk(ct, prev=None, shared=frozenset()):
     for m in (ct.get("Mounts") or []):
         if not m.get("RW") or m.get("Type") not in ("volume", "bind"):
             continue
-        src = m.get("Source")
-        if not src or not src.startswith("/") or src in shared:
+        src = _norm_src(m.get("Source"))
+        if not src or src in shared:
             continue
         sz = _dir_size(src)
         if sz is None:
@@ -1821,19 +1822,85 @@ def _container_disk(ct, prev=None, shared=frozenset()):
         return max(total, prev)
     return total
 
+def _norm_src(src):
+    """A mount source as a normalised host path, or None when it isn't one.
+
+    Podman reports pseudo-sources (`devpts`, `tmpfs`) for some mounts and
+    `_container_disk` has always skipped anything not absolute; the sharing check
+    has to apply the same rule and the same normalisation, or the two disagree
+    about what a source is and the `src in shared` skip silently misses."""
+    if not src or not src.startswith("/"):
+        return None
+    p = os.path.normpath(src)
+    return p[1:] if p.startswith("//") else p   # POSIX keeps a leading "//" verbatim
+
+def _covers(parent, child):
+    """True when `parent` is a *strict* ancestor directory of `child`.
+
+    Both arguments must already be normalised (see `_norm_src`). Compared per path
+    component, so `/srv` doesn't "contain" `/srvfoo`, and `/` is an ancestor of
+    every other absolute path. Equality is deliberately False: the caller treats
+    "someone mounts the same source" and "someone mounts a directory above mine"
+    as two different cases.
+
+    Purely lexical, so it can't see through symlinks: if `/srv/models` is a link
+    to `/mnt/disk/models` and another container mounts `/mnt/disk`, the sharing
+    goes unnoticed. Resolving that would mean `realpath` against the host rootfs,
+    which isn't always mounted — the pre-existing behaviour, left alone."""
+    if parent == child:
+        return False
+    return True if parent == "/" else child.startswith(parent + "/")
+
+_shared_note = {"seen": frozenset()}
+
 def _shared_mount_sources(sized):
-    """Sources (volume/bind) mounted read-write by more than one container — i.e.
-    shared infrastructure that shouldn't be attributed to any single container."""
-    users = {}
-    for ct in sized:
-        seen = set()
+    """Sources (volume/bind) that shouldn't be attributed to any single container.
+
+    Two ways a source qualifies:
+
+    - **Another container mounts the same source.** The original rule, unchanged.
+    - **Another container mounts a directory above it.** New, and the reason this
+      function was touched: a container mounting `/srv/models` and another mounting
+      `/` (what toolbox and distrobox do, at `/run/host`) write the same bytes, but
+      no two sources match as strings. The whole tree used to be billed to the one
+      container that named it — on the host that prompted this, a container stopped
+      for two weeks with a 40.9 kB writable layer was charged 1.25 TB.
+
+    The check is deliberately **one-directional**: mounting a parent does not make
+    you lose it because someone else mounted a subdirectory of yours. A container
+    with 500 GB under `/srv/media` keeps being billed for it when another mounts
+    only `/srv/media/photos` — the sub-tree stops being double-counted, and the
+    exclusive part doesn't vanish from the report. Nesting between two mounts of
+    the *same* container is not sharing either."""
+    owners = {}                                    # source -> set of container indexes
+    for i, ct in enumerate(sized):
         for m in (ct.get("Mounts") or []):
             if m.get("RW") and m.get("Type") in ("volume", "bind"):
-                src = m.get("Source")
-                if src and src not in seen:        # a container mounting it twice still counts once
-                    seen.add(src)
-                    users[src] = users.get(src, 0) + 1
-    return frozenset(src for src, n in users.items() if n > 1)
+                src = _norm_src(m.get("Source"))
+                if src:
+                    owners.setdefault(src, set()).add(i)   # mounted twice still counts once
+    shared, covered = set(), set()
+    for src, mine in owners.items():
+        if len(mine) > 1:
+            shared.add(src)
+            continue
+        for other, theirs in owners.items():
+            if _covers(other, src) and theirs - mine:
+                shared.add(src)
+                covered.add(src)
+                break
+    # A parent mount can silently empty the disk column for a whole host (one
+    # container with `/` read-write covers everything), so say it once when the
+    # set changes rather than let the numbers disappear without explanation.
+    if covered != _shared_note["seen"]:
+        _shared_note["seen"] = frozenset(covered)
+        if covered:
+            names = sorted(covered)
+            head = ", ".join(names[:3]) + (f" (+{len(names) - 3} more)" if len(names) > 3 else "")
+            print(f"NOTE: not billing {head} to any container — another container mounts a "
+                  f"parent directory read-write, so that data isn't exclusively theirs",
+                  flush=True)
+    return frozenset(shared)
 
 def _refresh_docker_disk():
     """Measure every container's footprint (running or stopped — stopped

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.29.0"
+VERSION      = "0.29.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))

--- a/tests/snapshots/api_changelog.json
+++ b/tests/snapshots/api_changelog.json
@@ -1,6 +1,6 @@
 {
   "has_content": true,
   "has_sections": true,
-  "markdown_prefix": "## [0.29.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.29.0) \u2014 2026-08-01 \u00b7 *",
+  "markdown_prefix": "## [0.29.1](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.29.1) \u2014 2026-08-07 \u00b7 *",
   "status": 200
 }

--- a/tests/snapshots/api_data.json
+++ b/tests/snapshots/api_data.json
@@ -119,5 +119,5 @@
     "up": 0,
     "worst_down": null
   },
-  "version": "0.29.0"
+  "version": "0.29.1"
 }

--- a/tests/snapshots/api_health.json
+++ b/tests/snapshots/api_health.json
@@ -82,9 +82,9 @@
   },
   "update": {
     "available": false,
-    "current": "0.29.0",
+    "current": "0.29.1",
     "self_update_enabled": true
   },
   "updated": 1735689600,
-  "version": "0.29.0"
+  "version": "0.29.1"
 }

--- a/tests/snapshots/api_settings_get.json
+++ b/tests/snapshots/api_settings_get.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.29.0"
+  "version": "0.29.1"
 }

--- a/tests/snapshots/api_settings_post.json
+++ b/tests/snapshots/api_settings_post.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.29.0"
+  "version": "0.29.1"
 }

--- a/tests/snapshots/healthz.json
+++ b/tests/snapshots/healthz.json
@@ -1,4 +1,4 @@
 {
   "status": "ok",
-  "version": "0.29.0"
+  "version": "0.29.1"
 }

--- a/tests/test_container_disk.py
+++ b/tests/test_container_disk.py
@@ -1,0 +1,198 @@
+"""Unit tests for container disk attribution — `_norm_src` / `_covers` /
+`_shared_mount_sources`.
+
+The case that prompted these: on a toolbox/distrobox host, one stopped container
+mounted `/srv/models` while five running ones mounted `/` at `/run/host`. Nobody
+mounted the *same string*, so the shared-source filter (string equality) let the
+whole 1.25 TB models tree be billed to the stopped container.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app
+
+
+def _ct(cid, *mounts, size_rw=0):
+    """A /containers/json?size=1 row. `mounts` are (source, rw) or (source, rw, type)."""
+    return {
+        "Id": cid,
+        "SizeRw": size_rw,
+        "Mounts": [
+            {"Source": m[0], "RW": m[1], "Type": (m[2] if len(m) > 2 else "bind")}
+            for m in mounts
+        ],
+    }
+
+
+class TestNormSrc(unittest.TestCase):
+    def test_relative_and_empty_sources_are_rejected(self):
+        # podman reports these for pseudo-mounts; _container_disk always skipped them
+        for src in ("devpts", "tmpfs", "", None):
+            self.assertIsNone(app._norm_src(src))
+
+    def test_normalises_dot_dot_and_trailing_slash(self):
+        self.assertEqual(app._norm_src("/srv/models/"), "/srv/models")
+        self.assertEqual(app._norm_src("/srv/models/../cache"), "/srv/cache")
+        self.assertEqual(app._norm_src("/srv/./models"), "/srv/models")
+
+    def test_collapses_slashes_including_the_posix_double(self):
+        self.assertEqual(app._norm_src("/srv//models"), "/srv/models")
+        # os.path.normpath keeps a leading "//" verbatim — two spellings of one path
+        self.assertEqual(app._norm_src("//srv/models"), "/srv/models")
+
+    def test_root_stays_root(self):
+        self.assertEqual(app._norm_src("/"), "/")
+
+
+class TestCovers(unittest.TestCase):
+    def test_strict_ancestor(self):
+        self.assertTrue(app._covers("/srv", "/srv/models"))
+        self.assertTrue(app._covers("/", "/srv/models"))
+
+    def test_equality_is_not_coverage(self):
+        """Same-source sharing is the caller's other branch, not this one."""
+        self.assertFalse(app._covers("/srv/models", "/srv/models"))
+        self.assertFalse(app._covers("/", "/"))
+
+    def test_not_a_sibling_sharing_a_prefix(self):
+        # the string-prefix trap: /srv must not "contain" /srvfoo
+        self.assertFalse(app._covers("/srv", "/srvfoo"))
+        self.assertFalse(app._covers("/srv/models", "/srv/models-old"))
+        # compose named volumes with a common prefix must not collide either
+        self.assertFalse(app._covers("/var/lib/docker/volumes/p_db/_data",
+                                     "/var/lib/docker/volumes/p_db_data/_data"))
+
+    def test_child_does_not_cover_its_parent(self):
+        self.assertFalse(app._covers("/srv/models", "/srv"))
+
+
+class TestSharedMountSources(unittest.TestCase):
+    def setUp(self):
+        app._shared_note["seen"] = frozenset()   # the NOTE line is printed on change
+
+    def test_equal_sources_still_shared(self):
+        """The original behaviour must survive: same path, two containers."""
+        sized = [_ct("a", ("/srv/share", True)), _ct("b", ("/srv/share", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/share"}))
+
+    def test_sole_owner_is_not_shared(self):
+        """A container with its own volume keeps being charged for it."""
+        sized = [_ct("a", ("/var/lib/app", True)), _ct("b", ("/var/lib/other", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_nested_under_another_containers_mount(self):
+        """The reported bug: nobody mounts the same string, yet the data is shared."""
+        sized = [
+            _ct("stopped-toolbox", ("/srv/models", True)),
+            _ct("running-toolbox", ("/", True)),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models"}))
+
+    def test_the_parent_owner_keeps_its_data(self):
+        """One-directional on purpose: a container mounting a subdirectory of mine
+        must not make my exclusive data disappear from the report."""
+        sized = [
+            _ct("media", ("/srv/media", True)),          # 500 GB, mostly exclusive
+            _ct("gallery", ("/srv/media/photos", True)),  # small shared subdir
+        ]
+        self.assertEqual(app._shared_mount_sources(sized),
+                         frozenset({"/srv/media/photos"}))
+
+    def test_three_containers_merge(self):
+        """Two whole-root toolboxes plus the nested one: still exactly one verdict."""
+        sized = [
+            _ct("stopped", ("/srv/models", True)),
+            _ct("tool1", ("/", True)),
+            _ct("tool2", ("/", True)),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models", "/"}))
+
+    def test_read_only_mounts_do_not_make_data_shared(self):
+        """Our own /rootfs is read-only: it must not turn everyone else's volume
+        into shared data, or every row would collapse to SizeRw."""
+        sized = [_ct("app", ("/var/lib/app", True)), _ct("monitor", ("/", False))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_non_bind_volume_types_ignored(self):
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/", True, "tmpfs"))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_docker_named_volumes_are_handled_like_binds(self):
+        sized = [
+            _ct("a", ("/var/lib/docker/volumes/data/_data", True, "volume")),
+            _ct("b", ("/var/lib/docker/volumes/data/_data", True, "volume")),
+        ]
+        self.assertEqual(app._shared_mount_sources(sized),
+                         frozenset({"/var/lib/docker/volumes/data/_data"}))
+
+    def test_same_container_mounting_parent_and_child_is_not_shared(self):
+        """One container owning both /srv and /srv/models shares with nobody."""
+        sized = [_ct("solo", ("/srv", True), ("/srv/models", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_same_container_mounting_one_source_twice(self):
+        sized = [_ct("solo", ("/srv/data", True), ("/srv/data", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_relative_sources_never_reach_the_shared_set(self):
+        """Consistent with _container_disk, which can't measure them anyway."""
+        sized = [_ct("a", ("devpts", True)), _ct("b", ("devpts", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+    def test_sharing_is_seen_through_unnormalised_spellings(self):
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/srv/../srv/models/", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset({"/srv/models"}))
+
+    def test_dot_dot_that_escapes_is_not_a_child(self):
+        """/srv/models/../cache normalises to /srv/cache — not under /srv/models."""
+        sized = [_ct("a", ("/srv/models", True)), _ct("b", ("/srv/models/../cache", True))]
+        self.assertEqual(app._shared_mount_sources(sized), frozenset())
+
+
+class TestContainerDiskUsesShared(unittest.TestCase):
+    SIZES = {"/srv/models": 1_251_228_588_133, "/srv/media": 500_000_000_000}
+
+    def setUp(self):
+        app._shared_note["seen"] = frozenset()
+        self._real_dir_size = app._dir_size
+        app._dir_size = lambda path, timeout=120: self.SIZES.get(path, 0)
+
+    def tearDown(self):
+        app._dir_size = self._real_dir_size
+
+    def test_nested_shared_mount_is_not_billed(self):
+        """End to end over the helpers: the stopped container is left with its
+        writable layer instead of the whole models tree."""
+        stopped = _ct("stopped-toolbox", ("/srv/models", True), size_rw=40_887)
+        running = _ct("running-toolbox", ("/", True), size_rw=3_070_000)
+        shared = app._shared_mount_sources([stopped, running])
+        self.assertEqual(app._container_disk(stopped, None, shared), 40_887)
+
+    def test_without_the_shared_set_it_is_billed(self):
+        """Control: same container, no sharing information, keeps the old (wrong)
+        total — so the test above measures the filter, not luck."""
+        stopped = _ct("stopped-toolbox", ("/srv/models", True), size_rw=40_887)
+        self.assertEqual(app._container_disk(stopped, None, frozenset()),
+                         40_887 + 1_251_228_588_133)
+
+    def test_parent_owner_still_billed_when_a_child_is_shared(self):
+        """The one-directional rule, end to end: /srv/media stays on its owner."""
+        media = _ct("media", ("/srv/media", True), size_rw=100)
+        gallery = _ct("gallery", ("/srv/media/photos", True), size_rw=50)
+        shared = app._shared_mount_sources([media, gallery])
+        self.assertEqual(app._container_disk(media, None, shared), 100 + 500_000_000_000)
+        self.assertEqual(app._container_disk(gallery, None, shared), 50)
+
+    def test_unnormalised_source_still_skipped(self):
+        """`src in shared` compares normalised paths on both sides — if only one
+        side were normalised the skip would silently miss."""
+        stopped = _ct("stopped", ("/srv/./models/", True), size_rw=7)
+        running = _ct("tool", ("/", True))
+        shared = app._shared_mount_sources([stopped, running])
+        self.assertEqual(app._container_disk(stopped, None, shared), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Patch release. One fix, contributed by @andreahaku (#264/#265): the Containers tab was charging a whole shared data directory to whichever container happened to name it, because sharing was decided by string equality on mount sources. A container stopped for two weeks with a 40.9 kB writable layer read as 1.25 TB.

Version bumped to 0.29.1, snapshots rebaselined, CHANGELOG updated. Patch, so it ships silently (Discord/selfh.st announcers gate on non-zero patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuAQwfcoUqEVgWD1jTjjjh