### PR TITLE
test(dashboard): cover locale re-render paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Dashboard refresh-loop behaviour
         run: node tests/js/test_refresh_loop.js
 
+      # Locale changes hydrate static markup and then re-render whichever
+      # JavaScript-built view is active. Lift that listener from the shipped
+      # dashboard and cover every tab branch without needing a browser build.
+      - name: Dashboard locale re-render behaviour
+        run: node tests/js/test_locale_rerender.js
+
       # Same lift-and-run technique, for the AI Models tab's TFLOPS arithmetic.
       # The live fleet can't cover it: the hub has one card and one fully-
       # resident model, so the multi-card and RAM-spill branches only ever get

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Dashboard refresh-loop behaviour
         run: node tests/js/test_refresh_loop.js
 
+      - name: Dashboard locale re-render behaviour
+        run: node tests/js/test_locale_rerender.js
+
       - name: Build the image
         run: docker build -t homelab-monitor:release-check .
 

--- a/tests/js/test_locale_rerender.js
+++ b/tests/js/test_locale_rerender.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/*
+ * Locale changes hydrate static markup inside I18N.set(), then the
+ * `lang:changed` listener rebuilds the dashboard pieces whose text is produced
+ * by JavaScript. A browser smoke test can miss stale labels in tabs that were
+ * not open during the run, so exercise every branch of that listener here.
+ *
+ * As with test_refresh_loop.js and test_tflops_cells.js, the listener is lifted
+ * directly from static/dashboard.html and evaluated in a `vm` context. The
+ * assertions therefore cover the code that ships rather than a test copy.
+ *
+ * Run: node tests/js/test_locale_rerender.js
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const DASH = process.env.DASHBOARD_HTML
+  || path.join(__dirname, '..', '..', 'static', 'dashboard.html');
+const SRC = fs.readFileSync(DASH, 'utf8');
+
+function takeLangChangedListener() {
+  const marker = "\ndocument.addEventListener('lang:changed'";
+  const start = SRC.indexOf(marker);
+  if (start < 0) {
+    throw new Error(
+      `the lang:changed listener was not found in ${DASH}.\n` +
+      '       Either the locale re-render path was renamed, or this extractor\n' +
+      '       needs updating to follow its new entry point.');
+  }
+
+  // The listener itself closes at column zero. Nested callbacks are indented,
+  // so this does not stop at one of the safe(() => ...) calls inside it.
+  const end = SRC.indexOf('\n});', start);
+  if (end < 0) throw new Error('could not find the end of the lang:changed listener');
+  return SRC.slice(start + 1, end + 4);
+}
+
+const LISTENER = takeLangChangedListener();
+const VIEW_RENDERERS = [
+  'renderServicesTab',
+  'renderExperiments',
+  'renderCosts',
+  'renderNetwork',
+  'renderSecurity',
+  'loadHosts',
+  'renderDisksTab',
+];
+
+function build(tab, options = {}) {
+  const calls = [];
+  const listeners = {};
+  const disksBody = { dataset: { sig: 'cached-before-locale-change' } };
+  const fail = new Set(options.fail || []);
+
+  const record = name => (...args) => {
+    calls.push({ name, args, diskSig: disksBody.dataset.sig });
+    if (fail.has(name)) throw new Error(`${name} failed`);
+  };
+
+  const document = {
+    addEventListener(type, listener) { listeners[type] = listener; },
+    getElementById(id) { return id === 'disksbody' ? disksBody : null; },
+  };
+
+  const ctx = {
+    document,
+    TAB: tab,
+    FLEET: options.withData === false ? null : { hosts: [] },
+    D: options.withData === false ? null : { now: {} },
+    HH: options.withData === false ? null : { health: {} },
+    buildNav: record('buildNav'),
+    applyTheme: record('applyTheme'),
+    buildLangSwitch: record('buildLangSwitch'),
+    renderFleet: record('renderFleet'),
+    renderData: record('renderData'),
+    renderHealth: record('renderHealth'),
+  };
+  for (const name of VIEW_RENDERERS) ctx[name] = record(name);
+
+  vm.createContext(ctx);
+  vm.runInContext(LISTENER, ctx);
+  if (typeof listeners['lang:changed'] !== 'function') {
+    throw new Error('the extracted code did not register a lang:changed listener');
+  }
+
+  return {
+    calls,
+    disksBody,
+    fire: () => listeners['lang:changed'](),
+  };
+}
+
+let checks = 0, failures = 0;
+function check(what, ok, detail) {
+  checks++;
+  if (ok) { console.log(`  ok   ${what}`); }
+  else { failures++; console.log(`  FAIL ${what}${detail ? ' — ' + detail : ''}`); }
+}
+function section(title) { console.log(`\n${title}`); }
+function names(run) { return run.calls.map(call => call.name); }
+
+section('shell and loaded data — every JS-built label is refreshed');
+{
+  const run = build('overview');
+  run.fire();
+  const actual = names(run);
+  const expected = [
+    'buildNav', 'applyTheme', 'buildLangSwitch',
+    'renderFleet', 'renderData', 'renderHealth',
+  ];
+  check('the shell and loaded datasets re-render in order',
+    JSON.stringify(actual) === JSON.stringify(expected), JSON.stringify(actual));
+  check('an unrelated tab renderer is not called',
+    !actual.some(name => VIEW_RENDERERS.includes(name)), JSON.stringify(actual));
+}
+
+section('not-yet-loaded data — locale switching stays safe during startup');
+{
+  const run = build('overview', { withData: false });
+  run.fire();
+  const actual = names(run);
+  check('the shell still re-renders',
+    JSON.stringify(actual) === JSON.stringify(['buildNav', 'applyTheme', 'buildLangSwitch']),
+    JSON.stringify(actual));
+  check('absent fleet, dashboard, and health payloads are not rendered',
+    !actual.includes('renderFleet') && !actual.includes('renderData') && !actual.includes('renderHealth'),
+    JSON.stringify(actual));
+}
+
+section('active views — only the visible tab takes the locale change');
+{
+  const cases = [
+    ['services', 'renderServicesTab', []],
+    ['experiments', 'renderExperiments', [true]],
+    ['costs', 'renderCosts', [true]],
+    ['network', 'renderNetwork', []],
+    ['security', 'renderSecurity', []],
+    ['hosts', 'loadHosts', []],
+    ['disks', 'renderDisksTab', []],
+  ];
+
+  for (const [tab, renderer, expectedArgs] of cases) {
+    const run = build(tab, { withData: false });
+    run.fire();
+    const viewCalls = run.calls.filter(call => VIEW_RENDERERS.includes(call.name));
+    check(`${tab} re-renders through ${renderer} only`,
+      viewCalls.length === 1 && viewCalls[0].name === renderer,
+      JSON.stringify(viewCalls.map(call => call.name)));
+    check(`${renderer} receives the expected refresh arguments`,
+      JSON.stringify(viewCalls[0] && viewCalls[0].args) === JSON.stringify(expectedArgs),
+      JSON.stringify(viewCalls[0] && viewCalls[0].args));
+  }
+}
+
+section('disks — cached row signatures are invalidated before repaint');
+{
+  const run = build('disks', { withData: false });
+  run.fire();
+  const repaint = run.calls.find(call => call.name === 'renderDisksTab');
+  check('the cached signature is cleared', run.disksBody.dataset.sig === '', run.disksBody.dataset.sig);
+  check('the disk renderer observes the cleared signature', repaint && repaint.diskSig === '',
+    repaint && repaint.diskSig);
+}
+
+section('failure isolation — one stale view cannot block the rest');
+{
+  const run = build('services', { fail: ['buildNav', 'renderData'] });
+  let escaped = null;
+  try { run.fire(); } catch (error) { escaped = error; }
+  const actual = names(run);
+  check('renderer failures do not escape the locale event', escaped === null, escaped && escaped.message);
+  check('shell work after a failed navigation rebuild still runs',
+    actual.includes('applyTheme') && actual.includes('buildLangSwitch'), JSON.stringify(actual));
+  check('health rendering continues after dashboard data fails',
+    actual.includes('renderHealth'), JSON.stringify(actual));
+  check('the visible tab still renders after earlier failures',
+    actual.includes('renderServicesTab'), JSON.stringify(actual));
+}
+
+console.log(`\n${checks - failures}/${checks} checks passed`);
+if (failures) { console.error(`${failures} check(s) FAILED`); process.exit(1); }

--- a/tests/js/test_locale_rerender.js
+++ b/tests/js/test_locale_rerender.js
@@ -167,17 +167,34 @@ section('disks — cached row signatures are invalidated before repaint');
 
 section('failure isolation — one stale view cannot block the rest');
 {
-  const run = build('services', { fail: ['buildNav', 'renderData'] });
-  let escaped = null;
-  try { run.fire(); } catch (error) { escaped = error; }
-  const actual = names(run);
-  check('renderer failures do not escape the locale event', escaped === null, escaped && escaped.message);
-  check('shell work after a failed navigation rebuild still runs',
-    actual.includes('applyTheme') && actual.includes('buildLangSwitch'), JSON.stringify(actual));
-  check('health rendering continues after dashboard data fails',
-    actual.includes('renderHealth'), JSON.stringify(actual));
-  check('the visible tab still renders after earlier failures',
-    actual.includes('renderServicesTab'), JSON.stringify(actual));
+  const cases = [
+    ['buildNav', 'services', 'applyTheme'],
+    ['applyTheme', 'services', 'buildLangSwitch'],
+    ['buildLangSwitch', 'services', 'renderFleet'],
+    ['renderFleet', 'services', 'renderData'],
+    ['renderData', 'services', 'renderHealth'],
+    ['renderHealth', 'services', 'renderServicesTab'],
+    ['renderServicesTab', 'services', null],
+    ['renderExperiments', 'experiments', null],
+    ['renderCosts', 'costs', null],
+    ['renderNetwork', 'network', null],
+    ['renderSecurity', 'security', null],
+    ['loadHosts', 'hosts', null],
+    ['renderDisksTab', 'disks', null],
+  ];
+
+  for (const [failing, tab, nextCall] of cases) {
+    const run = build(tab, { fail: [failing] });
+    let escaped = null;
+    try { run.fire(); } catch (error) { escaped = error; }
+    const actual = names(run);
+    check(`${failing} failure does not escape the locale event`,
+      escaped === null, escaped && escaped.message);
+    if (nextCall) {
+      check(`${nextCall} still runs after ${failing} fails`,
+        actual.includes(nextCall), JSON.stringify(actual));
+    }
+  }
 }
 
 console.log(`\n${checks - failures}/${checks} checks passed`);


### PR DESCRIPTION
## What this changes

Adds a VM-lifted Node test for the dashboard's `lang:changed` listener and runs it in both the integration and release validation workflows. The new test executes the listener directly from `static/dashboard.html`, so a production refactor that drops or changes a locale re-render branch will fail the test rather than continuing to pass against a copied implementation.

This covers the locale option proposed in #284:

- the navigation, theme, language switch, fleet, dashboard data, and health views refresh when their data is available;
- switching language during startup remains safe before the three data payloads exist;
- each active tab selects only its own renderer, including the forced refresh arguments used by Experiments and Costs;
- the Disks view clears its cached row signature before repainting; and
- an exception in one renderer remains isolated so later views can still pick up the new locale.

The test changes no dashboard behavior. It only makes the existing re-render contract executable in CI.

Fixes #284.

## Why this area

The existing VM test already exercises the refresh loop, live-tail folding, in-place chart/card repainting, and stale-stream recovery in depth. Locale changes had a similarly branchy client-side path but no direct test, so extending the same source-lifting pattern there adds coverage without duplicating the refresh-loop cases.

## Checklist

- [x] **Base branch is `next`** (the integration branch), not `main`.
- [x] Branched off the **latest `next`** (`54fdb43b49241721d0776527e8bd32f415e33aae`, re-fetched immediately before commit).
- [x] Tested locally with `docker compose -p codex-hlm-284 up -d --build`; `/healthz` returned `{"status":"ok","version":"0.33.0"}` and the dashboard returned HTTP 200.
- [x] No version bump in this PR.
- [x] The new-monitor/probe pattern is not applicable; this PR adds test coverage only.

## Verification

- `node tests/js/test_locale_rerender.js` — 39/39 checks passed (including every guarded renderer as a failure source)
- `node tests/js/test_refresh_loop.js` — 80/80 checks passed
- `node tests/js/test_tflops_cells.js` — 28/28 checks passed
- `git diff --check` — passed
- Docker build, container start, `/healthz`, and dashboard HTTP smoke — passed; the test container was removed afterward

## Notes for the reviewer

The extractor deliberately looks for the listener's column-zero closing `});`; the nested `safe(() => ...)` callbacks are indented, matching the existing single-file dashboard style. If the listener is later moved or renamed, the test fails with an entry-point-specific message instead of silently exercising nothing.

AI assistance was used to help inspect candidate paths and draft the test, with the final diff reviewed and all commands above run by the contributor.
