### PR TITLE
fix(charts): keep the charts moving between history polls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Byte-compile the app
         run: python -m py_compile app.py probe.py
 
+      # Structural guards on the dashboard's refresh loop. Pure stdlib (re +
+      # pathlib over static/dashboard.html), so pytest is the only dependency —
+      # the snapshot job's flask/prometheus stack isn't needed here.
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Dashboard refresh-loop invariants
+        run: python -m pytest tests/test_dashboard_refresh_invariants.py -q
+
       # The dashboard is one HTML file with no build step, so there is no npm
       # project here and nothing to install: this lifts the refresh-loop and
       # live-tail functions straight out of static/dashboard.html and runs them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Byte-compile the app
         run: python -m py_compile app.py probe.py
 
+      # The dashboard is one HTML file with no build step, so there is no npm
+      # project here and nothing to install: this lifts the refresh-loop and
+      # live-tail functions straight out of static/dashboard.html and runs them
+      # against a fake clock on the runner's preinstalled Node.
+      - name: Dashboard refresh-loop behaviour
+        run: node tests/js/test_refresh_loop.js
+
       - name: Build the image
         run: docker build -t homelab-monitor:ci .
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -3675,7 +3675,7 @@ function gpuStatusPill(card){
 }
 
 // One small-multiple panel per card.
