### PR TITLE
fix(dashboard): the live lane repaints in place instead of rebuilding its panels

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -3452,6 +3452,56 @@ function renderData(){
 // see mcCountUp().
 let LIVE_TICK = false;
 
+// ── In-place painters ─────────────────────────────────────────────────────────
+// "leave the page structure alone" was the intent of the split, but the panels
+// below still rebuilt their markup with innerHTML on every frame. An innerHTML
+// write destroys and recreates the subtree even when nothing changed, and these
+// panels sit inside a backdrop-filtered .card — so the browser re-composites the
+// blur layer twice a second. That is the flicker. These helpers touch only what
+// actually moved.
+function setText(el, v){ if(el && el.textContent !== v) el.textContent = v; }
+function setHTML(el, html){ if(el && el._sig !== html){ el._sig = html; el.innerHTML = html; } }
+
+// A KPI row is a fixed set of cells whose numbers move every frame, so rebuild
+// the cells only when the row's shape changes and patch the text otherwise.
+function paintKpis(el, items){
+  if(!el) return;
+  if(el.children.length !== items.length){
+    el.innerHTML = items.map(()=>'<div class="kpi"><div class="v"></div><div class="l"></div><div class="s"></div></div>').join('');
+  }
+  items.forEach((t,i)=>{
+    const c = el.children[i];
+    setText(c.children[0], t.v);
+    setText(c.children[1], t.l);
+    setText(c.children[2], t.s || '');
+  });
+}
+
+// Disk bars are keyed by mount: the set only changes when a filesystem appears
+// or goes away, while the numbers change every frame.
+function paintDisks(el, disks){
+  if(!el) return;
+  // NUL is the one byte a mount path cannot contain, so joining on it cannot
+  // collide two different mount sets into one key — the patch loop below
+  // indexes rows one-for-one with `disks`.
+  const key = disks.map(d=>d.mount).join('\u0000');
+  if(el._key !== key){
+    el._key = key;
+    el.innerHTML = disks.map(()=>
+      '<div style="margin-bottom:9px"><div style="display:flex;justify-content:space-between;font-size:13px">'
+      +'<span></span><span class="muted"></span></div>'
+      +'<div class="dbar"><div></div></div></div>').join('');
+  }
+  disks.forEach((dk,i)=>{
+    const row=el.children[i], head=row.children[0], bar=row.children[1].firstElementChild;
+    setText(head.children[0], '💾 '+dk.mount);
+    setText(head.children[1], `${dk.used} / ${dk.total} GB · ${dk.pct}%`);
+    const w=dk.pct+'%', bg=sev(dk.pct);
+    if(bar.style.width !== w) bar.style.width = w;
+    if(bar.style.background !== bg) bar.style.background = bg;
+  });
+}
+
 // The live half: repaint the values, leave the page structure alone.
 function renderLive(opts){
   if(!D || !D.now) return;
@@ -3482,17 +3532,14 @@ function paintLive(){
   // renderHostTab() owns these panels with the remote's polled data.
   if(CURRENT_HOST === 'local'){
     const ramPct = H.ram_total? Math.round(H.ram_used/H.ram_total*100):0;
-    document.getElementById('hostkpis').innerHTML=[
+    paintKpis(document.getElementById('hostkpis'), [
       {v:Math.round(H.cpu||0)+'%',l:I18N.t('kpi.cpu','CPU utilization'),s:I18N.tf('kpi.cores','{n} cores',{n:(H.cores||'?')})},
       {v:ramPct+'%',l:I18N.t('kpi.ram','RAM used'),s:fmtMB(H.ram_used||0)+' / '+fmtMB(H.ram_total||0)},
       {v:(H.load1||0).toFixed(2),l:I18N.t('kpi.load1','Load (1m)'),s:I18N.tf('kpi.of_cores','of {n} cores',{n:(H.cores||'?')})},
       {v:fmtUp(H.uptime||0),l:I18N.t('kpi.uptime','Uptime')},
       {v:(H.ctemp||0)+' °C',l:I18N.t('kpi.temp','CPU/system temp')},
-    ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div><div class="s">${t.s||''}</div></div>`).join('');
-    document.getElementById('disks').innerHTML=(H.disks||[]).map(dk=>
-      `<div style="margin-bottom:9px"><div style="display:flex;justify-content:space-between;font-size:13px">
-       <span>💾 ${esc(dk.mount)}</span><span class="muted">${dk.used} / ${dk.total} GB · ${dk.pct}%</span></div>
-       <div class="dbar"><div style="width:${dk.pct}%;background:${sev(dk.pct)}"></div></div></div>`).join('');
+    ]);
+    paintDisks(document.getElementById('disks'), H.disks||[]);
   }
 }
 
@@ -3558,8 +3605,8 @@ function renderGpuSpill(n){
     d='';
   }
   el.style.display='flex';
-  el.innerHTML=`<div class="ic" style="color:var(--warn)">${sic('ram')}</div><div><div class="t">${t}</div>`
-    +`<div class="d">${d}${d&&sum?'<br>':''}${sum}</div></div>`;
+  setHTML(el, `<div class="ic" style="color:var(--warn)">${sic('ram')}</div><div><div class="t">${t}</div>`
+    +`<div class="d">${d}${d&&sum?'<br>':''}${sum}</div></div>`);
 }
 
 // ── GPU cockpit ───────────────────────────────────────────────────────────────
@@ -4671,9 +4718,9 @@ function renderModels(){
   live.forEach(m=>{const arr=bySvc[m.service]=bySvc[m.service]||[]; if(!arr.some(x=>x.model===m.model)) arr.push({model:m.model,peak:null,avg:null,vram:m.vram,ram:m.ram,ctxNow:m.ctx_now,runs:0,spilled:0,peakRam:0,usedBy:[]});});
   const host=document.getElementById('modelsbody'); if(!host) return;
   const services=Object.keys(bySvc);
-  if(!services.length){ host.innerHTML='<div class="card"><div class="muted">'+I18N.t('models.empty','No recognised AI model server is running. Start one (Ollama, vLLM, faster-whisper, Stable Diffusion, …) and it will appear here.')+'</div></div>'; return; }
+  if(!services.length){ setHTML(host, '<div class="card"><div class="muted">'+I18N.t('models.empty','No recognised AI model server is running. Start one (Ollama, vLLM, faster-whisper, Stable Diffusion, …) and it will appear here.')+'</div></div>'); return; }
   const maxV=Math.max(tot||1, ...sums.map(m=>m.peak||0));
-  host.innerHTML = services.map(svc=>{
+  setHTML(host, services.map(svc=>{
     const ss=svcSum[svc]||{}, c=colorFor(svc);
     const models=bySvc[svc].slice().sort((a,b)=>(b.peak||0)-(a.peak||0));
     const rows=models.map(m=>{
@@ -4721,7 +4768,7 @@ function renderModels(){
       ${callersFor(svc)}
       <table style="margin-top:12px"><thead><tr><th>${I18N.t('col.model','Model')}</th><th>${I18N.t('col.status','Status')}</th><th>${I18N.t('col.now','Now')}</th><th>${I18N.t('col.peak','Peak')}</th><th>${I18N.t('col.avg','Avg')}</th><th>${I18N.t('col.runs','Runs')}</th><th>${I18N.t('col.used_by','Used by')}</th><th>${I18N.t('col.peak_avg','Peak·Avg')}</th></tr></thead><tbody>${rows}</tbody></table>
     </div>`;
-  }).join('');
+  }).join(''));
 }
 // Model metadata badges (Ollama /api/show): param size, quantization, context
 // length, capabilities. From D.now.model_meta, keyed by model name. Cheap polish

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -3462,11 +3462,21 @@ let LIVE_TICK = false;
 function setText(el, v){ if(el && el.textContent !== v) el.textContent = v; }
 function setHTML(el, html){ if(el && el._sig !== html){ el._sig = html; el.innerHTML = html; } }
 
+// True when `el` holds exactly `n` rows that still match the shape this painter
+// builds — the test for "safe to patch in place rather than rebuild".
+function ourRows(el, n, shaped){
+  return el.children.length === n && [...el.children].every(shaped);
+}
+
 // A KPI row is a fixed set of cells whose numbers move every frame, so rebuild
 // the cells only when the row's shape changes and patch the text otherwise.
+// Both of these panels have a second writer — renderHostTab() paints a remote
+// host into them — so the cells are only patched when they are still the ones
+// this function built. Trusting the cache against someone else's markup is how
+// a painter ends up indexing off the end of it.
 function paintKpis(el, items){
   if(!el) return;
-  if(el.children.length !== items.length){
+  if(!ourRows(el, items.length, c=>c.children.length===3)){
     el.innerHTML = items.map(()=>'<div class="kpi"><div class="v"></div><div class="l"></div><div class="s"></div></div>').join('');
   }
   items.forEach((t,i)=>{
@@ -3485,7 +3495,7 @@ function paintDisks(el, disks){
   // collide two different mount sets into one key — the patch loop below
   // indexes rows one-for-one with `disks`.
   const key = disks.map(d=>d.mount).join('\u0000');
-  if(el._key !== key){
+  if(el._key !== key || !ourRows(el, disks.length, r=>r.children.length===2 && r.children[1].classList.contains('dbar'))){
     el._key = key;
     el.innerHTML = disks.map(()=>
       '<div style="margin-bottom:9px"><div style="display:flex;justify-content:space-between;font-size:13px">'
@@ -8111,23 +8121,22 @@ async function renderHostTab(){
   const dk = document.getElementById('disks');
   if(!HOST_DATA || !HOST_DATA.online){
     renderHostChart();   // still draw whatever history the host left behind
-    hk.innerHTML = '';
+    paintKpis(hk, []);
     const err = HOST_DATA && HOST_DATA.error ? esc(HOST_DATA.error) : I18N.t('host.no_data','no data yet');
     dk.innerHTML = I18N.tf('host.probe_wait','<div class="muted" style="padding:12px 2px">⏳ <b>{host}</b> — {err}. Probes run every {i}s; new hosts take one cycle to populate.</div>',{host:esc(CURRENT_HOST),err,i:(FLEET ? (FLEET.interval||10) : 10)});
     return;
   }
   const ramPct = h.ram_total ? Math.round((h.ram_used||0)*100/h.ram_total) : 0;
-  hk.innerHTML=[
+  // Same painters the live lane uses, so a remote host repaints in place too and
+  // the two writers can never disagree about this markup.
+  paintKpis(hk, [
     {v:Math.round(h.cpu||0)+'%',         l:I18N.t('kpi.cpu','CPU utilization'), s:I18N.tf('kpi.cores','{n} cores',{n:(h.cores||'?')})},
     {v:ramPct+'%',                       l:I18N.t('kpi.ram','RAM used'),        s:fmtMBshort(h.ram_used)+' / '+fmtMBshort(h.ram_total)},
     {v:(h.load1!=null?h.load1.toFixed(2):'—'), l:I18N.t('kpi.load1','Load (1m)'),  s:I18N.tf('kpi.of_cores','of {n} cores',{n:(h.cores||'?')})},
     {v:fmtUpShort(h.uptime),             l:I18N.t('kpi.uptime','Uptime')},
     {v:(h.ctemp!=null?h.ctemp+' °C':'—'),l:I18N.t('kpi.temp','CPU/system temp')},
-  ].map(t=>`<div class="kpi"><div class="v">${t.v}</div><div class="l">${t.l}</div><div class="s">${t.s||''}</div></div>`).join('');
-  dk.innerHTML = (h.disks||[]).map(dkk =>
-    `<div style="margin-bottom:9px"><div style="display:flex;justify-content:space-between;font-size:13px">
-     <span>💾 ${esc(dkk.mount)}</span><span class="muted">${dkk.used} / ${dkk.total} GB · ${dkk.pct}%</span></div>
-     <div class="dbar"><div style="width:${dkk.pct}%;background:${sev(dkk.pct)}"></div></div></div>`).join('');
+  ]);
+  paintDisks(dk, h.disks||[]);
   renderSysInfo();
   renderRamTree();
   renderTopProcs();      // now that HOST_DATA is this host's

--- a/tests/js/test_refresh_loop.js
+++ b/tests/js/test_refresh_loop.js
@@ -543,6 +543,137 @@ suite('gpu   the small-multiples cards refresh in place off a live frame');
     ctxWith(mkBox([0, 1], { hidden: true })).updateGpuCardsLive(d(1, 2)) === false);
 }
 
+// ── in-place painters: the KPI row and disk bars ─────────────────────────────
+// The live lane repaints these every ~2s. Rebuilding their markup destroyed and
+// recreated the subtree on every frame, which re-composited the backdrop-filter
+// on the surrounding .card — the flicker. They are patched in place now.
+//
+// Both panels have a SECOND writer: renderHostTab() paints a remote host (or a
+// "waiting for its first probe" message) into the same elements. A painter that
+// trusted its cache against that markup would index off the end of it and throw,
+// and a throw here kills the whole live frame.
+suite('paint the live panels must repaint in place, and never patch foreign markup');
+{
+  reset();
+
+  const node = () => ({ textContent: '' });
+  const diskRow = () => ({ children: [
+    { children: [node(), node()] },
+    { classList: { contains: c => c === 'dbar' }, firstElementChild: { style: { width: '', background: '' } } },
+  ] });
+  const kpiCell = () => ({ children: [node(), node(), node()] });
+
+  // innerHTML is modelled the way the parser behaves: assigning markup replaces
+  // the children with one row per row-template found in it.
+  function mkHost(kind) {
+    const el = { _children: [], rebuilds: 0, _html: '' };
+    Object.defineProperty(el, 'children', { get: () => el._children });
+    Object.defineProperty(el, 'innerHTML', {
+      get: () => el._html,
+      set(html) {
+        el._html = html; el.rebuilds++;
+        const re = kind === 'disks' ? /class="dbar"/g : /class="kpi"/g;
+        const n = (html.match(re) || []).length;
+        el._children = Array.from({ length: n }, kind === 'disks' ? diskRow : kpiCell);
+      },
+    });
+    return el;
+  }
+  // What renderHostTab() leaves behind: markup this painter did not build.
+  const foreign = (el, kids) => { el._children = kids; };
+
+  function ctx() {
+    const c = build({});
+    c.sev = pct => (pct >= 90 ? 'var(--crit)' : 'var(--ok)');
+    vm.runInContext([
+      takeLine(/^function setText\(.*$/m, 'the setText helper'),
+      takeFunction('ourRows'),
+      takeFunction('paintKpis'),
+      takeFunction('paintDisks'),
+    ].join('\n\n'), c);
+    return c;
+  }
+
+  const disks = (pct) => [
+    { mount: '/', used: 10, total: 100, pct },
+    { mount: '/home', used: 20, total: 200, pct: 5 },
+  ];
+
+  // 1. The anti-flicker invariant: same mounts, new numbers, no rebuild.
+  const c = ctx();
+  const el = mkHost('disks');
+  c.paintDisks(el, disks(50));
+  const built = el.rebuilds;
+  const firstRow = el.children[0];
+  c.paintDisks(el, disks(60));
+  check('a repaint with the same mounts does not rebuild the rows',
+    el.rebuilds === built, `rebuilds ${built} -> ${el.rebuilds}`);
+  check('the row objects survived the repaint', el.children[0] === firstRow,
+    'rebuilding is what re-composites the .card blur behind them');
+  check('the numbers still moved',
+    el.children[0].children[1].firstElementChild.style.width === '60%',
+    `width=${el.children[0].children[1].firstElementChild.style.width}`);
+  check('the mount label is set as text, not markup',
+    el.children[0].children[0].children[0].textContent === '💾 /');
+
+  // 2. A mount appearing rebuilds, because the row count changed.
+  c.paintDisks(el, disks(60).concat([{ mount: '/boot', used: 1, total: 2, pct: 50 }]));
+  check('a new filesystem rebuilds the rows', el.rebuilds === built + 1);
+
+  // 3. REGRESSION: renderHostTab left a "waiting for probe" message here, so the
+  //    row count no longer matches the cache. Patching it would throw.
+  const c3 = ctx();
+  const el3 = mkHost('disks');
+  c3.paintDisks(el3, disks(50));
+  foreign(el3, [{ children: [] }]);              // the muted <div> message
+  let threw = null;
+  try { c3.paintDisks(el3, disks(50)); } catch (e) { threw = e; }
+  check('coming back from an offline remote does not throw', threw === null,
+    threw && String(threw));
+  check('and the disk rows were rebuilt from scratch', el3.children.length === 2,
+    `children=${el3.children.length}`);
+
+  // 4. REGRESSION, harder: the foreign markup has the SAME row count, so only a
+  //    shape check can catch it. This is a remote host with two disks whose rows
+  //    this painter did not build.
+  const c4 = ctx();
+  const el4 = mkHost('disks');
+  c4.paintDisks(el4, disks(50));
+  foreign(el4, [kpiCell(), kpiCell()]);          // right count, wrong shape
+  threw = null;
+  try { c4.paintDisks(el4, disks(50)); } catch (e) { threw = e; }
+  check('foreign rows of the same count do not throw', threw === null,
+    threw && String(threw));
+  check('they were replaced with real disk rows',
+    el4.children.length === 2 && el4.children[0].children.length === 2,
+    'a same-count cache hit must still verify the row shape');
+
+  // 5. The KPI row gets the same treatment.
+  const c5 = ctx();
+  const el5 = mkHost('kpis');
+  const items = v => [
+    { v, l: 'CPU utilization', s: '4 cores' }, { v: '9%', l: 'RAM used', s: '1 / 2' },
+    { v: '0.5', l: 'Load (1m)', s: 'of 4' },   { v: '1d', l: 'Uptime' },
+    { v: '40 °C', l: 'CPU/system temp' },
+  ];
+  c5.paintKpis(el5, items('10%'));
+  const kpiBuilt = el5.rebuilds, cell0 = el5.children[0];
+  c5.paintKpis(el5, items('80%'));
+  check('a KPI repaint does not rebuild the cells', el5.rebuilds === kpiBuilt);
+  check('the KPI cell objects survived', el5.children[0] === cell0);
+  check('the KPI value moved', el5.children[0].children[0].textContent === '80%');
+  check('an absent sub-label is blank, not undefined',
+    el5.children[3].children[2].textContent === '');
+
+  foreign(el5, [{ children: [] }, { children: [] }, { children: [] }, { children: [] }, { children: [] }]);
+  threw = null;
+  try { c5.paintKpis(el5, items('12%')); } catch (e) { threw = e; }
+  check('foreign KPI cells of the same count do not throw', threw === null,
+    threw && String(threw));
+  check('and they were rebuilt into real cells',
+    el5.children.length === 5 && el5.children[0].children.length === 3);
+}
+
 // ── result ───────────────────────────────────────────────────────────────────
 console.log(`\n${checks - failures}/${checks} checks passed`);
 if (failures) { console.error(`${failures} check(s) FAILED`); process.exit(1); }


### PR DESCRIPTION
## The problem

v0.30.0 split the renderers into a live half and a history half and moved live values onto a 2s SSE frame. The live half still wrote its markup with `innerHTML`.

An `innerHTML` write destroys and recreates the whole subtree even when nothing in it changed — and these panels sit inside a `backdrop-filter` `.card`, so every frame re-composited the blur layer. The old 15s poll had the same bug; at 2s it reads as constant flicker.

Reported against v0.31.0.

## The change

`static/dashboard.html` only. No backend, no build step, no new dependencies.

| Helper | Applied to | Behaviour |
|---|---|---|
| `setText` | — | writes only when the string differs |
| `setHTML` | `renderGpuSpill`, `renderModels` (×2) | writes only when the markup differs |
| `paintKpis` | `#hostkpis` | rebuilds cells only on a shape change; patches text otherwise |
| `paintDisks` | `#disks` | rebuilds rows only when the mount set changes; patches text + bar width |

The second commit fixes a crash found in review: `#hostkpis` and `#disks` have a **second writer** — `renderHostTab()` paints a remote host into them, or a "waiting for its first probe" message. Neither touched the painters' cache, so local → offline remote → back to local left the cache describing rows that no longer existed and the patch loop threw `TypeError`. That throw escapes `paintLive()`, so `paintLiveCharts()` never runs and every later frame dies at the same point — the page looks alive while nothing moves.

Both painters now verify the rows on the page are the shape they build before trusting the cache, and `renderHostTab` paints through the same two functions instead of hand-rolling the markup a second time.

## Verification

Before/after on a live container, same probe, same 9s window (~4 live ticks). Each node is tagged with a JS expando; a marker only vanishes if `innerHTML` recreated the node:

| Build | KPI cells | Disk rows | Model cards |
|---|---|---|---|
| v0.31.0 stock | DESTROYED ×5 | DESTROYED ×5 | DESTROYED |
| this branch | survived ×5 | survived ×5 | survived |

- Values still move (CPU 56→26%, load 3.76→3.55, temp 99→88 °C); bars render correct widths and colours.
- Screenshots of the System tab on both builds are identical in layout, cards, bars and colours.
- No console errors or warnings.
- Built and run via `docker compose up -d --build`; container reports 0.31.0.

## Tests

New suite in `tests/js/test_refresh_loop.js` (65 → 80 checks): the in-place invariant (same mounts repaint without rebuilding, values still move), plus both crash paths — foreign markup with a different row count, and the harder case of foreign markup with the **same** row count, which only a shape check catches.

Confirmed the tests fail against a build with just the guards removed: **5 failures, both `TypeError`s reproduced**. They are not vacuous.

Python suite: 843 passed / 7 failed, identical to unmodified `next` (verified on a pristine `origin/next` worktree). One of those seven is fixed by #275; the other six are in files CI does not run.

## Not covered

The remote-host path is covered by test, not by live exercise — that needs a second box on the Hosts tab. If you have one: local → remote → back to local, then confirm the charts still move and the console is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)