### PR TITLE
feat(dashboard): Reduced motion setting to disable gauge animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+Project-specific instructions for AI agents working in this repo. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing contributor guide
+(branching, the "add a monitor" pattern, style) — it applies here too.
+
+## Conventions
+
+- **Animations**: see [`docs/animations.md`](docs/animations.md) before
+  adding any transition, `@keyframes`, or JS-driven value tween. CSS-based
+  animations are covered automatically by the reduced-motion kill switch;
+  JS number tweens must go through `mcCountUp()`, never a new
+  `requestAnimationFrame` loop.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,10 @@ external deps would defeat the "agentless" promise.
   for not knowing something.
 - Match the existing code style — short functions, plain names, comments only
   where the *why* isn't obvious from the code.
+- Adding an animation? See [`docs/animations.md`](docs/animations.md) — CSS
+  transitions/`@keyframes` are covered automatically by the reduced-motion
+  kill switch; JS-driven number tweens must go through `mcCountUp()`, not a
+  new `requestAnimationFrame` loop.
 
 ## Submitting a PR
 

--- a/app.py
+++ b/app.py
@@ -4392,6 +4392,8 @@ SETTING_DEFAULTS = {
     # ── Public status page (#217 follow-up) — Settings-driven toggle so it
     # doesn't require an env-var restart to turn on/off ─────────────────────
     "public_status_enabled": "0",     # "0" / "1"
+    # ── Display preferences ────────────────────────────────────────────────
+    "reduced_motion":       "0",      # "0" (default, matches prior behaviour) / "1" — disables gauge animations
 }
 SETTING_SECRETS = {"discord_webhook_url", "telegram_token", "email_password", "slack_webhook_url", "webhook_url", "api_key", "mlflow_token"}   # never round-tripped to the UI in full
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -1,19 +1,21 @@
 # Animation conventions
 
-The dashboard has a "Reduced motion" setting (Settings → General, backed by
-`reduced_motion` in `SETTING_DEFAULTS`) so people who find the live-refreshing
-gauges exhausting to look at can turn the movement off. It also respects the
-OS-level `prefers-reduced-motion` automatically. Both feed a single JS flag,
-`MC_RM` (`static/dashboard.html`), and a matching DOM attribute,
-`html[data-reduced-motion="1"]`.
+The dashboard has a "Reduced motion" setting (Settings → General, `reduced_motion`
+in `SETTING_DEFAULTS`) and also respects the OS-level `prefers-reduced-motion`.
+Both feed a single JS flag, `MC_RM` (`static/dashboard.html`), and a matching DOM
+attribute, `html[data-reduced-motion="1"]`.
 
-New animations must plug into one of the two mechanisms below — never invent
-a third.
+## Which path does your animation take?
+
+New animations must use one of these two mechanisms — never invent a third.
+
+- **Pure CSS** (`transition`, `@keyframes`) → §1, nothing to do.
+- **JS stepping a value** (e.g. via `requestAnimationFrame`) → §2, route through `mcCountUp()`.
 
 ## 1. CSS transitions / `@keyframes` → nothing to do
 
-Any animation expressed as a CSS `transition` or `@keyframes` is silenced
-automatically by the global kill switch near the top of the `<style>` block:
+A global kill switch near the top of the `<style>` block silences every CSS
+transition/animation in the app:
 
 ```css
 html[data-reduced-motion="1"] *,
@@ -21,26 +23,22 @@ html[data-reduced-motion="1"] *::before,
 html[data-reduced-motion="1"] *::after{transition:none!important;animation:none!important}
 ```
 
-This covers everything — present and future — with zero per-element opt-out.
-If you add a gauge arc, a progress bar, a pulsing badge, anything driven by
-CSS, it's covered the moment it ships. You don't need to check `MC_RM` in
-JS for these; just use ordinary CSS transitions/animations as you normally
-would.
+Write ordinary CSS transitions/animations, no `MC_RM` check needed. A gauge arc,
+a progress bar, a pulsing badge — all covered the moment they ship, present and
+future, with zero per-element opt-out.
 
 ## 2. JS-driven value tweens → route through `mcCountUp()`
 
