### PR TITLE
fix(ci): restore pytest install in release-validate.yml

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt pytest==9.1.0
 
       - name: VERSION / CHANGELOG / Unreleased contract
         id: release


### PR DESCRIPTION
## Summary
- release-validate.yml's "Install dependencies" step lost pytest when 2402eab switched it to `pip install -r requirements.txt` (requirements.txt is runtime-only per CONTRIBUTING.md, and is installed straight into the production Docker image). Every push to main since then fails the test-suite step with "No module named pytest", blocking release-validate -> tag -> publish.
- Surfaced on the v0.34.0 release (PR #293): the merge succeeded, but release-validate.yml failed before tagging/publishing.

## Fix
Append pytest to the install step, pinned to match the local dev environment — mirrors how ci.yml already does this for its own jobs, keeping requirements.txt runtime-only.

## Test plan
- [ ] release-validate.yml green on this PR's merge to main