### PR TITLE
test(snapshots): rebaseline api_changelog for the 0.31.0 entry

### DIFF
--- a/tests/snapshots/api_changelog.json
+++ b/tests/snapshots/api_changelog.json
@@ -1,6 +1,6 @@
 {
   "has_content": true,
   "has_sections": true,
-  "markdown_prefix": "## [0.30.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.30.0) \u2014 2026-08-08 \u00b7 *",
+  "markdown_prefix": "## [0.31.0](https://github.com/SikamikanikoBG/homelab-monitor/releases/tag/v0.31.0) \u2014 2026-08-16 \u00b7 *",
   "status": 200
 }


### PR DESCRIPTION
## What

One line in `tests/snapshots/api_changelog.json`:

```diff
-  "markdown_prefix": "## [0.30.0](.../v0.30.0) — 2026-08-08 · *",
+  "markdown_prefix": "## [0.31.0](.../v0.31.0) — 2026-08-16 · *",
```

## Why

The v0.31.0 release added its `CHANGELOG.md` section but left the snapshot expecting 0.30.0. `/api/changelog` returns what `CHANGELOG.md` says, so its first heading no longer matched and the `snapshot` job has failed on `next` since `20371f4`.

This is a declared **content** change, not a behavior change — the endpoint is doing exactly what it should; the fixture was stale.

## Verification

- New prefix matches `CHANGELOG.md:10` exactly (checked against the file, not against the regenerated snapshot).
- `UPDATE_SNAPSHOTS=1` was scoped to `-k api_changelog` so nothing else could be quietly rebaselined; `git status` confirms one file changed. The other 70 snapshots are untouched and still byte-identical.
- Both CI snapshot steps pass locally, run exactly as the workflow defines them:

| Step | Result |
|---|---|
| `pytest tests/test_snapshots.py -v --tb=short` | 71 passed |
| `pytest tests/test_snapshots.py -q` (byte-identical rerun) | 71 passed |

## Note

While diagnosing this I found six other failing tests on `next` that CI never runs — `tests/test_public_status.py` (5, `monitors_summary["maintenance"]` is asserted but `app.py:_public_monitors_summary` never emits it) and `tests/test_no_silent_swallow.py` (1, four silent `except Exception` blocks in `backend/`). CI runs `tests/test_snapshots.py`, not `tests/`. Out of scope here — flagging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJZ43XxhUek4X7q7ZTeRRv