-Some effects can't be expressed in CSS — the cockpit's count-up numbers are
-the one example today (`mcCountUp()` in `static/dashboard.html`, used for
-every gauge percentage, the burn-rate figures, and the cost cards). It
-manually steps `textContent` over a series of `requestAnimationFrame` calls,
-and it already checks `MC_RM` (and `LIVE_TICK`, so a number doesn't
-re-animate on every ~2s live refresh — a separate concern from reduced
-motion).
+`mcCountUp(el, target, duration, decimals)` (`static/dashboard.html`) steps
+`textContent` over a series of `requestAnimationFrame` calls. It's the one
+JS-driven tween in the app today, used for every gauge percentage, the
+burn-rate figures, and the cost cards. It already checks `MC_RM` (and
+`LIVE_TICK`, so a number doesn't re-animate on every ~2s live refresh — a
+separate concern from reduced motion).
 
-**Rule: don't hand-roll a new `requestAnimationFrame` tween.** Call
-`mcCountUp(el, target, duration, decimals)` instead. It's the single place
-this decision is made, so as long as new code reuses it, new code is
-automatically correct — there's nothing to remember per call site.
+**Don't hand-roll a new `requestAnimationFrame` tween.** Call `mcCountUp()`
+instead — it's the single place this decision is made, so any code that
+reuses it is automatically correct.
 
 If a future effect genuinely can't go through `mcCountUp()` (not a numeric
 text tween), gate it explicitly:
@@ -52,7 +50,8 @@ if(!MC_RM){ /* animate */ } else { /* jump straight to the end state */ }
 ## Why two mechanisms instead of one
 
 A pure-CSS count-up (`@property` + `counter()`) was considered and rejected:
-`counter()` only renders integers, and `mcCountUp()` is shared with decimal
-figures (cost cards use 3 decimal places), so a CSS-only version would need
-a second, parallel implementation — more code, not less, for one function
-that already funnels every call site through a single, already-gated place.
+`counter()` only renders integers, but `mcCountUp()` also drives decimal
+figures (the burn-rate readout uses 3 decimal places). A CSS-only version
+would need a second, parallel implementation for decimals — more code, not
+less, for a function that already funnels every call site through one
+already-gated place.

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -1,0 +1,58 @@
+# Animation conventions
+
+The dashboard has a "Reduced motion" setting (Settings → General, backed by
+`reduced_motion` in `SETTING_DEFAULTS`) so people who find the live-refreshing
+gauges exhausting to look at can turn the movement off. It also respects the
+OS-level `prefers-reduced-motion` automatically. Both feed a single JS flag,
+`MC_RM` (`static/dashboard.html`), and a matching DOM attribute,
+`html[data-reduced-motion="1"]`.
+
+New animations must plug into one of the two mechanisms below — never invent
+a third.
+
+## 1. CSS transitions / `@keyframes` → nothing to do
+
+Any animation expressed as a CSS `transition` or `@keyframes` is silenced
+automatically by the global kill switch near the top of the `<style>` block:
+
+```css
+html[data-reduced-motion="1"] *,
+html[data-reduced-motion="1"] *::before,
+html[data-reduced-motion="1"] *::after{transition:none!important;animation:none!important}
+```
+
+This covers everything — present and future — with zero per-element opt-out.
+If you add a gauge arc, a progress bar, a pulsing badge, anything driven by
+CSS, it's covered the moment it ships. You don't need to check `MC_RM` in
+JS for these; just use ordinary CSS transitions/animations as you normally
+would.
+
+## 2. JS-driven value tweens → route through `mcCountUp()`
+
+Some effects can't be expressed in CSS — the cockpit's count-up numbers are
+the one example today (`mcCountUp()` in `static/dashboard.html`, used for
+every gauge percentage, the burn-rate figures, and the cost cards). It
+manually steps `textContent` over a series of `requestAnimationFrame` calls,
+and it already checks `MC_RM` (and `LIVE_TICK`, so a number doesn't
+re-animate on every ~2s live refresh — a separate concern from reduced
+motion).
+
+**Rule: don't hand-roll a new `requestAnimationFrame` tween.** Call
+`mcCountUp(el, target, duration, decimals)` instead. It's the single place
+this decision is made, so as long as new code reuses it, new code is
+automatically correct — there's nothing to remember per call site.
+
+If a future effect genuinely can't go through `mcCountUp()` (not a numeric
+text tween), gate it explicitly:
+
+```js
+if(!MC_RM){ /* animate */ } else { /* jump straight to the end state */ }
+```
+
+## Why two mechanisms instead of one
+
+A pure-CSS count-up (`@property` + `counter()`) was considered and rejected:
+`counter()` only renders integers, and `mcCountUp()` is shared with decimal
+figures (cost cards use 3 decimal places), so a CSS-only version would need
+a second, parallel implementation — more code, not less, for one function
+that already funnels every call site through a single, already-gated place.

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -6,6 +6,14 @@
 <script src="/static/chart.min.js" onerror="this.remove();var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"></script>
 <script src="/static/html2canvas.min.js" onerror="this.remove();var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js';document.head.appendChild(s)"></script>
 <style>
