### PR TITLE
chore: centralize Python dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install flask pytest prometheus_client
+        run: pip install -r requirements.txt pytest
 
       - name: Run snapshot tests (determinism check)
         run: python -m pytest tests/test_snapshots.py -v --tb=short

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install flask pytest prometheus_client
+        run: pip install -r requirements.txt
 
       - name: VERSION / CHANGELOG / Unreleased contract
         id: release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,13 @@ the file if you want a clean slate.
 To rebuild after a code change: `docker compose up -d --build` again. To follow
 logs: `docker compose logs -f`.
 
+For a local Python environment, install the runtime dependencies from the same
+file the Docker image and CI use:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
 > **GPU panels** need an NVIDIA GPU and the
 > [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 > Without a GPU the container, service and host panels still work fine — handy

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 # openssh-client provides ssh + ssh-keygen for the multi-host registry probes.
 # mcp = the Model Context Protocol SDK powering the built-in MCP server (served on
 # $MCP_PORT alongside the dashboard); it pulls in starlette/uvicorn for HTTP.
-RUN pip install --no-cache-dir flask==3.0.3 jeepney==0.8.0 prometheus_client==0.20.0 "mcp>=1.9.0,<2" \
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt \
  && apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates openssh-client \
  && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask==3.0.3
+jeepney==0.8.0
+prometheus_client==0.20.0
+mcp>=1.9.0,<2


### PR DESCRIPTION
## Summary
- move runtime dependency constraints into `requirements.txt` as the shared source for Docker, CI, and local development
- add weekly Dependabot updates for pip and GitHub Actions
- document the local dependency installation command

Closes #282

## Validation
- `pip check`
- `python -m py_compile app.py probe.py`
- CI-targeted pytest suites: 77 passed
- broader `pytest tests`: 919 passed, 1 skipped; one unrelated `test_topproc` assertion assumes Linux 4KB pages and fails on this 16KB-page macOS host