### PR TITLE
fix(host tab): stop showing hub data when viewing a remote host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ release notes.
 
 ## [Unreleased] — `next`
 
-**Added**
-- **The System tab's chart now draws the host you selected.** Per-host CPU, RAM and load were already being stored in `host_samples` on every poll, but nothing ever read them back for a chart, so the panel stayed hardwired to the hub's own series. A new `/api/host_history?host=&range=` serves them, falling back to the hourly rollup once raw retention expires. A host with no history yet says so next to the canvas instead of drawing an empty chart, which is indistinguishable from a chart of zeroes.
-
 **Fixed**
 - **Switching to a remote host left the hub's data on screen.** Only the System card changed; **Top processes**, **Power & cost** and the **CPU/RAM/load chart** kept the hub's numbers under the remote machine's name. The bug had a peculiar shape: `renderTopProcs()` and `renderCost()` each open with a correct guard that hides them on a remote — and their only caller wrapped them in *the same condition*, so on a remote they were never called, the guard never ran, and the last local paint stayed. The chart had no guard at all; it plotted `/api/data`, which is always the hub. This only surfaced on the local → remote *switch*, never on a fresh load, which is how it survived. The hub-only cards now hide the moment the host changes rather than on the next 15-second tick.
+- **The System tab's chart now draws the host you selected.** Per-host CPU, RAM and load were already being stored in `host_samples` on every poll, but nothing ever read them back, so the panel stayed hardwired to the hub's own series — fixing the chart meant adding the reader it never had. `/api/host_history?host=&range=` serves those rows, falling back to the hourly rollup once raw retention expires. A host with no history yet says so next to the canvas instead of drawing an empty chart, which is indistinguishable from a chart of zeroes.
 
 ## [0.30.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.30.0) — 2026-08-08 · **A dashboard that keeps up, disk scans on every box — and a container that had quietly been running itself twice**
 *Live values went from twenty-five seconds stale to two, and the app asks the server for less than it did before, because the fix was to stop conflating how often something is measured with how often it is stored. Chasing a stream that ticked twice per interval then turned up something older and worse: every container ever shipped has been running two complete copies of the application.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ release notes.
 
 ## [Unreleased] — `next`
 
+**Added**
+- **The System tab's chart now draws the host you selected.** Per-host CPU, RAM and load were already being stored in `host_samples` on every poll, but nothing ever read them back for a chart, so the panel stayed hardwired to the hub's own series. A new `/api/host_history?host=&range=` serves them, falling back to the hourly rollup once raw retention expires. A host with no history yet says so next to the canvas instead of drawing an empty chart, which is indistinguishable from a chart of zeroes.
+
+**Fixed**
+- **Switching to a remote host left the hub's data on screen.** Only the System card changed; **Top processes**, **Power & cost** and the **CPU/RAM/load chart** kept the hub's numbers under the remote machine's name. The bug had a peculiar shape: `renderTopProcs()` and `renderCost()` each open with a correct guard that hides them on a remote — and their only caller wrapped them in *the same condition*, so on a remote they were never called, the guard never ran, and the last local paint stayed. The chart had no guard at all; it plotted `/api/data`, which is always the hub. This only surfaced on the local → remote *switch*, never on a fresh load, which is how it survived. The hub-only cards now hide the moment the host changes rather than on the next 15-second tick.
+
 ## [0.30.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.30.0) — 2026-08-08 · **A dashboard that keeps up, disk scans on every box — and a container that had quietly been running itself twice**
 *Live values went from twenty-five seconds stale to two, and the app asks the server for less than it did before, because the fix was to stop conflating how often something is measured with how often it is stored. Chasing a stream that ticked twice per interval then turned up something older and worse: every container ever shipped has been running two complete copies of the application.*
 

--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.30.0"
+VERSION      = "0.31.0"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))

--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ try:
 except ImportError:
     _PROM_OK = False
 
-VERSION      = "0.31.0"
+VERSION      = "0.30.1"
 DB_PATH      = os.environ.get("DB_PATH", "/data/gpu.db")
 MCP_IDLE_SEC = 45   # seconds without MCP activity before the pill shows idle
 INTERVAL     = int(os.environ.get("SAMPLE_INTERVAL", "10"))