+/* Reduced-motion kill switch — covers OS prefers-reduced-motion AND the
+   Settings > General "Reduced motion" toggle (applyReducedMotion() sets this
+   attribute). Any transition or @keyframes animation added anywhere in the
+   app, present or future, is silenced by this rule alone — no per-element
+   opt-out needed. See docs/animations.md. */
+html[data-reduced-motion="1"] *,
+html[data-reduced-motion="1"] *::before,
+html[data-reduced-motion="1"] *::after{transition:none!important;animation:none!important}
 :root{--mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,Consolas,monospace}
 :root,[data-theme="dark"]{--bg:#0d1117;--card:#161b22;--bd:#30363d;--tx:#e6edf3;--mut:#8b949e;--accent:#d29922;--free:#21262d;
 --crit:#f85149;--warn:#d29922;--ok:#3fb950;--info:#58a6ff;
@@ -6847,8 +6855,14 @@ function renderFleet(){
 // plain value displays. applyReducedMotion() re-derives this whenever the
 // setting loads or changes and repaints the cockpit so it takes effect live.
 let MC_RM = matchMedia('(prefers-reduced-motion: reduce)').matches;
+function setReducedMotionAttr(on){
+  if(on) document.documentElement.setAttribute('data-reduced-motion','1');
+  else document.documentElement.removeAttribute('data-reduced-motion');
+}
+setReducedMotionAttr(MC_RM);
 function applyReducedMotion(settingOn){
   const next = matchMedia('(prefers-reduced-motion: reduce)').matches || !!settingOn;
+  setReducedMotionAttr(next);
   if(next === MC_RM) return;
   MC_RM = next;
   if(typeof paintMissionControl==='function' && typeof TAB!=='undefined' && TAB==='overview') paintMissionControl();

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -2423,6 +2423,12 @@ with homelab.run("my-finetune", params={"lr":2e-4}) as r:
           <input type="number" id="al_retention_days" min="1" max="3650" step="1" class="field" style="max-width:160px">
           <p class="cap" style="margin-top:4px" data-i18n-html="general.retention_cap" data-i18n-def="How many days of metric history to keep. Older rows are pruned every ~6 minutes. Default: 180.">How many days of metric history to keep. Older rows are pruned every ~6 minutes. Default: 180.</p>
         </div>
+        <div>
+          <label style="display:flex;align-items:center;gap:9px;margin:4px 0">
+            <input type="checkbox" id="al_reduced_motion">
+            <span data-i18n-html="general.reduced_motion_label"><b>Reduced motion</b> — turn off gauge animations, gauges just show the current value.</span>
+          </label>
+        </div>
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
           <button class="rb on" id="al_save_general" data-i18n="btn.save">Save</button>
         </div>
@@ -5602,6 +5608,8 @@ async function loadAlerts(){
   document.getElementById('al_gpu_fanstall').checked   = (s.gpu_fanstall_alerts||'1')==='1';
   document.getElementById('al_gpu_missing').checked    = (s.gpu_missing_alerts||'1')==='1';
   document.getElementById('al_retention_days').value = s.retention_days||'180';
+  document.getElementById('al_reduced_motion').checked = s.reduced_motion==='1';
+  applyReducedMotion(s.reduced_motion==='1');
   document.getElementById('al_kwh').value         = s.kwh_price||'';
   document.getElementById('al_currency').value    = s.currency||'$';
   document.getElementById('al_kwh_night').value   = s.kwh_price_night||'';
@@ -5758,6 +5766,7 @@ function collectSettingsBody(){
     gpu_fanstall_alerts:    document.getElementById('al_gpu_fanstall').checked ? '1' : '0',
     gpu_missing_alerts:     document.getElementById('al_gpu_missing').checked ? '1' : '0',
     retention_days:   (v=>{const n=parseInt(v,10);return v.trim()===''?'180':String(isNaN(n)?180:Math.max(1,n));})(document.getElementById('al_retention_days').value),
+    reduced_motion:   document.getElementById('al_reduced_motion').checked ? '1' : '0',
     kwh_price:        document.getElementById('al_kwh').value.trim(),
     currency:         document.getElementById('al_currency').value.trim()||'$',
     tariff_mode:      TARIFF_DUAL ? 'dual' : 'single',
@@ -5844,8 +5853,10 @@ const AUTOSAVE_IDS=['al_enabled','al_ntfy_topic','al_ntfy_server','al_telegram_c
   'al_email_user','al_email_pass','al_discord','al_slack','al_webhook','al_minlevel','al_disk',
   'al_kwh','al_currency','al_kwh_night','al_night_start','al_night_end','al_idle_w','al_mlflow_uri',
   'al_mlflow_token','al_country','al_brief_enabled','al_brief_time','al_brief_channel','al_brief_theme',
-  'al_public_status_enabled','al_retention_days'];
+  'al_public_status_enabled','al_retention_days','al_reduced_motion'];
 function wireAutoSave(){
+  const rmChk=document.getElementById('al_reduced_motion');
+  if(rmChk) rmChk.addEventListener('change', () => applyReducedMotion(rmChk.checked));
   AUTOSAVE_IDS.forEach(id=>{ const el=document.getElementById(id); if(el) el.addEventListener('change', scheduleAutoSave); });
   // Tariff mode is toggled by buttons (no change event) — autosave on those too.
   ['al_mode_single','al_mode_dual'].forEach(id=>{ const el=document.getElementById(id); if(el) el.addEventListener('click', scheduleAutoSave); });
@@ -6831,7 +6842,17 @@ function renderFleet(){
 // undefined on the first paint. Only does work when TAB==='overview'. The four
 // legacy Overview cards (#fleet_tbl, #ai-band, #mcpcard, #diagcard) are untouched
 // and keep being driven by renderFleet()/renderAiBand()/renderHealth().
-const MC_RM = matchMedia('(prefers-reduced-motion: reduce)').matches;
+// True when either the OS-level "prefers-reduced-motion" is set or the user
+// opted into the "Reduced motion" setting — either source turns gauges into
+// plain value displays. applyReducedMotion() re-derives this whenever the
+// setting loads or changes and repaints the cockpit so it takes effect live.
+let MC_RM = matchMedia('(prefers-reduced-motion: reduce)').matches;
+function applyReducedMotion(settingOn){
+  const next = matchMedia('(prefers-reduced-motion: reduce)').matches || !!settingOn;
+  if(next === MC_RM) return;
+  MC_RM = next;
+  if(typeof paintMissionControl==='function' && typeof TAB!=='undefined' && TAB==='overview') paintMissionControl();
+}
 const MC_AC = {ok:'var(--ok)', warn:'var(--warn)', crit:'var(--crit)', info:'var(--info)'};
 // D.insights use level=critical|warning|ok|info; map to our short keys.
 const MC_LVL = {critical:'crit', warning:'warn', warn:'warn', crit:'crit', ok:'ok', info:'info'};
@@ -7155,7 +7176,7 @@ function mcPaintEngine($, g, gx, host){
     arc.style.strokeDashoffset=Math.max(0,100-Math.min(100,arcPct));
     ring.style.transition=MC_RM?'none':'stroke-dashoffset 1.4s cubic-bezier(.2,.8,.2,1)';
     ring.style.strokeDashoffset=Math.max(0,100-Math.min(100,ringPct));
-    m.forEach((mm,i)=>{ const bar=$(['mc-m1bar','mc-m2bar','mc-m3bar'][i]); bar.style.transition='width 1.2s cubic-bezier(.2,.8,.2,1)'; bar.style.width=Math.min(100,Math.max(0,mm.w))+'%'; });
+    m.forEach((mm,i)=>{ const bar=$(['mc-m1bar','mc-m2bar','mc-m3bar'][i]); bar.style.transition=MC_RM?'none':'width 1.2s cubic-bezier(.2,.8,.2,1)'; bar.style.width=Math.min(100,Math.max(0,mm.w))+'%'; });
   }));
   // per-GPU breakdown when the focused host is a multi-GPU box
   const exH=$('mc-vitals-extra');
@@ -7219,7 +7240,7 @@ function mcApplyEngine($, V){
   requestAnimationFrame(()=>requestAnimationFrame(()=>{
     arc.style.transition=MC_RM?'none':'stroke-dashoffset 1.4s cubic-bezier(.2,.8,.2,1)'; arc.style.strokeDashoffset=Math.max(0,100-Math.min(100,V.arcPct||0));
     ring.style.transition=MC_RM?'none':'stroke-dashoffset 1.4s cubic-bezier(.2,.8,.2,1)'; ring.style.strokeDashoffset=Math.max(0,100-Math.min(100,V.ringPct||0));
-    M.forEach((mm,i)=>{ const b=$(['mc-m1bar','mc-m2bar','mc-m3bar'][i]); b.style.transition='width 1.2s cubic-bezier(.2,.8,.2,1)'; b.style.width=Math.min(100,Math.max(0,mm.w||0))+'%'; });
+    M.forEach((mm,i)=>{ const b=$(['mc-m1bar','mc-m2bar','mc-m3bar'][i]); b.style.transition=MC_RM?'none':'width 1.2s cubic-bezier(.2,.8,.2,1)'; b.style.width=Math.min(100,Math.max(0,mm.w||0))+'%'; });
   }));
   const ex=$('mc-vitals-extra'); if(ex) ex.innerHTML=mcBreakdownHTML(V.breakdown||[]);
 }
@@ -9102,6 +9123,9 @@ document.getElementById('updcopy').onclick = async () => {
 document.getElementById('updnowbtn').onclick = startSelfUpdate;
 showTab(TAB);
 loadData(); loadHealth(); loadFleet();
+// Pick up the reduced-motion preference before the Settings tab is ever
+// opened — otherwise gauges would animate on first paint regardless of it.
+(async () => { try{ const j=await(await fetch('/api/settings')).json(); applyReducedMotion(j&&j.settings&&j.settings.reduced_motion==='1'); }catch(e){} })();
 
 // ── Live values over SSE, history on a timer ─────────────────────────────────
 // Two cadences instead of one. `/api/stream` pushes the live values the moment

--- a/tests/snapshots/api_settings_get.json
+++ b/tests/snapshots/api_settings_get.json
@@ -37,6 +37,7 @@
     "ntfy_server": "https://ntfy.sh",
     "ntfy_topic": "",
     "public_status_enabled": "0",
+    "reduced_motion": "0",
     "retention_days": "180",
     "slack_webhook_url_set": false,
     "system_idle_watts": "",

--- a/tests/snapshots/api_settings_post.json
+++ b/tests/snapshots/api_settings_post.json
@@ -37,6 +37,7 @@
     "ntfy_server": "https://ntfy.sh",
     "ntfy_topic": "",
     "public_status_enabled": "0",
+    "reduced_motion": "0",
     "retention_days": "180",
     "slack_webhook_url_set": false,
     "system_idle_watts": "",


### PR DESCRIPTION
## Summary
- Adds a "Reduced motion" toggle (Settings → General, `reduced_motion` setting, default off) that turns off the Overview cockpit's gauge/count-up/meter-bar animations — gauges just show the current value. Also respects OS-level `prefers-reduced-motion` automatically.
- Adds a global CSS kill switch (`html[data-reduced-motion="1"] * { transition:none!important; animation:none!important }`) so any future CSS-based animation is covered automatically, no per-element opt-out needed.
- Documents the convention in `docs/animations.md` — CSS is auto-covered; JS-driven number tweens must go through the existing `mcCountUp()` helper rather than a new `requestAnimationFrame` loop — and links it from `CONTRIBUTING.md` and a new `CLAUDE.md`.

## Test plan
- [x] Verified in-browser (chrome-devtools): checkbox appears in Settings → General, toggling flips `MC_RM` and the `data-reduced-motion` attribute instantly, persists via autosave, survives reload, and default (off) preserves the original animated behavior.
- [x] Confirmed the three tri-gauge arcs render with `transition: none` (computed style) when enabled, and the normal `1.1s cubic-bezier` transition when disabled.
- [x] `app.py` parses; all inline `<script>` blocks in `dashboard.html` parse.
- [x] Booted the app locally on this branch (based on `next`) and spot-checked Overview, Costs, Containers tabs — no new console errors (only a pre-existing 404 for vendored JS outside Docker, which self-heals via the existing CDN fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)