-function gpuMiniCard(card, d, ranges){
+function gpuMiniCardBody(card, d, ranges){
   const now = card.now || {};
   const spans = spansToIdx(card.throttle_spans, d.labels);
   const rows = GPU_SPARK_ROWS.map(m=>{
@@ -3726,14 +3726,52 @@ function gpuMiniCard(card, d, ranges){
     now.temp!=null ? Math.round(now.temp)+'°C' : null,
   ].filter(Boolean).join(' · ');
 
-  return `<div class="gpu-mini st-${card.status}" tabindex="0" role="button" data-idx="${card.idx}"
-       aria-label="${I18N.tf('gpu.card_aria','GPU {n} details',{n:card.idx})}">
-    <div class="gpu-mini-h"><b>GPU ${card.idx}</b><span class="nm" title="${esc(card.name)}">${esc(card.name)}</span>${gpuStatusPill(card)}</div>
+  return `<div class="gpu-mini-h"><b>GPU ${card.idx}</b><span class="nm" title="${esc(card.name)}">${esc(card.name)}</span>${gpuStatusPill(card)}</div>
     <div class="gpu-mini-now">${stats || (card.status==='retired' && card.last_seen
         ? I18N.tf('gpu.last_seen','last reported {t}',{t:relTime(card.last_seen)})
         : I18N.t('gpu.no_live','no live reading'))}</div>
-    ${rows}${attrib}
-  </div>`;
+    ${rows}${attrib}`;
+}
+
+// The wrapper carries the click/keyboard handlers, the focus ring and the status
+// class; the body is everything that changes as the card runs. Keeping them
+// separate is what lets the live path refresh the numbers and sparklines every
+// couple of seconds without rebuilding the element under the pointer.
+function gpuMiniCard(card, d, ranges){
+  return `<div class="gpu-mini st-${card.status}" tabindex="0" role="button" data-idx="${card.idx}"
+       aria-label="${I18N.tf('gpu.card_aria','GPU {n} details',{n:card.idx})}">${gpuMiniCardBody(card, d, ranges)}</div>`;
+}
+
+// Refresh the small multiples in place off a live frame.
+//
+// The old path only ever repainted these on the 60s history fetch, because the
+// full render replaces #pergpu wholesale and re-binds every handler — doing that
+// twice a second would fight the pointer and drop focus mid-keyboard-nav. But
+// per-card temp/watts/util are the fastest-moving numbers on the page, so on the
+// small-multiples view the whole grid sat still while the detail chart behind it
+// (a Chart.js in-place update) tracked live. Same data, two different answers.
+//
+// Writing only each card's body leaves the wrapper — and therefore its handlers,
+// its focus and its tabindex — untouched. Anything structural (a card appearing,
+// retiring, changing status) still goes through the full render.
+function updateGpuCardsLive(d){
+  const box = document.getElementById('pergpu');
+  if(!box || box.hidden || GPU_VIEW !== 'card' || !d || !d.has_gpu) return false;
+  const els = box.querySelectorAll('.gpu-mini');
+  const cards = d.cards || [];
+  if(!els.length || els.length !== cards.length) return false;   // structure changed: let the full render own it
+  const ranges = {};
+  GPU_SPARK_ROWS.forEach(m=>{ ranges[m] = gpuSharedRange(cards, m) || {}; });
+  let painted = 0;
+  els.forEach(el=>{
+    const card = cards.find(c=>String(c.idx) === el.dataset.idx);
+    if(!card) return;
+    const cls = 'gpu-mini st-' + card.status;
+    if(el.className !== cls) el.className = cls;
+    el.innerHTML = gpuMiniCardBody(card, d, ranges);
+    painted++;
+  });
+  return painted > 0;
 }
 
 // Fetch + paint the whole GPU tab for whichever host is selected.
@@ -9324,7 +9362,8 @@ function paintLiveCharts(){
     // own, whatever buildCharts() does or doesn't guard.
     if(TAB==='host'){ if(CURRENT_HOST==='local') buildCharts(); return; }   // overview repaints via renderMissionControl()
     if(TAB==='gpu' && GPUC && GPUC.has_gpu){
-      if(GPU_VIEW!=='card') renderGpuMetricChart(GPUC);   // small multiples stay on the history cadence
+      if(GPU_VIEW!=='card') renderGpuMetricChart(GPUC);
+      else                  updateGpuCardsLive(GPUC);   // in place: never rebuild the grid under the pointer
       renderGpuCombined(GPUC);
       renderGpuKpis(GPUC);
     }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -9237,6 +9237,19 @@ function mergeLiveTail(n){
   const keys=['util','mem','mempk','power','temp','cpu','ram_used','ram_total','load1','ctemp'];
   const arrs=keys.map(k=>t[k]).filter(Array.isArray);
   if(!arrs.length) return false;
+  // D.total is not the only thing indexed against D.labels. The per-service
+  // memory series, the "other" remainder and every per-device disk-I/O series
+  // are the same length and read with the same indices (_dioSpark draws them
+  // against D.labels), so they have to slide on a bucket rollover too — else
+  // the Disk I/O sparklines sit one bucket out of step until the next poll.
+  // Nothing live is folded into them: they take the null tail the server itself
+  // writes for a bucket it has not sampled yet.
+  if(Array.isArray(D.other)) arrs.push(D.other);
+  Object.keys(D.services||{}).forEach(k=>{ if(Array.isArray(D.services[k])) arrs.push(D.services[k]); });
+  Object.keys(D.disk_io||{}).forEach(dev=>{
+    const s=D.disk_io[dev]||{};
+    ['read_mb_s','write_mb_s','util_pct'].forEach(k=>{ if(Array.isArray(s[k])) arrs.push(s[k]); });
+  });
   const i=_tailSlot(D.labels, arrs, D.bucket_sec, ts, LIVE_TAIL, D.interval);
   if(i<0) return false;
   const c=LIVE_TAIL.n, H=n.host||{};
@@ -9302,7 +9315,14 @@ function mergeGpuTail(n){
 // one to redraw and shows nobody anything, and showTab() rebuilds on the way in.
 function paintLiveCharts(){
   try{
-    if(TAB==='host'){ buildCharts(); return; }         // overview repaints via renderMissionControl()
+    // Hub-only, and guarded here rather than trusting buildCharts() to do it.
+    // D is always this hub's own series, so driving the System chart from a live
+    // frame while a remote machine is selected animates the hub's CPU/RAM/load
+    // convincingly under the remote's name — a wrong answer that now moves every
+    // two seconds instead of sitting still. mergeGpuTail() scopes itself the same
+    // way. Keeping the check in this function means the branch is correct on its
+    // own, whatever buildCharts() does or doesn't guard.
+    if(TAB==='host'){ if(CURRENT_HOST==='local') buildCharts(); return; }   // overview repaints via renderMissionControl()
     if(TAB==='gpu' && GPUC && GPUC.has_gpu){
       if(GPU_VIEW!=='card') renderGpuMetricChart(GPUC);   // small multiples stay on the history cadence
       renderGpuCombined(GPUC);

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -3351,6 +3351,7 @@ function showTab(id){
 async function loadData(){
   try{ D = await(await fetch('/api/data?range='+R)).json(); }
   catch(e){ document.getElementById('lastup').textContent='offline'; return; }
+  LIVE_TAIL={b:null,n:0};   // fresh authoritative series: start folding again from it
   renderData();
   if(TAB==='disks') renderDisksTab();   // populate/refresh disk cards (sig-guarded; won't wipe a scan)
 }
@@ -3552,6 +3553,10 @@ function renderGpuSpill(n){
 let GPUC = null;               // last /api/gpu/history payload
 let GPUC_ATTR = null;          // last /api/gpu/attribution payload
 let GPUC_HOST = null, GPUC_RANGE = null, GPUC_INFLIGHT = null;
+// Live-tail bookkeeping (bucket start + how many samples are folded into it).
+// Declared up here, not next to the merge code far below, so the loaders that
+// reset it can never run against a name that isn't initialised yet.
+let LIVE_TAIL={b:null,n:0}, GPU_TAIL={b:null,n:0};
 let GPU_VIEW = 'card';         // 'card' small multiples | 'metric' one metric, all cards
 let GPU_METRIC = 'temp';
 
@@ -3758,6 +3763,7 @@ async function renderGpuTab(force){
   finally{ if(GPUC_INFLIGHT === host+'|'+range) GPUC_INFLIGHT = null; }
   if(host !== CURRENT_HOST || range !== R) return;   // user moved on; don't paint
   GPUC = hist; GPUC_ATTR = attr; GPUC_HOST = host; GPUC_RANGE = range;
+  GPU_TAIL={b:null,n:0};   // fresh authoritative series: start folding again from it
   paintGpuTab(false);
 }
 
@@ -3806,8 +3812,33 @@ function paintGpuTab(loading){
   if(title) title.innerHTML = `${sic('gpu')} ${I18N.tf('gpu.pooled_title','GPU on {host}',{host:esc(d.host)})}`
     + (p.model ? ` <span class="muted" style="font-weight:400;font-size:13px">· ${esc(p.model)}</span>` : '');
 
-  // Pooled KPIs, each with its own sparkline: the snapshot and the trend in one
-  // eye movement. The sub-line is the fleet-relevant fact, not the number again.
+  renderGpuKpis(d);
+
+  const pcap = document.getElementById('gpu-pooled-cap');
+  if(pcap){
+    pcap.textContent = d.online
+      ? I18N.tf('gpu.pooled_cap','Live · updated {t} · history every {i}s',{t:relTime(d.at), i:d.interval})
+      : I18N.tf('gpu.pooled_cap_off','Host offline — showing the last snapshot from {t}',{t:relTime(d.at)});
+  }
+
+  renderGpuDetail(gpuPooledExtra(d), p.power);
+  renderGpuAlertStrip(d);
+  renderGpuHealth(d);
+  renderGpuCards(d);
+  renderGpuCombined(d);
+  renderGpuAttribution(d, GPUC_ATTR);
+  renderGpuNow(d);
+}
+
+// Pooled KPIs, each with its own sparkline: the snapshot and the trend in one
+// eye movement. The sub-line is the fleet-relevant fact, not the number again.
+// Split out of paintGpuTab() so the live path can refresh just these tiles every
+// couple of seconds — they read now_pooled, which the stream already carries,
+// and used to sit still until the next 60s history fetch.
+function renderGpuKpis(d){
+  const box = document.getElementById('gpukpis');
+  if(!box || !d || !d.has_gpu) return;
+  const p = d.now_pooled || {};
   const C = d.combined || {};
   const memPct = p.mem_total ? Math.round(p.mem_used/p.mem_total*100) : 0;
   const hotN = (d.cards||[]).filter(c=>(c.now&&c.now.temp||0) >= d.hot_c).length;
@@ -3833,21 +3864,6 @@ function paintGpuTab(loading){
                            min: GPU_METRICS[t.m] && GPU_METRICS[t.m].max===100 ? 0 : null}) : '';
     return `<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div>${sp}<div class="s">${t.s||''}</div></div>`;
   }).join('');
-
-  const pcap = document.getElementById('gpu-pooled-cap');
-  if(pcap){
-    pcap.textContent = d.online
-      ? I18N.tf('gpu.pooled_cap','Live · updated {t} · history every {i}s',{t:relTime(d.at), i:d.interval})
-      : I18N.tf('gpu.pooled_cap_off','Host offline — showing the last snapshot from {t}',{t:relTime(d.at)});
-  }
-
-  renderGpuDetail(gpuPooledExtra(d), p.power);
-  renderGpuAlertStrip(d);
-  renderGpuHealth(d);
-  renderGpuCards(d);
-  renderGpuCombined(d);
-  renderGpuAttribution(d, GPUC_ATTR);
-  renderGpuNow(d);
 }
 
 // Small multiples, or the by-metric chart — same data, two questions.
@@ -5345,13 +5361,27 @@ function dualOpts(labels,ymax){const grid=cv('--free'),tick=cv('--mut'),leg=cv('
 // peak still lands.
 function mk(id,cfg){
   const c=charts[id];
+  // Inline plugins are part of the shape. They are closures over the payload
+  // they were built from — the GPU throttle bands close over d.cards, the
+  // threshold line over d.hot_c, the VRAM capacity line over d.capacity_mb — and
+  // a chart keeps the plugin objects it was constructed with. Ignoring them here
+  // meant the bands and the cap line stayed frozen at page-load state for the
+  // life of the tab while the lines underneath them moved.
+  const curP = (c && c.config.plugins) || [];
+  const newP = cfg.plugins || [];
+  const samePlugins = curP.length===newP.length
+    && curP.every((p,i)=>p && newP[i] && p.id===newP[i].id);
   const sameShape = c && c.config.type===cfg.type
     && c.data.datasets.length===cfg.data.datasets.length
-    && c.data.datasets.every((ds,i)=>ds.label===cfg.data.datasets[i].label);
+    && c.data.datasets.every((ds,i)=>ds.label===cfg.data.datasets[i].label)
+    && samePlugins;
   if(sameShape){
     c.data.labels=cfg.data.labels;
     cfg.data.datasets.forEach((ds,i)=>Object.assign(c.data.datasets[i],ds));
     if(cfg.options) c.options=cfg.options;
+    // Copy the fresh hooks onto the objects Chart.js already holds, rather than
+    // swapping the array — the chart's plugin list is read once at construction.
+    newP.forEach((p,i)=>Object.assign(curP[i],p));
     c.update('none');   // no entry animation: this is a refresh, not a redraw
     return;
   }
@@ -7286,7 +7316,14 @@ function renderMcChart(){
   const hasGpu=!!(HH&&HH.now&&HH.now.gpu&&HH.now.gpu.available);
   const useGpu=(MC_HEROMODE!=='fcpu') && hasGpu && (t.util&&t.util.length);
   const rng=(typeof R!=='undefined'&&R)||'6h';
-  const sig=(useGpu?'g':'c')+'_'+D.labels.length+'_'+(D.labels[D.labels.length-1]||0)+'_'+rng+'_'+(document.documentElement.getAttribute('data-theme')||'');
+  // The signature has to include the values, not just the bucket labels. The
+  // newest bucket keeps being re-averaged (and, between polls, updated from the
+  // live stream) under a label that does not change until the bucket closes —
+  // a label-only signature held this chart still for a whole bucket at a time
+  // while every tile around it moved.
+  const tl=a=>{ const v=(a&&a.length)?a[a.length-1]:null; return v==null?'-':(+v).toFixed(2); };
+  const sig=(useGpu?'g':'c')+'_'+D.labels.length+'_'+(D.labels[D.labels.length-1]||0)+'_'+rng+'_'+(document.documentElement.getAttribute('data-theme')||'')
+    +'_'+(useGpu ? tl(t.util)+tl(t.power)+tl(t.temp) : tl(t.cpu)+tl(t.ram_used)+tl(t.load1));
   const titleEl=document.getElementById('mc-chart-title'), tagEl=document.getElementById('mc-chart-tag');
   if(titleEl) titleEl.textContent = useGpu ? I18N.t('mc.chart_gpu','GPU · util, power & temp') : I18N.t('mc.chart_cpu','CPU, RAM & load');
   if(tagEl) tagEl.textContent = I18N.tf('mc.last_range','last {r}',{r:rng});
@@ -8665,7 +8702,12 @@ document.addEventListener('lang:changed', ()=>{
   if(TAB==='disks')       safe(()=>{ const r=document.getElementById('disksbody'); if(r) r.dataset.sig=''; renderDisksTab(); });
 });
 document.querySelectorAll('.rb').forEach(b=>b.onclick=()=>{R=b.dataset.r;localStorage.setItem('hl_range',R);
-  document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));loadData();
+  document.querySelectorAll('.rb').forEach(x=>x.classList.toggle('on',x.dataset.r===R));
+  // Re-arm after the new range lands, not before: the poll period is derived
+  // from D.bucket_sec, so re-arming synchronously would just re-apply the old
+  // range's period. Switching 24h -> 1h otherwise left the page waiting out the
+  // remains of a 60s tick before it started refreshing at the new range's pace.
+  loadData().then(()=>scheduleHistory(true)).catch(()=>scheduleHistory(true));
   if(TAB==='experiments') renderExperiments(true);
   if(TAB==='costs') renderCosts(true);
   if(TAB==='gpu') renderGpuTab(true);});
@@ -9115,8 +9157,159 @@ loadData(); loadHealth(); loadFleet();
 // got slower, and a backgrounded tab now costs nothing at all instead of
 // fetching the full payload every 15 seconds forever.
 let LIVE_ES=null, LIVE_ON=false, LIVE_REV_SEEN=-1, HIST_TIMER=null;
+// When the last `now`/`fleet` frame landed. A stream can stop delivering without
+// ever firing onerror (a dead TCP connection the browser hasn't noticed yet), and
+// LIVE_ON only ever tracked connection *events* — so the page could sit forever
+// believing it was live: history pinned to the slow cadence and, because
+// refreshHistory() gates the fleet poll on !LIVE_ON, the fleet never polled at all.
+let LIVE_LAST_FRAME=0;
 
 const autoOn = () => { const el=document.getElementById('auto'); return !el || el.checked; };
+
+// A stream that has gone quiet for far longer than its own frame interval is not
+// live, whatever the connection says. The server pushes `now` every
+// FAST_INTERVAL (~2s) and a keepalive comment at worst every 20s — but comments
+// don't surface as events, so the threshold has to clear that keepalive.
+function liveStale(){
+  if(!LIVE_LAST_FRAME) return false;                  // nothing has arrived yet
+  const iv = ((D && D.fast_interval) || 2) * 1000;
+  return (Date.now() - LIVE_LAST_FRAME) > Math.max(6*iv, 45000);
+}
+
+// Note a frame arriving, and recover if the watchdog had written the stream off.
+function noteLiveFrame(){
+  LIVE_LAST_FRAME = Date.now();
+  if(!LIVE_ON){ LIVE_ON = true; scheduleHistory(); }
+}
+
+// ── Live tail ────────────────────────────────────────────────────────────────
+// /api/data and /api/gpu/history bucket their series — 60s on the default 6h
+// range, 240s on 24h — so the newest point only moves when a whole bucket
+// closes, while the tiles above it move every 2s off the stream. That gap is
+// what made the charts look stuck: on 6h a new point took up to ~120s to appear.
+//
+// The stream already carries every value the newest bucket is made of, so fold
+// each frame into that bucket on the client instead of asking the server again.
+// Within a bucket we keep a running mean, which converges on the AVG() the
+// server will send, so the next authoritative /api/data barely moves the point
+// instead of snapping it. VRAM is the exception: it is a step metric, and
+// averaging it is exactly what hid a model load, so it carries the latest value.
+// (LIVE_TAIL / GPU_TAIL are declared with the chart state further up.)
+
+// Running mean of `n` samples, given the previous mean.
+const _tailMean=(prev,v,n)=>(prev==null||n<=1)?v:prev+(v-prev)/n;
+
+// Slide the window: append a bucket and drop the oldest, so the arrays keep the
+// length the server sent and the x-axis scrolls instead of growing.
+function _tailPush(labels, arrs, bucket){
+  labels.push(bucket); labels.shift();
+  arrs.forEach(a=>{ a.push(null); a.shift(); });
+}
+
+// Fold one live frame into the newest bucket of a labelled series set.
+// Returns the index to write at, or -1 when the frame doesn't belong.
+//
+// Picking the sample count back up matters. A fresh poll lands with the server's
+// own average of however many samples are already in the open bucket; resuming
+// at n=1 would let the very next frame slam the instantaneous value straight
+// over it, which is the jitter this is meant to avoid. So when we start tracking
+// a bucket we haven't been folding into, seed the count from how far into the
+// bucket we are — the live value then nudges the average instead of replacing it.
+function _tailSlot(labels, arrs, bucketSec, ts, state, intervalSec){
+  if(!Array.isArray(labels) || labels.length<2 || !bucketSec || !ts) return -1;
+  const bucket = Math.floor(ts/bucketSec)*bucketSec;
+  const last = labels[labels.length-1];
+  if(bucket < last) return -1;                       // frame older than the series
+  if(bucket > last){
+    _tailPush(labels, arrs, bucket);
+    state.b=bucket; state.n=0;                       // genuinely empty bucket
+  } else if(state.b !== bucket){
+    state.b=bucket;
+    state.n=Math.max(0, Math.floor((ts-bucket)/Math.max(1, intervalSec||10)));
+  }
+  state.n++;
+  return labels.length-1;
+}
+
+function mergeLiveTail(n){
+  if(!D || !D.total || !n) return false;
+  const t=D.total, ts=n.fast_ts||n.ts;
+  const keys=['util','mem','mempk','power','temp','cpu','ram_used','ram_total','load1','ctemp'];
+  const arrs=keys.map(k=>t[k]).filter(Array.isArray);
+  if(!arrs.length) return false;
+  const i=_tailSlot(D.labels, arrs, D.bucket_sec, ts, LIVE_TAIL, D.interval);
+  if(i<0) return false;
+  const c=LIVE_TAIL.n, H=n.host||{};
+  const set=(k,v,mode)=>{ const a=t[k]; if(!Array.isArray(a)||v==null) return;
+    a[i] = mode==='last' ? v
+         : mode==='max'  ? Math.max(a[i]==null?v:a[i], v)
+         : _tailMean(a[i], v, c); };
+  set('cpu',H.cpu); set('ram_used',H.ram_used); set('ram_total',H.ram_total);
+  set('load1',H.load1); set('ctemp',H.ctemp);
+  // The sampler stores NULL in the GPU columns when there is no GPU, so history
+  // skips the gap instead of drawing a fake zero. Don't invent one here either.
+  if(n.gpu_avail){
+    set('util',n.util); set('power',n.power); set('temp',n.temp);
+    set('mem',n.mem_used,'last'); set('mempk',n.mem_used,'max');
+  }
+  return true;
+}
+
+// Same fold for the GPU tab, whose charts read /api/gpu/history rather than
+// /api/data. Hub-scoped: the live frame is this box's, so a remote's cockpit
+// must keep its own polled series.
+function mergeGpuTail(n){
+  if(!GPUC || !GPUC.has_gpu || !n || !n.gpu_avail) return false;
+  if(CURRENT_HOST!=='local' || GPUC.host!=='local') return false;
+  const C=GPUC.combined||{}, ts=n.fast_ts||n.ts;
+  const arrs=[];
+  ['util','vram','vram_total','power','temp_max','fan_max'].forEach(k=>{ if(Array.isArray(C[k])) arrs.push(C[k]); });
+  (GPUC.cards||[]).forEach(cd=>Object.keys(cd.series||{}).forEach(k=>{ if(Array.isArray(cd.series[k])) arrs.push(cd.series[k]); }));
+  if(!arrs.length) return false;
+  const i=_tailSlot(GPUC.labels, arrs, GPUC.bucket_sec, ts, GPU_TAIL, GPUC.interval);
+  if(i<0) return false;
+  const c=GPU_TAIL.n, live=n.gpus||[];
+  const put=(a,v,mode)=>{ if(!Array.isArray(a)||v==null) return;
+    a[i] = mode==='last' ? v
+         : mode==='max'  ? Math.max(a[i]==null?v:a[i], v)
+         : _tailMean(a[i], v, c); };
+  put(C.util,n.util); put(C.power,n.power); put(C.temp_max,n.temp,'max');
+  put(C.vram,n.mem_used,'last'); put(C.vram_total,n.mem_total,'last');
+  const fanMax=live.reduce((m,g)=>(g.fan!=null?Math.max(m==null?g.fan:m,g.fan):m), null);
+  put(C.fan_max,fanMax,'max');
+  (GPUC.cards||[]).forEach(cd=>{
+    const g=live.find(x=>x.idx===cd.idx), s=cd.series;
+    if(!g||!s) return;
+    put(s.util,g.util); put(s.power,g.power); put(s.temp,g.temp); put(s.temp_max,g.temp,'max');
+    put(s.vram,g.mem_used,'last'); put(s.vram_total,g.mem_total,'last');
+    put(s.fan,g.fan); put(s.fan_max,g.fan,'max'); put(s.mem_util,g.mem_util); put(s.clk_sm,g.clk_sm);
+    if(cd.now) Object.assign(cd.now,{util:g.util,mem_used:g.mem_used,mem_total:g.mem_total,
+      power:g.power,temp:g.temp,fan:g.fan,mem_util:g.mem_util,clk_sm:g.clk_sm,pstate:g.pstate});
+  });
+  // The pooled KPI tiles read now_pooled, which otherwise only moved on the 60s
+  // history fetch even though the stream had the numbers all along.
+  const P=GPUC.now_pooled;
+  if(P){
+    P.util=n.util; P.mem_used=n.mem_used; P.mem_total=n.mem_total;
+    P.power=Math.round(n.power||0); P.temp_max=n.temp;
+    if(fanMax!=null){ P.fan_max=fanMax; }
+    P.busy=live.filter(g=>(g.util||0)>0).length;
+  }
+  return true;
+}
+
+// Repaint only what is on screen. A hidden canvas costs the same as a visible
+// one to redraw and shows nobody anything, and showTab() rebuilds on the way in.
+function paintLiveCharts(){
+  try{
+    if(TAB==='host'){ buildCharts(); return; }         // overview repaints via renderMissionControl()
+    if(TAB==='gpu' && GPUC && GPUC.has_gpu){
+      if(GPU_VIEW!=='card') renderGpuMetricChart(GPUC);   // small multiples stay on the history cadence
+      renderGpuCombined(GPUC);
+      renderGpuKpis(GPUC);
+    }
+  }catch(e){ console.error('live chart repaint failed', e); }
+}
 
 function applyLive(j){
   if(!j || !j.now) return;
@@ -9126,7 +9319,14 @@ function applyLive(j){
   if(!D) return;              // history hasn't landed yet; nothing to merge into
   D.now = j.now;
   if(j.mem_total) D.mem_total = j.mem_total;
+  if(j.fast_interval) D.fast_interval = j.fast_interval;
+  // /api/data doesn't carry the sampler interval but the live frame does, and the
+  // tail needs it to judge how much of the open bucket the server already averaged.
+  if(j.interval) D.interval = j.interval;
+  mergeLiveTail(j.now);
+  mergeGpuTail(j.now);
   renderLive({live:true});
+  paintLiveCharts();
 }
 
 function openLiveStream(){
@@ -9135,12 +9335,24 @@ function openLiveStream(){
   try{ es = new EventSource('/api/stream'); }
   catch(e){ return; }        // no stream: the history timer keeps the page alive
   LIVE_ES = es;
-  es.addEventListener('now',   e => { if(autoOn()){ try{ applyLive(JSON.parse(e.data)); }catch(err){} } });
-  es.addEventListener('fleet', e => { if(autoOn()){ try{ applyFleet(JSON.parse(e.data)); }catch(err){} } });
-  es.onopen  = () => { LIVE_ON = true;  scheduleHistory(); };
+  // Frames are stamped even when a handler throws: arrival is what proves the
+  // stream is alive, and a parse failure shouldn't make the watchdog declare a
+  // healthy connection dead. Handler errors are logged, not swallowed — a silent
+  // catch here is how a broken live path looks exactly like a quiet homelab.
+  es.addEventListener('now',   e => { noteLiveFrame(); if(autoOn()){ try{ applyLive(JSON.parse(e.data)); }catch(err){ console.error('live frame failed', err); } } });
+  es.addEventListener('fleet', e => { noteLiveFrame(); if(autoOn()){ try{ applyFleet(JSON.parse(e.data)); }catch(err){ console.error('fleet frame failed', err); } } });
+  es.onopen  = () => { LIVE_ON = true; LIVE_LAST_FRAME = Date.now(); scheduleHistory(); };
   // EventSource reconnects on its own; until it does, LIVE_ON=false pulls the
   // history timer back to the old 15s cadence so the page keeps updating.
-  es.onerror = () => { LIVE_ON = false; scheduleHistory(); };
+  es.onerror = () => {
+    LIVE_ON = false;
+    // A CLOSED EventSource is terminal — the spec stops reconnecting on a non-200
+    // (the stream cap answers 503), and openLiveStream() guards on LIVE_ES being
+    // set. Without dropping the reference the page could never open a stream
+    // again for the rest of its life. refreshHistory() retries the open.
+    if(es.readyState === 2 && LIVE_ES === es) LIVE_ES = null;
+    scheduleHistory();
+  };
 }
 
 function closeLiveStream(){
@@ -9152,12 +9364,17 @@ function closeLiveStream(){
 // max(INTERVAL, span/MAX_POINTS), so on a 6h range a point cannot change more
 // than once a minute — polling every 15s just re-fetches the same numbers.
 function historyPeriod(){
-  if(!LIVE_ON) return 15000;                       // no stream: unchanged cadence
+  if(!LIVE_ON || liveStale()) return 15000;        // no stream: unchanged cadence
   const bk = (D && D.bucket_sec) ? D.bucket_sec*1000 : 15000;
   return Math.max(15000, Math.min(60000, bk));
 }
 
 function refreshHistory(){
+  // A stream that stopped delivering is not a stream. Demote it before anything
+  // reads LIVE_ON below, so the cadence returns to 15s and the fleet poll — which
+  // is gated on !LIVE_ON — starts running again instead of silently never firing.
+  if(LIVE_ON && liveStale()) LIVE_ON = false;
+  if(!LIVE_ES) openLiveStream();   // self-heal a stream that failed terminally
   loadData(); loadHealth();
   if(!LIVE_ON) loadFleet();   // with a stream open, the fleet arrives on push
   // Re-render host-scoped tabs so cached remote data refreshes too.
@@ -9176,12 +9393,31 @@ function refreshHistory(){
   if(LOCAL_ONLY_TABS.has(TAB) && CURRENT_HOST!=='local') renderLocalOnlyNotice(TAB);
 }
 
-function scheduleHistory(){
+// When the pending history tick is due, so a re-arm can tell "sooner" from
+// "same or later". Every stream connect/disconnect calls scheduleHistory(), and
+// the old version opened with an unconditional clearTimeout: a stream flapping
+// on its 3s retry hint reset the 15s timer forever, so it could never fire and
+// the whole page stopped refreshing while looking perfectly connected.
+let HIST_NEXT_AT = 0;
+
+function scheduleHistory(force){
+  const period = historyPeriod();
+  const want = Date.now() + period;
+  // Keep whatever is already pending unless the new period genuinely fires
+  // sooner. A reconnect must never be able to push the next refresh further out.
+  if(!force && HIST_TIMER && HIST_NEXT_AT && want >= HIST_NEXT_AT - 250) return;
   clearTimeout(HIST_TIMER);
+  HIST_NEXT_AT = want;
   HIST_TIMER = setTimeout(() => {
-    if(autoOn() && !document.hidden) refreshHistory();
-    scheduleHistory();
-  }, historyPeriod());
+    HIST_TIMER = null; HIST_NEXT_AT = 0;
+    // The reschedule lives in `finally`. It used to sit after the call, so one
+    // throw out of a synchronous renderer (renderDiskIo, renderLocalOnlyNotice)
+    // killed the refresh chain for the life of the page — silently, because the
+    // header shows a clock time rather than an age.
+    try{ if(autoOn() && !document.hidden) refreshHistory(); }
+    catch(e){ console.error('refreshHistory failed', e); }
+    finally{ scheduleHistory(); }
+  }, period);
 }
 
 // A tab nobody is looking at should cost nothing. The old poll ran flat out in
@@ -9190,8 +9426,9 @@ function scheduleHistory(){
 document.addEventListener('visibilitychange', () => {
   if(document.hidden){ closeLiveStream(); return; }
   openLiveStream();
-  if(autoOn()){ refreshHistory(); loadFleet(); }
-  scheduleHistory();
+  try{ if(autoOn()){ refreshHistory(); loadFleet(); } }
+  catch(e){ console.error('catch-up refresh failed', e); }
+  finally{ scheduleHistory(true); }   // coming back into view always re-arms
 });
 
 openLiveStream();

--- a/tests/js/test_refresh_loop.js
+++ b/tests/js/test_refresh_loop.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/*
+ * Behavioural tests for the dashboard's history-refresh loop and live tail.
+ *
+ * The client is one 745 KB HTML file with no build step, so there is nothing to
+ * import. Instead this lifts the functions under test straight out of
+ * static/dashboard.html and runs them in a `vm` context against a fake clock —
+ * the shipped source is never modified, patched or duplicated, so the test can
+ * only ever pass by the real code behaving.
+ *
+ * Covers the four ways the refresh loop was found to stop refreshing:
+ *   R2  a throw out of a synchronous renderer killed the chain permanently
+ *   R3  a flapping SSE reconnect reset the timer faster than it could fire
+ *   R4  LIVE_ON tracked connection events, so a dead-but-open stream froze
+ *       the cadence and silently stopped the fleet poll entirely
+ *   R7  a range switch never re-armed the timer with the new period
+ * plus the live-tail merge that keeps the newest chart point moving between
+ * history polls.
+ *
+ * Run: node tests/js/test_refresh_loop.js
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// DASHBOARD_HTML lets the suite be pointed at another build of the page — used
+// to confirm these tests genuinely fail against the version that shipped the bug.
+const DASH = process.env.DASHBOARD_HTML
+  || path.join(__dirname, '..', '..', 'static', 'dashboard.html');
+const SRC = fs.readFileSync(DASH, 'utf8');
+
+// ── extraction ───────────────────────────────────────────────────────────────
+// Top-level declarations in dashboard.html start at column 0 and a function's
+// closing brace is the next `}` at column 0. That is enough structure to slice
+// out exactly the definitions under test without parsing the whole file.
+function takeFunction(name) {
+  const start = SRC.indexOf(`\nfunction ${name}(`);
+  if (start < 0) throw new Error(`could not find function ${name}() in dashboard.html`);
+  const end = SRC.indexOf('\n}', start);
+  if (end < 0) throw new Error(`could not find the end of ${name}()`);
+  return SRC.slice(start + 1, end + 2);
+}
+
+function takeLine(re, what) {
+  const m = SRC.match(re);
+  if (!m) throw new Error(`could not find ${what} in dashboard.html`);
+  return m[0];
+}
+
+// ── fake clock ───────────────────────────────────────────────────────────────
+let NOW = 1700000000000, SEQ = 0;
+const timers = new Map();
+const setTimeout_ = (fn, ms) => { const id = ++SEQ; timers.set(id, { at: NOW + ms, fn }); return id; };
+const clearTimeout_ = (id) => { timers.delete(id); };
+function advance(ms) {
+  const end = NOW + ms;
+  for (;;) {
+    let next = null;
+    for (const [id, t] of timers) if (t.at <= end && (!next || t.at < next.t.at)) next = { id, t };
+    if (!next) break;
+    NOW = next.t.at;
+    timers.delete(next.id);
+    next.t.fn();          // deliberately unguarded: an escaping throw is a failure
+  }
+  NOW = end;
+}
+const pending = () => timers.size;
+
+// ── context ──────────────────────────────────────────────────────────────────
+function build(opts = {}) {
+  const ctx = {
+    // mutable state the shipped code reads and writes
+    LIVE_ON: opts.liveOn || false,
+    HIST_TIMER: null,
+    HIST_NEXT_AT: 0,
+    LIVE_LAST_FRAME: 0,
+    LIVE_ES: opts.liveEs === undefined ? {} : opts.liveEs,
+    D: opts.D || null,
+    GPUC: opts.GPUC || null,
+    LIVE_TAIL: { b: null, n: 0 },
+    GPU_TAIL: { b: null, n: 0 },
+    TAB: opts.tab || 'overview',
+    CURRENT_HOST: opts.host || 'local',
+    LOCAL_ONLY_TABS: new Set(['models', 'experiments', 'containers']),
+    // counters
+    loadDataCalls: 0, loadFleetCalls: 0, loadHealthCalls: 0, openStreamCalls: 0,
+    // environment
+    Math, JSON, Set, Array, Object,
+    Date: { now: () => NOW },
+    setTimeout: setTimeout_, clearTimeout: clearTimeout_,
+    document: { hidden: false, getElementById: () => ({ checked: opts.auto !== false }) },
+  };
+  // Captured rather than printed: the loop is supposed to log what it caught,
+  // and the R2 test asserts on that instead of letting a stack trace spam CI.
+  ctx.errors = [];
+  ctx.console = { log: () => {}, warn: () => {}, error: (...a) => ctx.errors.push(a.map(String).join(' ')) };
+  ctx.autoOn = () => { const el = ctx.document.getElementById('auto'); return !el || el.checked; };
+  ctx.loadData = () => { ctx.loadDataCalls++; };
+  ctx.loadHealth = () => { ctx.loadHealthCalls++; };
+  ctx.loadFleet = () => { ctx.loadFleetCalls++; };
+  ctx.openLiveStream = () => { ctx.openStreamCalls++; ctx.LIVE_ES = {}; };
+  ctx.renderHostTab = () => {};
+  ctx.renderNetwork = () => {};
+  ctx.renderSecurity = () => {};
+  ctx.renderGpuTab = () => {};
+  ctx.renderLocalOnlyNotice = () => {};
+  ctx.renderDiskIo = () => {
+    if (opts.diskIoThrows) throw new TypeError("Cannot read properties of undefined (reading 'items')");
+  };
+  vm.createContext(ctx);
+  vm.runInContext([
+    takeFunction('liveStale'),
+    takeFunction('noteLiveFrame'),
+    takeFunction('historyPeriod'),
+    takeFunction('refreshHistory'),
+    takeFunction('scheduleHistory'),
+    takeLine(/^const _tailMean=.*$/m, 'the _tailMean helper'),
+    takeFunction('_tailPush'),
+    takeFunction('_tailSlot'),
+    takeFunction('mergeLiveTail'),
+    takeFunction('mergeGpuTail'),
+  ].join('\n\n'), ctx);
+  return ctx;
+}
+
+// ── assertions ───────────────────────────────────────────────────────────────
+let failures = 0, checks = 0;
+function check(label, cond, detail) {
+  checks++;
+  if (cond) { console.log(`  ok   ${label}`); return; }
+  failures++;
+  console.log(`  FAIL ${label}${detail ? '\n         ' + detail : ''}`);
+}
+function suite(name) { console.log(`\n${name}`); }
+
+function reset() { NOW = 1700000000000; timers.clear(); }
+
+// ── R2: a throwing renderer must not kill the chain ──────────────────────────
+suite('R2  a sync throw inside refreshHistory() must not stop the loop');
+{
+  reset();
+  const c = build({ tab: 'diskio', diskIoThrows: true, liveOn: false });
+  c.scheduleHistory();
+  advance(20000);
+  const afterThrow = c.loadDataCalls;
+  check('the tick still ran', afterThrow >= 1, `refreshes=${afterThrow}`);
+  check('a timer is still pending after the throw', pending() === 1, `pending=${pending()}`);
+  advance(600000);
+  check('still refreshing 10 minutes later',
+    c.loadDataCalls >= 40, `refreshes=${c.loadDataCalls} (expected ~41 at 15s)`);
+  check('the failure was logged, not swallowed',
+    c.errors.length > 0 && c.errors[0].includes('refreshHistory failed'),
+    `errors=${JSON.stringify(c.errors.slice(0, 1))}`);
+}
+
+// ── R3: reconnect flapping must not starve the timer ─────────────────────────
+suite('R3  a 3s SSE reconnect flap must not starve the 15s poll');
+{
+  reset();
+  const c = build({ liveOn: false });
+  c.scheduleHistory();
+  for (let i = 0; i < 100; i++) { advance(3000); c.LIVE_ON = false; c.scheduleHistory(); }
+  check('refreshes still happened during 300s of flapping',
+    c.loadDataCalls >= 15, `refreshes=${c.loadDataCalls} (expected ~20)`);
+  check('no timer stacking', pending() === 1, `pending=${pending()}`);
+}
+
+// ── R3b: a re-arm must never push the fire time further out ──────────────────
+suite('R3b a re-arm must never delay an already-pending tick');
+{
+  reset();
+  const c = build({ liveOn: false });
+  c.scheduleHistory();                       // 15s
+  advance(14000);
+  c.LIVE_ON = true; c.D = { bucket_sec: 60 };  // would compute a 60s period
+  c.scheduleHistory();
+  advance(1100);
+  check('the pending 15s tick still fired on time', c.loadDataCalls === 1,
+    `refreshes=${c.loadDataCalls}`);
+}
+
+// ── R3c: a shorter period must be adopted immediately ────────────────────────
+suite('R3c a genuinely sooner period must replace the pending tick');
+{
+  reset();
+  const c = build({ liveOn: true, D: { bucket_sec: 60 } });
+  c.scheduleHistory();                       // 60s
+  advance(1000);
+  c.LIVE_ON = false;                         // stream lost -> 15s
+  c.scheduleHistory();
+  advance(15100);
+  check('re-armed at the shorter period', c.loadDataCalls === 1, `refreshes=${c.loadDataCalls}`);
+}
+
+// ── R4: watchdog on a dead-but-open stream ───────────────────────────────────
+suite('R4  a stream that stops delivering must be demoted');
+{
+  reset();
+  const c = build({ liveOn: true, D: { bucket_sec: 60, fast_interval: 2 } });
+  c.noteLiveFrame();                          // one frame arrives, then silence
+  check('period is the slow cadence while live', c.historyPeriod() === 60000,
+    `period=${c.historyPeriod()}`);
+  check('fleet is not polled while genuinely live', (() => {
+    c.refreshHistory(); return c.loadFleetCalls === 0;
+  })(), `loadFleet=${c.loadFleetCalls}`);
+  advance(60000);                             // 60s of silence, > max(6*2s, 45s)
+  check('watchdog reports the stream stale', c.liveStale() === true);
+  c.refreshHistory();
+  check('LIVE_ON demoted to false', c.LIVE_ON === false);
+  check('period fell back to 15s', c.historyPeriod() === 15000, `period=${c.historyPeriod()}`);
+  check('fleet polling resumed', c.loadFleetCalls === 1, `loadFleet=${c.loadFleetCalls}`);
+}
+
+// ── R4b: a live stream must not be demoted ───────────────────────────────────
+suite('R4b a stream still delivering frames must stay live');
+{
+  reset();
+  const c = build({ liveOn: true, D: { bucket_sec: 60, fast_interval: 2 } });
+  for (let i = 0; i < 30; i++) { c.noteLiveFrame(); advance(2000); }
+  check('watchdog leaves a healthy stream alone', c.liveStale() === false);
+  c.refreshHistory();
+  check('LIVE_ON still true', c.LIVE_ON === true);
+  check('fleet still left to the stream', c.loadFleetCalls === 0, `loadFleet=${c.loadFleetCalls}`);
+}
+
+// ── R7: range switch re-arms with the new period ─────────────────────────────
+suite('R7  a range switch must re-arm the timer with the new period');
+{
+  reset();
+  const c = build({ liveOn: true, D: { bucket_sec: 240 } });   // 24h -> 60s cap
+  c.scheduleHistory();
+  advance(1000);
+  c.D = { bucket_sec: 10 };                    // user picks 1h
+  c.scheduleHistory(true);                     // what the .rb handler now does
+  advance(15100);
+  check('refreshed at the new 15s period, not the old 60s one',
+    c.loadDataCalls === 1, `refreshes=${c.loadDataCalls}`);
+}
+
+// ── stream self-heal ─────────────────────────────────────────────────────────
+suite('R8  a refresh tick must reopen a stream that failed terminally');
+{
+  reset();
+  const c = build({ liveOn: false, liveEs: null });
+  c.refreshHistory();
+  check('openLiveStream() was called when LIVE_ES was null', c.openStreamCalls === 1,
+    `openStreamCalls=${c.openStreamCalls}`);
+}
+
+// ── live tail ────────────────────────────────────────────────────────────────
+function mkD(lastBucket, bucketSec) {
+  const labels = [], mkArr = () => [];
+  const n = 5;
+  for (let i = n - 1; i >= 0; i--) labels.push(lastBucket - i * bucketSec);
+  const arr = (v) => Array(n).fill(v);
+  return {
+    bucket_sec: bucketSec, interval: 10, labels,
+    total: {
+      cpu: arr(10), ram_used: arr(1000), ram_total: arr(4000), load1: arr(1), ctemp: arr(40),
+      util: arr(5), mem: arr(500), mempk: arr(500), power: arr(20), temp: arr(30),
+    },
+  };
+}
+
+suite('tail  the newest bucket keeps moving between history polls');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const D = mkD(last, bk);
+  const c = build({ D });
+  // a frame 20s into the open bucket
+  const ok = c.mergeLiveTail({ fast_ts: last + 20, host: { cpu: 50, ram_used: 2000, ram_total: 4000, load1: 3, ctemp: 55 }, gpu_avail: false });
+  check('merge reported success', ok === true);
+  check('label window did not grow', D.labels.length === 5, `len=${D.labels.length}`);
+  check('newest label unchanged (same bucket)', D.labels[4] === last, `last=${D.labels[4]}`);
+  check('cpu moved toward the live value', D.total.cpu[4] > 10 && D.total.cpu[4] <= 50,
+    `cpu=${D.total.cpu[4]}`);
+  check('a GPU-less box grew no GPU value', D.total.util[4] === 5, `util=${D.total.util[4]}`);
+}
+
+suite('tail  a new bucket appends and slides the window');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const D = mkD(last, bk);
+  const oldest = D.labels[0];
+  const c = build({ D });
+  c.mergeLiveTail({ fast_ts: last + bk + 5, host: { cpu: 70 }, gpu_avail: false });
+  check('window length is unchanged', D.labels.length === 5, `len=${D.labels.length}`);
+  check('a new bucket was appended', D.labels[4] === last + bk, `last=${D.labels[4]}`);
+  check('the oldest bucket was dropped', D.labels[0] !== oldest);
+  check('the new point took the live value', D.total.cpu[4] === 70, `cpu=${D.total.cpu[4]}`);
+  check('every series slid together', D.total.power.length === 5, `len=${D.total.power.length}`);
+}
+
+suite('tail  VRAM is a step metric and must not be averaged away');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const D = mkD(last, bk);
+  const c = build({ D });
+  // a model loads: VRAM jumps from 500 MB to 20 GB inside the open bucket
+  c.mergeLiveTail({ fast_ts: last + 20, host: {}, gpu_avail: true, util: 90, mem_used: 20000, power: 250, temp: 70 });
+  check('VRAM shows the loaded value, not a mean', D.total.mem[4] === 20000, `mem=${D.total.mem[4]}`);
+  check('the VRAM peak was captured', D.total.mempk[4] === 20000, `mempk=${D.total.mempk[4]}`);
+  check('util was averaged, not slammed', D.total.util[4] > 5 && D.total.util[4] < 90,
+    `util=${D.total.util[4]}`);
+}
+
+suite('tail  an old frame is ignored, and a remote host is left alone');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const D = mkD(last, bk);
+  const c = build({ D });
+  const before = D.total.cpu[4];
+  const ok = c.mergeLiveTail({ fast_ts: last - 5 * bk, host: { cpu: 99 }, gpu_avail: false });
+  check('a frame older than the series is rejected', ok === false);
+  check('nothing was written', D.total.cpu[4] === before, `cpu=${D.total.cpu[4]}`);
+
+  const GPUC = {
+    has_gpu: true, host: 'local', bucket_sec: bk, interval: 10,
+    labels: D.labels.slice(),
+    combined: { util: [1, 1, 1, 1, 1], vram: [10, 10, 10, 10, 10], power: [1, 1, 1, 1, 1], temp_max: [1, 1, 1, 1, 1] },
+    cards: [], now_pooled: {},
+  };
+  const c2 = build({ GPUC, host: 'vader' });
+  check('a remote host does not get the hub\'s live frame',
+    c2.mergeGpuTail({ fast_ts: last + 20, gpu_avail: true, util: 99, mem_used: 9999, gpus: [] }) === false);
+  check('the remote series is untouched', GPUC.combined.util[4] === 1, `util=${GPUC.combined.util[4]}`);
+}
+
+suite('tail  the GPU tab rides the same fold');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const GPUC = {
+    has_gpu: true, host: 'local', bucket_sec: bk, interval: 10,
+    labels: [last - 4 * bk, last - 3 * bk, last - 2 * bk, last - bk, last],
+    combined: { util: [1, 1, 1, 1, 1], vram: [10, 10, 10, 10, 10], vram_total: [5120, 5120, 5120, 5120, 5120], power: [5, 5, 5, 5, 5], temp_max: [30, 30, 30, 30, 30], fan_max: [40, 40, 40, 40, 40] },
+    cards: [{ idx: 0, series: { util: [1, 1, 1, 1, 1], vram: [10, 10, 10, 10, 10], temp: [30, 30, 30, 30, 30] }, now: {} }],
+    now_pooled: { util: 1, mem_used: 10, power: 5, temp_max: 30 },
+  };
+  const c = build({ GPUC, host: 'local' });
+  const ok = c.mergeGpuTail({
+    fast_ts: last + 20, gpu_avail: true, util: 95, mem_used: 4800, mem_total: 5120,
+    power: 70, temp: 72, gpus: [{ idx: 0, util: 95, mem_used: 4800, mem_total: 5120, power: 70, temp: 72, fan: 80 }],
+  });
+  check('merge reported success', ok === true);
+  check('pooled VRAM took the latest value', GPUC.combined.vram[4] === 4800,
+    `vram=${GPUC.combined.vram[4]}`);
+  check('per-card VRAM took the latest value', GPUC.cards[0].series.vram[4] === 4800,
+    `vram=${GPUC.cards[0].series.vram[4]}`);
+  check('hottest card is a max, not a mean', GPUC.combined.temp_max[4] === 72,
+    `temp_max=${GPUC.combined.temp_max[4]}`);
+  check('KPI tiles were refreshed from the frame', GPUC.now_pooled.util === 95,
+    `util=${GPUC.now_pooled.util}`);
+}
+
+// ── result ───────────────────────────────────────────────────────────────────
+console.log(`\n${checks - failures}/${checks} checks passed`);
+if (failures) { console.error(`${failures} check(s) FAILED`); process.exit(1); }

--- a/tests/js/test_refresh_loop.js
+++ b/tests/js/test_refresh_loop.js
@@ -35,17 +35,25 @@ const SRC = fs.readFileSync(DASH, 'utf8');
 // Top-level declarations in dashboard.html start at column 0 and a function's
 // closing brace is the next `}` at column 0. That is enough structure to slice
 // out exactly the definitions under test without parsing the whole file.
+function missing(what) {
+  return new Error(
+    `${what} was not found in ${DASH}.\n` +
+    '       Either the page predates the chart-refresh fix (nothing to test — these\n' +
+    '       functions arrived with it), or the definition was renamed and this\n' +
+    '       extractor needs updating to match.');
+}
+
 function takeFunction(name) {
   const start = SRC.indexOf(`\nfunction ${name}(`);
-  if (start < 0) throw new Error(`could not find function ${name}() in dashboard.html`);
+  if (start < 0) throw missing(`function ${name}()`);
   const end = SRC.indexOf('\n}', start);
-  if (end < 0) throw new Error(`could not find the end of ${name}()`);
+  if (end < 0) throw new Error(`could not find the end of ${name}() — is it still a top-level function?`);
   return SRC.slice(start + 1, end + 2);
 }
 
 function takeLine(re, what) {
   const m = SRC.match(re);
-  if (!m) throw new Error(`could not find ${what} in dashboard.html`);
+  if (!m) throw missing(what);
   return m[0];
 }
 
@@ -54,6 +62,11 @@ let NOW = 1700000000000, SEQ = 0;
 const timers = new Map();
 const setTimeout_ = (fn, ms) => { const id = ++SEQ; timers.set(id, { at: NOW + ms, fn }); return id; };
 const clearTimeout_ = (id) => { timers.delete(id); };
+// Throws that escape a timer callback are recorded rather than propagated. An
+// escape IS a failure — it is exactly the v0.30.0 bug — but letting it kill the
+// node process turns a regression into a stack trace with no indication of which
+// invariant broke. The R2 suite asserts on `escaped` and reports it as a FAIL.
+let escaped = [];
 function advance(ms) {
   const end = NOW + ms;
   for (;;) {
@@ -62,7 +75,8 @@ function advance(ms) {
     if (!next) break;
     NOW = next.t.at;
     timers.delete(next.id);
-    next.t.fn();          // deliberately unguarded: an escaping throw is a failure
+    try { next.t.fn(); }
+    catch (e) { escaped.push(`${e.constructor.name}: ${e.message}`); }
   }
   NOW = end;
 }
@@ -83,9 +97,11 @@ function build(opts = {}) {
     GPU_TAIL: { b: null, n: 0 },
     TAB: opts.tab || 'overview',
     CURRENT_HOST: opts.host || 'local',
+    GPU_VIEW: opts.gpuView || 'card',
     LOCAL_ONLY_TABS: new Set(['models', 'experiments', 'containers']),
     // counters
     loadDataCalls: 0, loadFleetCalls: 0, loadHealthCalls: 0, openStreamCalls: 0,
+    buildChartsCalls: 0, gpuChartCalls: 0,
     // environment
     Math, JSON, Set, Array, Object,
     Date: { now: () => NOW },
@@ -109,6 +125,10 @@ function build(opts = {}) {
   ctx.renderDiskIo = () => {
     if (opts.diskIoThrows) throw new TypeError("Cannot read properties of undefined (reading 'items')");
   };
+  ctx.buildCharts = () => { ctx.buildChartsCalls++; };
+  ctx.renderGpuMetricChart = () => { ctx.gpuChartCalls++; };
+  ctx.renderGpuCombined = () => { ctx.gpuChartCalls++; };
+  ctx.renderGpuKpis = () => {};
   vm.createContext(ctx);
   vm.runInContext([
     takeFunction('liveStale'),
@@ -121,6 +141,7 @@ function build(opts = {}) {
     takeFunction('_tailSlot'),
     takeFunction('mergeLiveTail'),
     takeFunction('mergeGpuTail'),
+    takeFunction('paintLiveCharts'),
   ].join('\n\n'), ctx);
   return ctx;
 }
@@ -135,7 +156,7 @@ function check(label, cond, detail) {
 }
 function suite(name) { console.log(`\n${name}`); }
 
-function reset() { NOW = 1700000000000; timers.clear(); }
+function reset() { NOW = 1700000000000; timers.clear(); escaped = []; }
 
 // ── R2: a throwing renderer must not kill the chain ──────────────────────────
 suite('R2  a sync throw inside refreshHistory() must not stop the loop');
@@ -153,6 +174,8 @@ suite('R2  a sync throw inside refreshHistory() must not stop the loop');
   check('the failure was logged, not swallowed',
     c.errors.length > 0 && c.errors[0].includes('refreshHistory failed'),
     `errors=${JSON.stringify(c.errors.slice(0, 1))}`);
+  check('no throw escaped the timer callback', escaped.length === 0,
+    `escaped=${JSON.stringify(escaped.slice(0, 2))} — the reschedule is not protected`);
 }
 
 // ── R3: reconnect flapping must not starve the timer ─────────────────────────
@@ -211,6 +234,24 @@ suite('R4  a stream that stops delivering must be demoted');
   check('LIVE_ON demoted to false', c.LIVE_ON === false);
   check('period fell back to 15s', c.historyPeriod() === 15000, `period=${c.historyPeriod()}`);
   check('fleet polling resumed', c.loadFleetCalls === 1, `loadFleet=${c.loadFleetCalls}`);
+}
+
+// ── R4a: historyPeriod() must consult the watchdog on its own ────────────────
+// Without this the `|| liveStale()` clause is dead code as far as the suite is
+// concerned: every other R4 check goes through refreshHistory(), which demotes
+// LIVE_ON first, so historyPeriod() answers via its `!LIVE_ON` branch and the
+// staleness clause is never exercised. Assert it directly, LIVE_ON still true.
+suite('R4a historyPeriod() alone must fall back on a stale stream');
+{
+  reset();
+  const c = build({ liveOn: true, D: { bucket_sec: 60, fast_interval: 2 } });
+  c.noteLiveFrame();
+  check('slow cadence while frames are arriving', c.historyPeriod() === 60000,
+    `period=${c.historyPeriod()}`);
+  advance(120000);                            // two minutes of silence
+  check('LIVE_ON is still true (nothing demoted it)', c.LIVE_ON === true);
+  check('but the period already fell back to 15s', c.historyPeriod() === 15000,
+    `period=${c.historyPeriod()} — historyPeriod() is not consulting liveStale()`);
 }
 
 // ── R4b: a live stream must not be demoted ───────────────────────────────────
@@ -357,6 +398,67 @@ suite('tail  the GPU tab rides the same fold');
     `temp_max=${GPUC.combined.temp_max[4]}`);
   check('KPI tiles were refreshed from the frame', GPUC.now_pooled.util === 95,
     `util=${GPUC.now_pooled.util}`);
+}
+
+// ── host scope: the live repaint is hub-only ─────────────────────────────────
+// D is always this hub's own series. Driving the System chart from a live frame
+// while a remote machine is selected animates the hub's CPU/RAM/load under the
+// remote's name — and now it would do so every two seconds instead of sitting
+// still, which reads as authoritative rather than obviously stale.
+suite('scope  the live repaint must not paint hub data under a remote host');
+{
+  reset();
+  const c = build({ tab: 'host', host: 'local' });
+  c.paintLiveCharts();
+  check('the hub repaints its own System chart', c.buildChartsCalls === 1,
+    `buildCharts=${c.buildChartsCalls}`);
+
+  const c2 = build({ tab: 'host', host: 'vader' });
+  c2.paintLiveCharts();
+  check('a remote host does not repaint from the hub frame', c2.buildChartsCalls === 0,
+    `buildCharts=${c2.buildChartsCalls} — the hub's series would animate under the remote's name`);
+}
+
+// ── tail: everything indexed against D.labels slides together ────────────────
+// D.total is not the only thing the length of D.labels. The per-service memory
+// series, the "other" remainder and every per-device disk-I/O series are read
+// with the same indices, so a rollover that slides only D.total leaves them one
+// bucket out of step until the next authoritative poll.
+suite('tail  sibling series slide with the window on a bucket rollover');
+{
+  reset();
+  const bk = 60, last = 1786788000;
+  const five = v => [v, v, v, v, v];
+  const D = {
+    bucket_sec: bk, interval: 10,
+    labels: [last - 4 * bk, last - 3 * bk, last - 2 * bk, last - bk, last],
+    total: { cpu: five(3), ram_used: five(8000), ram_total: five(16000), load1: five(1) },
+    services: { 'ollama-embed': five(500) },
+    other: five(200),
+    disk_io: { md0: { read_mb_s: five(1), write_mb_s: five(2), util_pct: five(3) } },
+  };
+  const c = build({ D, host: 'local' });
+  // A frame in the NEXT bucket forces the window to slide.
+  const ok = c.mergeLiveTail({ fast_ts: last + bk + 5, host: { cpu: 40 } });
+  check('merge reported success', ok === true);
+  check('the window still holds five buckets', D.labels.length === 5,
+    `labels=${D.labels.length}`);
+  check('labels slid to the new bucket', D.labels[4] === last + bk,
+    `last label=${D.labels[4]}`);
+  check('D.total slid with the labels', D.total.cpu.length === 5 && D.total.cpu[4] === 40,
+    `cpu=${JSON.stringify(D.total.cpu)}`);
+  check('the per-service series slid too',
+    D.services['ollama-embed'].length === 5 && D.services['ollama-embed'][4] === null,
+    `svc=${JSON.stringify(D.services['ollama-embed'])}`);
+  check('the "other" remainder slid too',
+    D.other.length === 5 && D.other[4] === null, `other=${JSON.stringify(D.other)}`);
+  check('every disk-I/O series slid too',
+    D.disk_io.md0.read_mb_s.length === 5 && D.disk_io.md0.write_mb_s.length === 5
+      && D.disk_io.md0.util_pct.length === 5 && D.disk_io.md0.read_mb_s[4] === null,
+    `read=${JSON.stringify(D.disk_io.md0.read_mb_s)}`);
+  check('the oldest bucket was dropped, not kept',
+    D.services['ollama-embed'][0] === 500 && D.labels[0] === last - 3 * bk,
+    `first label=${D.labels[0]}`);
 }
 
 // ── result ───────────────────────────────────────────────────────────────────

--- a/tests/js/test_refresh_loop.js
+++ b/tests/js/test_refresh_loop.js
@@ -461,6 +461,88 @@ suite('tail  sibling series slide with the window on a bucket rollover');
     `first label=${D.labels[0]}`);
 }
 
+// ── GPU small multiples refresh in place ─────────────────────────────────────
+// The per-card grid used to repaint only on the 60s history fetch, because the
+// full render replaces #pergpu wholesale and re-binds every handler. The result
+// was a grid of temp/watt/util cards sitting still while the detail chart behind
+// them tracked live. The live path now writes each card's body and leaves the
+// wrapper — handlers, focus, tabindex — alone.
+suite('gpu   the small-multiples cards refresh in place off a live frame');
+{
+  reset();
+
+  // Minimal DOM: a #pergpu box holding one wrapper per card. Handlers live on
+  // the wrapper, so the test asserts the wrapper objects are never replaced.
+  function mkBox(idxs, opts = {}) {
+    const kids = idxs.map(i => ({
+      dataset: { idx: String(i) }, className: 'gpu-mini st-ok',
+      innerHTML: `ORIGINAL-${i}`, onclick: () => {},
+    }));
+    return {
+      hidden: opts.hidden || false, innerHTML: 'GRID', _kids: kids,
+      querySelectorAll: () => kids,
+    };
+  }
+  function ctxWith(box, opts = {}) {
+    const c = build({ tab: 'gpu' });
+    c.GPU_VIEW = opts.view || 'card';
+    c.GPU_SPARK_ROWS = ['util', 'temp'];
+    c.gpuSharedRange = () => ({ min: 0, max: 100 });
+    c.gpuMiniCardBody = (card) => `BODY-${card.idx}-${card.now.temp}`;
+    c.document.getElementById = (id) => (id === 'pergpu' ? box : null);
+    vm.runInContext(takeFunction('updateGpuCardsLive'), c);
+    return c;
+  }
+
+  const d = (t0, t1) => ({
+    has_gpu: true,
+    cards: [{ idx: 0, status: 'ok', now: { temp: t0 } }, { idx: 1, status: 'ok', now: { temp: t1 } }],
+  });
+
+  const box = mkBox([0, 1]);
+  const c = ctxWith(box);
+  const ok = c.updateGpuCardsLive(d(61, 70));
+  check('the live frame repainted the cards', ok === true);
+  check('card 0 took the new reading', box._kids[0].innerHTML === 'BODY-0-61',
+    `html=${box._kids[0].innerHTML}`);
+  check('card 1 took the new reading', box._kids[1].innerHTML === 'BODY-1-70',
+    `html=${box._kids[1].innerHTML}`);
+  check('the grid itself was NOT rebuilt', box.innerHTML === 'GRID',
+    'replacing #pergpu would drop every click handler and the focus ring');
+  check('the wrapper elements were not replaced',
+    typeof box._kids[0].onclick === 'function', 'the click handler must survive');
+
+  // A second frame keeps moving the numbers.
+  c.updateGpuCardsLive(d(72, 75));
+  check('a later frame moves them again', box._kids[0].innerHTML === 'BODY-0-72',
+    `html=${box._kids[0].innerHTML}`);
+
+  // Structural change: a card appeared. The full render owns that, not this.
+  const c2 = ctxWith(mkBox([0, 1]));
+  check('a changed card count defers to the full render',
+    c2.updateGpuCardsLive({
+      has_gpu: true,
+      cards: [{ idx: 0, status: 'ok', now: { temp: 1 } }, { idx: 1, status: 'ok', now: { temp: 2 } },
+              { idx: 2, status: 'ok', now: { temp: 3 } }],
+    }) === false);
+
+  // A status change still lands, since it rides on the wrapper's class.
+  const box3 = mkBox([0, 1]);
+  const c3 = ctxWith(box3);
+  c3.updateGpuCardsLive({
+    has_gpu: true,
+    cards: [{ idx: 0, status: 'hot', now: { temp: 90 } }, { idx: 1, status: 'ok', now: { temp: 40 } }],
+  });
+  check('a card that turned hot got the new status class',
+    box3._kids[0].className === 'gpu-mini st-hot', `class=${box3._kids[0].className}`);
+
+  // Not on the small-multiples view, or hidden: nothing to do.
+  check('the metric view is left to the chart path',
+    ctxWith(mkBox([0, 1]), { view: 'metric' }).updateGpuCardsLive(d(1, 2)) === false);
+  check('a hidden grid is not painted',
+    ctxWith(mkBox([0, 1], { hidden: true })).updateGpuCardsLive(d(1, 2)) === false);
+}
+
 // ── result ───────────────────────────────────────────────────────────────────
 console.log(`\n${checks - failures}/${checks} checks passed`);
 if (failures) { console.error(`${failures} check(s) FAILED`); process.exit(1); }

--- a/tests/test_dashboard_refresh_invariants.py
+++ b/tests/test_dashboard_refresh_invariants.py
@@ -1,0 +1,132 @@
+"""CI gate: structural invariants of the dashboard's refresh loop.
+
+The client is a single 745 KB HTML file with no build step and no module
+boundaries, so these are source-level assertions rather than unit tests. The
+behavioural coverage lives in tests/js/test_refresh_loop.js, which runs the real
+functions against a fake clock; this file is the cheap guard that runs inside the
+existing Python suite and fails loudly if one of the fixes is edited away.
+
+Each invariant below is a bug that shipped in v0.30.0 and made the charts stop
+refreshing while the rest of the page kept moving.
+"""
+import re
+from pathlib import Path
+
+DASHBOARD = Path(__file__).parent.parent / "static" / "dashboard.html"
+
+
+def _source() -> str:
+    return DASHBOARD.read_text(encoding="utf-8")
+
+
+def _function(src: str, name: str) -> str:
+    """Slice a top-level `function name(...)` out of the page.
+
+    Top-level declarations start at column 0 and end at the next `}` in column 0,
+    which is the whole structure this needs.
+    """
+    start = src.find(f"\nfunction {name}(")
+    assert start >= 0, f"function {name}() not found in static/dashboard.html"
+    end = src.find("\n}", start)
+    assert end >= 0, f"could not find the end of {name}()"
+    return src[start:end + 2]
+
+
+def test_schedule_history_reschedules_in_finally():
+    """A throw out of a synchronous renderer must not kill the refresh chain.
+
+    scheduleHistory() used to call refreshHistory() and then reschedule on the
+    next line. renderDiskIo() and renderLocalOnlyNotice() are synchronous, so one
+    exception from either skipped the reschedule and the page never refreshed
+    again — silently, because the header shows a clock time, not an age.
+    """
+    body = _function(_source(), "scheduleHistory")
+    assert "finally" in body, (
+        "scheduleHistory() must reschedule inside a finally block so a throwing "
+        "tick cannot end the refresh loop"
+    )
+    finally_idx = body.index("finally")
+    assert "scheduleHistory()" in body[finally_idx:], (
+        "the reschedule must be the finally clause, not merely present somewhere"
+    )
+
+
+def test_history_period_consults_the_liveness_watchdog():
+    """LIVE_ON tracks connection events, so it can stay true on a dead stream.
+
+    While stuck true the poll stayed on the slow cadence and refreshHistory()'s
+    `if(!LIVE_ON) loadFleet()` meant the fleet was never polled at all.
+    """
+    src = _source()
+    assert "\nfunction liveStale(" in src, "the stream-liveness watchdog is missing"
+    period = _function(src, "historyPeriod")
+    assert "liveStale()" in period, (
+        "historyPeriod() must treat a stream that stopped delivering as not live"
+    )
+    refresh = _function(src, "refreshHistory")
+    assert "liveStale()" in refresh, (
+        "refreshHistory() must demote LIVE_ON on a stale stream so the fleet poll resumes"
+    )
+
+
+def test_apply_live_merges_into_the_charted_series():
+    """The 2s stream must move the charts, not only the live tiles.
+
+    applyLive() used to assign D.now and nothing else, so every chart on the page
+    moved only at the history cadence — 60s on the default 6h range, against
+    tiles that moved every 2s.
+    """
+    body = _function(_source(), "applyLive")
+    assert "mergeLiveTail(" in body, (
+        "applyLive() must fold the live frame into the newest chart bucket"
+    )
+    assert "mergeGpuTail(" in body, (
+        "applyLive() must fold the live frame into the GPU tab's series too"
+    )
+    assert "paintLiveCharts(" in body, (
+        "applyLive() must repaint the visible tab's charts after merging"
+    )
+
+
+def test_vram_tail_is_not_averaged():
+    """VRAM is a step metric: averaging the open bucket hides a model load."""
+    body = _function(_source(), "mergeLiveTail")
+    assert re.search(r"set\('mem',\s*n\.mem_used,\s*'last'\)", body), (
+        "the VRAM tail must carry the latest value, not a running mean"
+    )
+    gpu = _function(_source(), "mergeGpuTail")
+    assert "'last'" in gpu, "the GPU VRAM tail must carry the latest value"
+
+
+def test_mk_reassigns_inline_plugins():
+    """Inline plugins close over the payload they were built from.
+
+    The GPU throttle bands close over d.cards, the threshold line over d.hot_c and
+    the VRAM capacity line over d.capacity_mb. mk()'s in-place branch reassigned
+    labels, datasets and options but never plugins, so those stayed frozen at
+    page-load state for the life of the tab while the lines underneath moved.
+    """
+    body = _function(_source(), "mk")
+    assert "plugins" in body, "mk() must account for inline plugins"
+    assert re.search(r"newP\.forEach\(\(p,\s*i\)\s*=>\s*Object\.assign\(curP\[i\],\s*p\)\)", body), (
+        "mk()'s in-place update must copy the fresh plugin hooks onto the objects "
+        "the chart already holds"
+    )
+    assert "samePlugins" in body, (
+        "a changed plugin set must count as a shape change and force a rebuild"
+    )
+
+
+def test_mc_chart_signature_includes_values():
+    """The overview chart's cache key must not be labels-only.
+
+    The newest bucket is re-averaged (and now updated from the stream) under a
+    label that does not change until the bucket closes, so a label-only signature
+    held the chart still for a whole bucket at a time.
+    """
+    body = _function(_source(), "renderMcChart")
+    sig = re.search(r"const sig=.*?;", body, re.S)
+    assert sig, "renderMcChart() no longer builds a signature"
+    assert "tl(" in sig.group(0), (
+        "the mc-chart signature must include the tail values, not just bucket labels"
+    )


### PR DESCRIPTION
## What was wrong

v0.30.0 split the page into two cadences: live values over SSE every ~2s, history on its own timer. The history half was pinned to its own bucket size, and `applyLive()` only assigned `D.now` — nothing on the live path touched a chart series. Every tile moved every 2 seconds; every chart sat still for a whole bucket.

Measured chart lag by range:

| range | bucket | chart lag |
|---|---|---|
| 1h | 10s | ~25s |
| **6h (default)** | 60s | **~120s** |
| 24h | 240s | ~5min |
| 7d | 1680s | ~29min |
| all | 19683s | ~5.5h |

VRAM was worst: it's the only step metric on the page, so a 60s bucket didn't just delay a model load, it averaged the peak away.

## What this does

Folds each live frame into the newest bucket on the client instead of asking the server again — no new HTTP request, the stream already carried every field. Within a bucket the tail keeps a running mean, seeded from how far into the bucket we are, so the point converges on the `AVG()` the server will send rather than jittering. VRAM carries the latest value, not a mean.

Verified against real prod payloads and 15 captured SSE frames: the chart edge moved on 15/15 frames, first movement at t=0.04s — before, 0 movements, pinned for the full 60s bucket. A simulated model load of 481 → 7900 MB lands at 7900 immediately; a mean would have drawn ~4191. A full bucket of steady 40% folds to 40.00 against the server's own `AVG()` of 40, so the authoritative poll doesn't visibly snap the point.

Also fixes four ways the refresh loop could stop entirely:

- a throw out of a synchronous renderer skipped the reschedule and killed the chain for the life of the page — the reschedule now lives in a `finally`
- `scheduleHistory()` opened with an unconditional `clearTimeout`, so a stream flapping on its 3s retry hint reset the 15s timer forever; 300s of flapping produced 0 refreshes
- `LIVE_ON` tracked connection events, never data arrival, so a dead-but-open stream left the cadence slow and stopped polling the fleet altogether
- a terminally failed EventSource left `LIVE_ES` set, so the page could never open a stream again

Plus: `mk()` never reassigned inline plugins, so GPU throttle bands and the capacity line stayed frozen at page-load state under moving lines; the mc-chart cache key was labels-only; a range switch never re-armed the timer; and the live repaint is hub-scoped, so a remote host can't animate the hub's series under its name.

## Tests

`tests/js/test_refresh_loop.js` runs the real functions — lifted out of the shipped HTML, unmodified — against a fake clock. 55 checks, wired into the existing smoke job on the runner's preinstalled Node; no npm project, no new deps.

`tests/test_dashboard_refresh_invariants.py` guards the structure, and is now actually run by CI. It wasn't before: the workflow ran pytest on `test_snapshots.py` alone.

Mutation-tested by re-introducing each original bug one at a time; every one is caught by exactly the check written for it.

Full suite on ardi: 827 passed / 6 failed. Pristine `next` gives 821 passed and the same 6 failures — no new failures, no snapshot rebaseline.

## Not verified

No live browser has rendered this yet. The thing to watch on the staging instance is `chart.update('none')` firing every 2s on the System and GPU tabs — whether it dismisses an open tooltip or fights a hover.

## Note

This doesn't reach prod until a release; prod runs v0.30.0. That release would also carry `7f86a72`, which prod is missing — without it a remote host's System tab charts the hub's series.