--- a/backend/api/hosts_api.py
+++ b/backend/api/hosts_api.py
@@ -82,6 +82,50 @@ def api_host_data(name):
                     "error": entry.get("error")})
 
 
+@bp.route("/api/host_history")
+def api_host_history():
+    """CPU / RAM / load history for one host — the System tab's chart feed.
+
+    `host=local` is the hub, served from its own `samples` series via /api/data;
+    everything else comes out of `host_samples`, which the poller has been
+    filling with each remote's vitals all along. There is deliberately no
+    "remote history" endpoint separate from this one: the System tab used to
+    chart the hub and then keep charting the hub after you switched machines,
+    and the only reason that bug could exist is that nothing here read the
+    per-host rows.
+
+    Shaped like the slice of /api/data the chart consumes — {labels, cpu,
+    ram_used, ram_total, load1, ctemp} — so the same drawing code serves both.
+    """
+    import app as _app
+    from backend.db.repos import host_samples as hs_repo
+
+    name = request.args.get("host", "local")
+    rng = request.args.get("range", "6h")
+    span = _app.RANGES.get(rng, 21600)
+    now = int(time.time())
+    with _app.LOCK:
+        if span is None:
+            since = hs_repo.min_ts(name, conn=_app.DB) or now
+        else:
+            since = now - span
+        bk = max(_app.INTERVAL, round(max(1, now - since) / _app.MAX_POINTS))
+        rows = hs_repo.vitals_series(name, since, bk, conn=_app.DB)
+
+    return jsonify({
+        "host": name, "range": rng, "bucket_sec": bk,
+        "labels":    [int(r[0]) for r in rows],
+        # None, not 0, for a sensor the host never reported: Chart.js leaves a
+        # gap where there is no reading, which is the honest drawing. A zeroed
+        # point would render as a machine that was genuinely idle.
+        "cpu":       [r[1] for r in rows],
+        "ram_used":  [r[2] for r in rows],
+        "ram_total": [r[3] for r in rows],
+        "load1":     [r[4] for r in rows],
+        "ctemp":     [r[5] for r in rows],
+    })
+
+
 @bp.route("/api/fleet")
 def api_fleet():
     import app as _app

--- a/backend/db/repos/host_samples.py
+++ b/backend/db/repos/host_samples.py
@@ -45,6 +45,53 @@ def min_ts_1h(host: str, conn=None):
     ).fetchone()[0]
 
 
+def min_ts(host: str, conn=None):
+    """Earliest sample for a host across raw and rollup, or None.
+
+    What `range=all` should actually span: raw rows are retention-purged, so
+    asking `host_samples` alone would shrink a host's "all" window to the last
+    couple of days the moment the purge runs.
+    """
+    c = conn or connection()
+    raw = c.execute("SELECT MIN(ts) FROM host_samples WHERE host=?", (host,)).fetchone()[0]
+    roll = min_ts_1h(host, conn=c)
+    vals = [v for v in (raw, roll) if v is not None]
+    return min(vals) if vals else None
+
+
+def _use_rollup(host: str, since: int, conn) -> bool:
+    """True when the raw table can't honestly answer for this window.
+
+    Same rule as gpu_samples: if the oldest raw row is newer than the window
+    start, raw would answer a 30d question with 2d of data and label it 30d.
+    """
+    oldest = conn.execute(
+        "SELECT MIN(ts) FROM host_samples WHERE host=?", (host,)
+    ).fetchone()[0]
+    return oldest is None or oldest > since
+
+
+def vitals_series(host: str, since: int, bucket: int, conn=None) -> list:
+    """Bucketed CPU / RAM / load / temperature for one host since `since`.
+
+    Returns (bucket_ts, avg_cpu, avg_ram_used, max_ram_total, avg_load1,
+    avg_ctemp) ordered by time — the per-host counterpart of the hub's own
+    `D.total` series, so the System tab's chart has one shape to draw whichever
+    machine is selected.
+
+    `ram_total` takes MAX rather than AVG: it is a capacity, not a rate, and
+    averaging it across a bucket where one poll missed the value would drag the
+    denominator of every RAM percentage down with it.
+    """
+    c = conn or connection()
+    table = "host_samples_1h" if _use_rollup(host, since, c) else "host_samples"
+    return c.execute(
+        "SELECT (ts/?)*? b, AVG(cpu), AVG(ram_used), MAX(ram_total), AVG(load1), AVG(ctemp) "
+        f"FROM {table} WHERE host=? AND ts>=? GROUP BY b ORDER BY b",
+        (bucket, bucket, host, since)
+    ).fetchall()
+
+
 def comp_bucketed(host: str, ts: int, bk: int, conn=None) -> list:
     """(bucket, avg_gpu_power, avg_cpu_power, avg_dram_power) since ts."""
     c = conn or connection()

--- a/backend/db/repos/host_samples.py
+++ b/backend/db/repos/host_samples.py
@@ -60,15 +60,24 @@ def min_ts(host: str, conn=None):
 
 
 def _use_rollup(host: str, since: int, conn) -> bool:
-    """True when the raw table can't honestly answer for this window.
+    """True when the raw ring can no longer answer for `since` but the rollup can.
 
-    Same rule as gpu_samples: if the oldest raw row is newer than the window
-    start, raw would answer a 30d question with 2d of data and label it 30d.
+    Same rule as gpu_samples._use_rollup, and for the same reason: the test is
+    "does the rollup hold an EARLIER HOUR than the oldest raw sample" — i.e. has
+    retention actually purged raw rows the rollup still remembers. Not simply
+    "does the window start before the oldest raw sample", which is also true for
+    a host added twenty minutes ago, where raw is the complete and correct
+    answer and switching to the rollup would hand back a four-point chart of a
+    machine that has fine-grained data for its whole life. (Rollup rows are
+    bucketed down to the hour, so the comparison is hour-to-hour.)
     """
-    oldest = conn.execute(
-        "SELECT MIN(ts) FROM host_samples WHERE host=?", (host,)
-    ).fetchone()[0]
-    return oldest is None or oldest > since
+    raw = conn.execute("SELECT MIN(ts) FROM host_samples WHERE host=?", (host,)).fetchone()[0]
+    roll = min_ts_1h(host, conn=conn)
+    if roll is None:
+        return False                      # nothing rolled up; raw is all there is
+    if raw is None:
+        return True                       # raw fully purged (or never written)
+    return since < raw and roll < (raw // 3600) * 3600
 
 
 def vitals_series(host: str, since: int, bucket: int, conn=None) -> list:

--- a/locales/en.json
+++ b/locales/en.json
@@ -402,6 +402,7 @@
   "fleet.meta": "{n} hosts · polling every {i}s · click a row to focus that host in the other tabs.",
   "host.no_data": "no data yet",
   "host.probe_wait": "<div class=\"muted\" style=\"padding:12px 2px\">⏳ <b>{host}</b> — {err}. Probes run every {i}s; new hosts take one cycle to populate.</div>",
+  "host.hist_wait": "No history for {host} yet — it starts building from its first successful poll.",
   "disks.none": "No disks reported yet.",
   "disks.host_offline": "Host is offline",
   "disks.host_offline_d": "A disk scan runs live over SSH, so <b>{host}</b> has to be reachable. It will be available again once the host is back.",

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -3414,11 +3414,16 @@ function renderData(){
   // /api/cost (a database range query — running it every couple of seconds is
   // exactly the cost this split avoids), and the inventory panels below read the
   // /api/health snapshot and server-side caches that only move every 60–300s.
-  if(CURRENT_HOST === 'local'){
-    renderSysInfo();
-    renderTopProcs();
-    renderCost();
-  }
+  // renderSysInfo() is local-only here because renderHostTab() owns it for a
+  // remote (it has to await that host's probe cache first). renderTopProcs()
+  // and renderCost() are called unconditionally on purpose: both are hub-only
+  // panels that hide *themselves* when the active host isn't local, and
+  // wrapping them in the same condition they test meant the guard could never
+  // run — so switching to a remote left the hub's process table and the hub's
+  // power bill on screen under the remote's name.
+  if(CURRENT_HOST === 'local') renderSysInfo();
+  renderTopProcs();
+  renderCost();
   // Network/Security read the active host block; re-render them on each data
   // refresh (and on first load) when one of them is the visible tab.
   if(TAB==='network')  renderNetwork();
@@ -5307,12 +5312,12 @@ function buildCharts(){
   // /api/gpu/* endpoints. It is deliberately absent here: /api/data is the hub's
   // own series, and charting it under a remote host's name is exactly the
   // cross-host bleed this slice set out to remove.
-  if(TAB==='host'){
+  // D is the hub's own series, so this branch is hub-only. A remote's history
+  // comes from /api/host_history via renderHostChart(); charting D.total under
+  // a remote host's name was the System tab's version of the cross-host bleed.
+  if(TAB==='host' && CURRENT_HOST==='local'){
     const ramPctArr=D.total.ram_used.map((u,i)=>D.total.ram_total[i]?Math.round(u/D.total.ram_total[i]*100):0);
-    mk('host',{type:'line',data:{labels,datasets:[
-      {label:'CPU %',data:D.total.cpu,borderColor:'#3fb950',backgroundColor:'#3fb95033',fill:true,pointRadius:0,tension:.3,yAxisID:'y'},
-      {label:'RAM %',data:ramPctArr,borderColor:'#a371f7',borderWidth:1.5,pointRadius:0,tension:.3,yAxisID:'y'},
-      {label:'Load',data:D.total.load1,borderColor:'#e3b341',borderWidth:1,pointRadius:0,tension:.3,yAxisID:'y1'}]},
+    mk('host',{type:'line',data:hostChartDatasets(labels,D.total.cpu,ramPctArr,D.total.load1),
       options:dualOpts(labels,100),plugins:[areaBg]});
   }
 }
@@ -7920,13 +7925,21 @@ async function renderHostTab(){
     // renderData() will populate #hostkpis / #disks for us.
     if(D) renderData();
     renderRamTree();
+    renderHostChart();   // clears any remote's "no history yet" note
     return;
   }
+  // Hub-only cards on this tab, hidden the moment the host changes rather than
+  // on the next /api/data tick — 15 seconds of the hub's process table sitting
+  // under a remote's name is 15 seconds of a wrong answer. Both return
+  // immediately (no fetch) once CURRENT_HOST isn't local.
+  renderTopProcs();
+  renderCost();
   await loadHostData(CURRENT_HOST);
   const h = (HOST_DATA && HOST_DATA.host) || {};
   const hk = document.getElementById('hostkpis');
   const dk = document.getElementById('disks');
   if(!HOST_DATA || !HOST_DATA.online){
+    renderHostChart();   // still draw whatever history the host left behind
     hk.innerHTML = '';
     const err = HOST_DATA && HOST_DATA.error ? esc(HOST_DATA.error) : I18N.t('host.no_data','no data yet');
     dk.innerHTML = I18N.tf('host.probe_wait','<div class="muted" style="padding:12px 2px">⏳ <b>{host}</b> — {err}. Probes run every {i}s; new hosts take one cycle to populate.</div>',{host:esc(CURRENT_HOST),err,i:(FLEET ? (FLEET.interval||10) : 10)});
@@ -7946,11 +7959,72 @@ async function renderHostTab(){
      <div class="dbar"><div style="width:${dkk.pct}%;background:${sev(dkk.pct)}"></div></div></div>`).join('');
   renderSysInfo();
   renderRamTree();
-  // History chart is local-only for now (no history on remote yet).
-  const cb = document.querySelector('section[data-tab="host"] .chartbox');
-  if(cb && !cb.querySelector('.scope-notice')){
-    // Keep the canvas in place but stack a notice above it.
+  renderHostChart();
+}
+
+// ── System-tab history chart, for whichever host is selected ─────────────────
+// The hub draws itself from D.total (already on the page, no extra request);
+// a remote is fetched from /api/host_history, which reads the host_samples rows
+// the poller has been writing since the multi-host slice. Before this the chart
+// was hardwired to D.total, so selecting a remote left the hub's own CPU/RAM/
+// load curve on screen under that remote's name — the same cross-host bleed the
+// GPU tab was rebuilt to remove.
+let HOSTC_HOST=null, HOSTC_RANGE=null, HOSTC_AT=0, HOSTC_INFLIGHT=null;
+function hostChartDatasets(labels, cpu, ramPct, load1){
+  return {labels, datasets:[
+    {label:'CPU %',data:cpu,          borderColor:'#3fb950',backgroundColor:'#3fb95033',fill:true,pointRadius:0,tension:.3,yAxisID:'y'},
+    {label:'RAM %',data:ramPct,       borderColor:'#a371f7',borderWidth:1.5,pointRadius:0,tension:.3,yAxisID:'y'},
+    {label:'Load', data:load1,        borderColor:'#e3b341',borderWidth:1,pointRadius:0,tension:.3,yAxisID:'y1'}]};
+}
+function hostHistNote(box, text){
+  // The "no history yet" line lives next to the canvas, not inside it — a chart
+  // of nothing is indistinguishable from a chart of zeroes.
+  if(!box) return;
+  let note = box.parentElement.querySelector('.host-hist-note');
+  if(!text){ if(note) note.remove(); return; }
+  if(!note){
+    note = document.createElement('p');
+    note.className = 'cap host-hist-note';
+    box.parentElement.insertBefore(note, box);
   }
+  note.textContent = text;
+}
+async function renderHostChart(force){
+  const cv2 = document.getElementById('host');
+  if(!cv2 || TAB!=='host') return;
+  if(CURRENT_HOST === 'local'){                            // D.total path
+    hostHistNote(cv2.closest('.chartbox'), null);
+    HOSTC_HOST = null;                                     // force a refetch on the way back
+    buildCharts();
+    return;
+  }
+  // Throttle: applyFleet() re-renders this tab on every fleet push, and the
+  // series only moves at the poll interval anyway.
+  const host = CURRENT_HOST, range = R;
+  const stale = force || host!==HOSTC_HOST || range!==HOSTC_RANGE || Date.now()-HOSTC_AT > 10000;
+  if(!stale || HOSTC_INFLIGHT) return;
+  HOSTC_INFLIGHT = (async () => {
+    let j;
+    try{ j = await (await fetch('/api/host_history?host='+encodeURIComponent(host)+'&range='+encodeURIComponent(range))).json(); }
+    catch(e){ return; }
+    if(host!==CURRENT_HOST || range!==R) return;   // user moved on; don't paint
+    HOSTC_HOST=host; HOSTC_RANGE=range; HOSTC_AT=Date.now();
+    const labels=j.labels||[];
+    const box = cv2.closest('.chartbox');
+    if(!labels.length){
+      if(charts['host']){ charts['host'].destroy(); delete charts['host']; }
+      hostHistNote(box, I18N.tf('host.hist_wait','No history for {host} yet — it starts building from its first successful poll.',{host:host}));
+      return;
+    }
+    hostHistNote(box, null);
+    const ramPct=(j.ram_used||[]).map((u,i)=>{
+      const t=(j.ram_total||[])[i];
+      return (u==null||!t) ? null : Math.round(u*100/t);
+    });
+    mk('host',{type:'line',data:hostChartDatasets(fmtLabels(labels), j.cpu||[], ramPct, j.load1||[]),
+      options:dualOpts(labels,100),plugins:[areaBg]});
+  })();
+  try{ await HOSTC_INFLIGHT; } finally { HOSTC_INFLIGHT = null; }
 }
 
 // ── System / Network / Security per-host detail ───────────────────────────────
@@ -8668,7 +8742,10 @@ document.querySelectorAll('.rb').forEach(b=>b.onclick=()=>{R=b.dataset.r;localSt
   document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));loadData();
   if(TAB==='experiments') renderExperiments(true);
   if(TAB==='costs') renderCosts(true);
-  if(TAB==='gpu') renderGpuTab(true);});
+  if(TAB==='gpu') renderGpuTab(true);
+  // A remote's System-tab chart has its own feed, so loadData() above doesn't
+  // re-range it — refetch here or the buttons look dead on every host but the hub.
+  if(TAB==='host' && CURRENT_HOST!=='local') renderHostChart(true);});
 // GPU cockpit view toggle. "What is card 1 doing" (small multiples) and "which
 // card is the problem" (one metric, every card) are different lookups, and the
 // choice sticks so a user who prefers one doesn't re-pick it on every visit.

--- a/tests/snapshots/api_data.json
+++ b/tests/snapshots/api_data.json
@@ -119,5 +119,5 @@
     "up": 0,
     "worst_down": null
   },
-  "version": "0.31.0"
+  "version": "0.30.1"
 }

--- a/tests/snapshots/api_data.json
+++ b/tests/snapshots/api_data.json
@@ -119,5 +119,5 @@
     "up": 0,
     "worst_down": null
   },
-  "version": "0.30.0"
+  "version": "0.31.0"
 }

--- a/tests/snapshots/api_health.json
+++ b/tests/snapshots/api_health.json
@@ -82,9 +82,9 @@
   },
   "update": {
     "available": false,
-    "current": "0.30.0",
+    "current": "0.31.0",
     "self_update_enabled": true
   },
   "updated": 1735689600,
-  "version": "0.30.0"
+  "version": "0.31.0"
 }

--- a/tests/snapshots/api_health.json
+++ b/tests/snapshots/api_health.json
@@ -82,9 +82,9 @@
   },
   "update": {
     "available": false,
-    "current": "0.31.0",
+    "current": "0.30.1",
     "self_update_enabled": true
   },
   "updated": 1735689600,
-  "version": "0.31.0"
+  "version": "0.30.1"
 }

--- a/tests/snapshots/api_settings_get.json
+++ b/tests/snapshots/api_settings_get.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.31.0"
+  "version": "0.30.1"
 }

--- a/tests/snapshots/api_settings_get.json
+++ b/tests/snapshots/api_settings_get.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.30.0"
+  "version": "0.31.0"
 }

--- a/tests/snapshots/api_settings_post.json
+++ b/tests/snapshots/api_settings_post.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.31.0"
+  "version": "0.30.1"
 }

--- a/tests/snapshots/api_settings_post.json
+++ b/tests/snapshots/api_settings_post.json
@@ -45,5 +45,5 @@
     "telegram_token_set": false,
     "webhook_url_set": false
   },
-  "version": "0.30.0"
+  "version": "0.31.0"
 }

--- a/tests/snapshots/healthz.json
+++ b/tests/snapshots/healthz.json
@@ -1,4 +1,4 @@
 {
   "status": "ok",
-  "version": "0.31.0"
+  "version": "0.30.1"
 }

--- a/tests/snapshots/healthz.json
+++ b/tests/snapshots/healthz.json
@@ -1,4 +1,4 @@
 {
   "status": "ok",
-  "version": "0.30.0"
+  "version": "0.31.0"
 }


### PR DESCRIPTION
The System tab failed to fully re-scope when switching from local to a remote host. The top System card updated correctly, but **Top processes**, **Power & cost** and the **CPU/RAM/load chart** kept displaying the hub's data under the remote machine's name.

**Root cause**

`renderTopProcs()` and `renderCost()` each open with a correct "not local → hide myself" guard — and their only caller wrapped them in *the same condition*, so on a remote they were never called, the guard never ran, and the last local paint stayed on screen. The chart had no guard at all; it plots `/api/data`, which is always the hub. This only surfaced on the local → remote *switch*, never on a fresh load of a remote (the cards start hidden), which is how it survived.

**Fix**

- Removed the redundant caller-side condition so the hub-only cards render or hide against the actual host state, and hide on the switch rather than on the next 15-second tick.
- `buildCharts()` charts `D.total` for the hub only.
- Added `/api/host_history?host=&range=` + `host_samples.vitals_series()`. Per-host CPU/RAM/load was already being written by the poller on every successful poll; nothing ever read it back. Fixing the chart meant adding the reader it never had, so it draws the selected machine — raw rows, with an hourly-rollup fallback once raw retention expires.
- A host with no history yet says so beside the canvas instead of drawing an empty chart.

**Verified** on the dev instance (`:9801`) with a headless-browser probe that switches hosts and inspects the resulting DOM and chart data. Against the released code the same probe reproduces the bug — the remote's Top-processes list comes back byte-identical to the hub's and the chart series is unchanged. After the fix: both cards hide, and the chart's data differs from the hub's.

`VERSION` 0.30.0 → **0.30.1** — a patch. This restores behaviour that was broken rather than adding a capability.

Test suite on Python 3.13: 821 passed. The 6 pre-existing failures on `next` (`test_no_silent_swallow`, `test_public_status`) are unchanged by this branch — CI only runs `test_snapshots.py`, which is green after the version rebaseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJEaRVjwRmf6DrXDXmuu7i